### PR TITLE
dial_mobile: set the originator on the originate

### DIFF
--- a/wazo_calld/plugins/dial_mobile/service.py
+++ b/wazo_calld/plugins/dial_mobile/service.py
@@ -91,6 +91,7 @@ class _PollingContactDialer:
             app='dial_mobile',
             appArgs=['join', future_bridge_uuid],
             callerId=caller_id,
+            originator=self._caller_channel_id,
         )
 
         self._called_contacts.add(contact)

--- a/wazo_calld/plugins/dial_mobile/tests/test_service.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_service.py
@@ -62,6 +62,7 @@ class TestSendContactToCurrentCall(DialerTestCase):
             app='dial_mobile',
             appArgs=['join', self.future_bridge_uuid],
             callerId=s.caller_id,
+            originator=self.channel_id,
         )
 
 


### PR DESCRIPTION
setting the originator fixes many problems including the linkedid of the
originated call being the same as the originator channel.

this fixes almost all of the problems we had with the call-log which had no
easy way of being linked together in the previous version.