### PR TITLE
snoop: wait until the snoop channel gets into status on snoop create

### DIFF
--- a/wazo_calld/helpers/ari_.py
+++ b/wazo_calld/helpers/ari_.py
@@ -1,6 +1,7 @@
 # Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import time
 import json
 
 from ari.exceptions import ARINotFound, ARINotInStasis
@@ -201,6 +202,14 @@ class Channel:
             return self._get_var('CHANNEL(pjsip,call-id)')
         except ARINotFound:
             return
+
+    def wait_until_in_stasis(self, retry=20, delay=0.1):
+        for _ in range(retry):
+            if self.is_in_stasis():
+                return
+            time.sleep(delay)
+
+        raise Exception('call failed to enter stasis')
 
     def _get_var(self, var):
         return self._ari.channels.getChannelVar(channelId=self.id, variable=var)['value']

--- a/wazo_calld/plugins/applications/models.py
+++ b/wazo_calld/plugins/applications/models.py
@@ -180,15 +180,15 @@ class _Snoop:
         except ARINotFound:
             raise NoSuchCall(self.snooped_call_id)
 
+        _ChannelHelper(snoop_channel.id, ari).wait_until_in_stasis()
+
         snoop_channel.setChannelVar(
             variable=self._whisper_mode_chan_var,
             value=whisper_mode,
-            bypassStasis=True,
         )
         snoop_channel.setChannelVar(
             variable=self._snooped_call_id_chan_var,
             value=self.snooped_call_id,
-            bypassStasis=True,
         )
         self.whisper_mode = whisper_mode
 


### PR DESCRIPTION
on slow computers it is possible that the channel gets added to the bridge
before getting into stasis. This results in a 422 error from ARI and undefined
and a 500 error from calld.

I also removed the bypassStasis arguments since they were used to work around
this issue.