### PR TITLE
Pull request for WAZO-1448-event-routing-headers

### DIFF
--- a/etc/wazo-calld/config.yml
+++ b/etc/wazo-calld/config.yml
@@ -55,12 +55,14 @@ bus:
   password: guest
   host: localhost
   port: 5672
-  exchange_name: xivo
-  exchange_type: topic
+  publish_exchange_name: xivo
+  publish_exchange_type: topic
+  subscribe_exchange_name: wazo-headers
+  subscribe_exchange_type: headers
 
 # Event bus exchange for collectd (statistics)
 collectd:
-  exchange_name: collectd
+  publish_exchange_name: collectd
 
 # Asterisk ARI connection informations
 ari:

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -197,6 +197,7 @@ class RealAsteriskIntegrationTest(IntegrationTest):
     def setUpClass(cls):
         super().setUpClass()
         cls.chan_test = ChanTest(cls.ari_config())
+        cls.bus.bind_exchanges(upstream_exchange_name='xivo', downstream_exchange_name='wazo-headers')
 
     @classmethod
     def ari_config(cls):

--- a/integration_tests/suite/helpers/bus.py
+++ b/integration_tests/suite/helpers/bus.py
@@ -11,13 +11,12 @@ from kombu.exceptions import TimeoutError
 from xivo_test_helpers import bus as bus_helper
 
 from .constants import BUS_QUEUE_NAME
-from .constants import BUS_EXCHANGE_XIVO
 from .constants import BUS_EXCHANGE_HEADERS
 
 
 class BusClient(bus_helper.BusClient):
 
-    def listen_events(self, routing_key, exchange=BUS_EXCHANGE_XIVO):
+    def listen_events(self, routing_key, exchange):
         with Connection(self._url) as conn:
             queue = Queue(BUS_QUEUE_NAME, exchange=exchange, routing_key=routing_key, channel=conn.channel())
             queue.declare()

--- a/integration_tests/suite/helpers/bus.py
+++ b/integration_tests/suite/helpers/bus.py
@@ -54,6 +54,7 @@ class BusClient(bus_helper.BusClient):
 
     def send_ami_newchannel_event(self, channel_id, channel=None):
         self.send_event({
+            'name': 'Newchannel',
             'data': {
                 'Event': 'Newchannel',
                 'Uniqueid': channel_id,
@@ -63,6 +64,7 @@ class BusClient(bus_helper.BusClient):
 
     def send_ami_newstate_event(self, channel_id, state='Up'):
         self.send_event({
+            'name': 'Newstate',
             'data': {
                 'Event': 'Newstate',
                 'Uniqueid': channel_id,
@@ -72,6 +74,7 @@ class BusClient(bus_helper.BusClient):
 
     def send_ami_hold_event(self, channel_id):
         self.send_event({
+            'name': 'Hold',
             'data': {
                 'Event': 'Hold',
                 'Uniqueid': channel_id,
@@ -80,14 +83,16 @@ class BusClient(bus_helper.BusClient):
 
     def send_ami_unhold_event(self, channel_id):
         self.send_event({
+            'name': 'Unhold',
             'data': {
                 'Event': 'Unhold',
                 'Uniqueid': channel_id,
-            }
+            },
         }, 'ami.Unhold')
 
     def send_ami_hangup_event(self, channel_id, base_exten=None, sip_call_id=None, channel=None):
         self.send_event({
+            'name': 'Hangup',
             'data': {
                 'Event': 'Hangup',
                 'Uniqueid': channel_id,
@@ -102,11 +107,12 @@ class BusClient(bus_helper.BusClient):
                     'XIVO_BASE_EXTEN': base_exten if base_exten else '*10',
                     'WAZO_SIP_CALL_ID': sip_call_id,
                 },
-            }
+            },
         }, 'ami.Hangup')
 
     def send_ami_peerstatus_event(self, channel_type, peer, status):
         self.send_event({
+            'name': 'PeerStatus',
             'data': {
                 'Event': 'PeerStatus',
                 'Privilege': 'system,all',
@@ -118,6 +124,7 @@ class BusClient(bus_helper.BusClient):
 
     def send_ami_registry_event(self, channel_type, domain, status, username):
         self.send_event({
+            'name': 'Registry',
             'data': {
                 'ChannelType': channel_type,
                 'Domain': domain,
@@ -139,31 +146,31 @@ class BusClient(bus_helper.BusClient):
 
     def send_moh_created_event(self, moh_uuid):
         self.send_event({
+            'name': 'moh_created',
             'data': {
                 'uuid': moh_uuid,
                 'name': 'default',
             },
-            'name': 'moh_created',
         }, 'config.moh.created')
 
     def send_moh_deleted_event(self, moh_uuid):
         self.send_event({
+            'name': 'moh_deleted',
             'data': {
                 'uuid': moh_uuid,
                 'name': 'default',
             },
-            'name': 'moh_deleted',
         }, 'config.moh.deleted')
 
     def send_application_created_event(self, application_uuid, destination=None):
         payload = {
+            'name': 'application_created',
             'data': {
                 'uuid': application_uuid,
                 'name': 'test-app-name',
                 'destination': destination,
                 'destination_options': {},
             },
-            'name': 'application_created',
         }
         if destination:
             payload['data']['destination_options'] = {
@@ -175,13 +182,13 @@ class BusClient(bus_helper.BusClient):
 
     def send_application_edited_event(self, application_uuid, destination=None):
         payload = {
+            'name': 'application_edited',
             'data': {
                 'uuid': application_uuid,
                 'name': 'test-app-name',
                 'destination': destination,
                 'destination_options': {},
             },
-            'name': 'application_edited',
         }
         if destination:
             payload['data']['destination_options'] = {
@@ -193,19 +200,19 @@ class BusClient(bus_helper.BusClient):
 
     def send_application_deleted_event(self, application_uuid):
         payload = {
+            'name': 'application_deleted',
             'data': {
                 'uuid': application_uuid,
                 'name': 'test-app-name',
                 'destination': None,
                 'destination_options': {},
             },
-            'name': 'application_deleted',
         }
         self.send_event(payload, 'config.applications.deleted')
 
     def send_trunk_endpoint_associated_event(self, trunk_id, endpoint_id):
         payload = {
-            'data': {'trunk_id': trunk_id, 'endpoint_id': endpoint_id},
             'name': 'trunk_endpoint_associated',
+            'data': {'trunk_id': trunk_id, 'endpoint_id': endpoint_id},
         }
         self.send_event(payload, 'config.trunks.endpoints.updated')

--- a/integration_tests/suite/helpers/bus.py
+++ b/integration_tests/suite/helpers/bus.py
@@ -12,6 +12,7 @@ from xivo_test_helpers import bus as bus_helper
 
 from .constants import BUS_QUEUE_NAME
 from .constants import BUS_EXCHANGE_XIVO
+from .constants import BUS_EXCHANGE_HEADERS
 
 
 class BusClient(bus_helper.BusClient):
@@ -48,8 +49,8 @@ class BusClient(bus_helper.BusClient):
 
     def send_event(self, event, routing_key):
         with Connection(self._url) as connection:
-            producer = Producer(connection, exchange=BUS_EXCHANGE_XIVO, auto_declare=True)
-            producer.publish(json.dumps(event), routing_key=routing_key, content_type='application/json')
+            producer = Producer(connection, exchange=BUS_EXCHANGE_HEADERS, auto_declare=True)
+            producer.publish(json.dumps(event), headers={'name': event['name']}, content_type='application/json')
 
     def send_ami_newchannel_event(self, channel_id, channel=None):
         self.send_event({

--- a/integration_tests/suite/helpers/bus.py
+++ b/integration_tests/suite/helpers/bus.py
@@ -47,7 +47,7 @@ class BusClient(bus_helper.BusClient):
                 except TimeoutError:
                     pass
 
-    def send_event(self, event, routing_key):
+    def send_event(self, event):
         with Connection(self._url) as connection:
             producer = Producer(connection, exchange=BUS_EXCHANGE_HEADERS, auto_declare=True)
             producer.publish(json.dumps(event), headers={'name': event['name']}, content_type='application/json')
@@ -60,7 +60,7 @@ class BusClient(bus_helper.BusClient):
                 'Uniqueid': channel_id,
                 'Channel': channel or 'PJSIP/abcdef-00000001',
             }
-        }, 'ami.Newchannel')
+        })
 
     def send_ami_newstate_event(self, channel_id, state='Up'):
         self.send_event({
@@ -70,7 +70,7 @@ class BusClient(bus_helper.BusClient):
                 'Uniqueid': channel_id,
                 'ChannelStateDesc': state,
             }
-        }, 'ami.Newstate')
+        })
 
     def send_ami_hold_event(self, channel_id):
         self.send_event({
@@ -79,7 +79,7 @@ class BusClient(bus_helper.BusClient):
                 'Event': 'Hold',
                 'Uniqueid': channel_id,
             }
-        }, 'ami.Hold')
+        })
 
     def send_ami_unhold_event(self, channel_id):
         self.send_event({
@@ -88,7 +88,7 @@ class BusClient(bus_helper.BusClient):
                 'Event': 'Unhold',
                 'Uniqueid': channel_id,
             },
-        }, 'ami.Unhold')
+        })
 
     def send_ami_hangup_event(self, channel_id, base_exten=None, sip_call_id=None, channel=None):
         self.send_event({
@@ -108,7 +108,7 @@ class BusClient(bus_helper.BusClient):
                     'WAZO_SIP_CALL_ID': sip_call_id,
                 },
             },
-        }, 'ami.Hangup')
+        })
 
     def send_ami_peerstatus_event(self, channel_type, peer, status):
         self.send_event({
@@ -120,7 +120,7 @@ class BusClient(bus_helper.BusClient):
                 'Peer': peer,
                 'PeerStatus': status,
             },
-        }, 'ami.PeerStatus')
+        })
 
     def send_ami_registry_event(self, channel_type, domain, status, username):
         self.send_event({
@@ -133,7 +133,7 @@ class BusClient(bus_helper.BusClient):
                 'Status': status,
                 'Username': username,
             },
-        }, 'ami.Registry')
+        })
 
     def send_ami_dtmf_end_digit(self, channel_id, digit):
         self.send_event({
@@ -142,7 +142,7 @@ class BusClient(bus_helper.BusClient):
                 'Uniqueid': channel_id,
                 'Digit': digit,
             },
-        }, 'ami.DTMFEnd')
+        })
 
     def send_moh_created_event(self, moh_uuid):
         self.send_event({
@@ -151,7 +151,7 @@ class BusClient(bus_helper.BusClient):
                 'uuid': moh_uuid,
                 'name': 'default',
             },
-        }, 'config.moh.created')
+        })
 
     def send_moh_deleted_event(self, moh_uuid):
         self.send_event({
@@ -160,7 +160,7 @@ class BusClient(bus_helper.BusClient):
                 'uuid': moh_uuid,
                 'name': 'default',
             },
-        }, 'config.moh.deleted')
+        })
 
     def send_application_created_event(self, application_uuid, destination=None):
         payload = {
@@ -178,7 +178,7 @@ class BusClient(bus_helper.BusClient):
                 'music_on_hold': None,
                 'answer': False,
             }
-        self.send_event(payload, 'config.applications.created')
+        self.send_event(payload)
 
     def send_application_edited_event(self, application_uuid, destination=None):
         payload = {
@@ -196,7 +196,7 @@ class BusClient(bus_helper.BusClient):
                 'music_on_hold': None,
                 'answer': False,
             }
-        self.send_event(payload, 'config.applications.edited')
+        self.send_event(payload)
 
     def send_application_deleted_event(self, application_uuid):
         payload = {
@@ -208,11 +208,11 @@ class BusClient(bus_helper.BusClient):
                 'destination_options': {},
             },
         }
-        self.send_event(payload, 'config.applications.deleted')
+        self.send_event(payload)
 
     def send_trunk_endpoint_associated_event(self, trunk_id, endpoint_id):
         payload = {
             'name': 'trunk_endpoint_associated',
             'data': {'trunk_id': trunk_id, 'endpoint_id': endpoint_id},
         }
-        self.send_event(payload, 'config.trunks.endpoints.updated')
+        self.send_event(payload)

--- a/integration_tests/suite/helpers/constants.py
+++ b/integration_tests/suite/helpers/constants.py
@@ -9,6 +9,7 @@ INVALID_ACL_TOKEN = 'invalid-acl-token'
 VALID_TOKEN = 'valid-token'
 VALID_TENANT = 'ffffffff-ffff-ffff-ffff-ffffffffffff'
 BUS_EXCHANGE_XIVO = Exchange('xivo', type='topic')
+BUS_EXCHANGE_HEADERS = Exchange('wazo-headers', type='headers')
 BUS_EXCHANGE_COLLECTD = Exchange('collectd', type='topic', durable=False)
 BUS_URL = 'amqp://guest:guest@localhost:5672//'
 BUS_QUEUE_NAME = 'integration'

--- a/integration_tests/suite/helpers/constants.py
+++ b/integration_tests/suite/helpers/constants.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from kombu import Exchange
@@ -8,7 +8,6 @@ ASSET_ROOT = os.path.join(os.path.dirname(__file__), '..', '..', 'assets')
 INVALID_ACL_TOKEN = 'invalid-acl-token'
 VALID_TOKEN = 'valid-token'
 VALID_TENANT = 'ffffffff-ffff-ffff-ffff-ffffffffffff'
-BUS_EXCHANGE_XIVO = Exchange('xivo', type='topic')
 BUS_EXCHANGE_HEADERS = Exchange('wazo-headers', type='headers')
 BUS_EXCHANGE_COLLECTD = Exchange('collectd', type='topic', durable=False)
 BUS_URL = 'amqp://guest:guest@localhost:5672//'

--- a/integration_tests/suite/test_conferences.py
+++ b/integration_tests/suite/test_conferences.py
@@ -661,7 +661,7 @@ class TestConferenceParticipants(TestConferences):
         until.assert_(talking_user_event_received, listening_user_bus_events, talking=True, timeout=10)
 
         # send fake "stopped talking" AMI event
-        self.bus.publish(
+        self.bus.send_event(
             {
                 'name': 'ConfbridgeTalking',
                 'data': {
@@ -675,7 +675,6 @@ class TestConferenceParticipants(TestConferences):
                     'TalkingStatus': 'off',
                 }
             },
-            routing_key='ami.ConfbridgeTalking'
         )
 
         until.assert_(talking_event_received, admin_bus_events, talking=False, timeout=10)

--- a/integration_tests/suite/test_push_mobile.py
+++ b/integration_tests/suite/test_push_mobile.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -20,6 +20,7 @@ class TestPushMobile(RealAsteriskIntegrationTest):
         events = self.bus.accumulator('calls.call.push_notification')
 
         push_mobile_event = {
+            'name': 'UserEvent',
             'data': {
                 'UserEvent': 'Pushmobile',
                 'Uniqueid': '1560784195.313',
@@ -45,7 +46,7 @@ class TestPushMobile(RealAsteriskIntegrationTest):
             }
         }
 
-        self.bus.publish(push_mobile_event, routing_key='ami.UserEvent')
+        self.bus.send_event(push_mobile_event)
 
         def bus_events_received():
             assert_that(events.accumulate(), contains(

--- a/integration_tests/suite/test_switchboards.py
+++ b/integration_tests/suite/test_switchboards.py
@@ -648,7 +648,6 @@ class TestSwitchboardConfdCache(IntegrationTest):
                 'name': 'user_edited',
                 'data': {'uuid': user_uuid},
             },
-            routing_key='config.user.edited',
         )
 
         reset_confd()
@@ -664,7 +663,6 @@ class TestSwitchboardConfdCache(IntegrationTest):
                 'name': 'switchboard_edited',
                 'data': {'uuid': switchboard_uuid},
             },
-            routing_key='config.switchboards.{}.edited'.format(switchboard_uuid),
         )
 
         reset_confd()
@@ -681,7 +679,6 @@ class TestSwitchboardConfdCache(IntegrationTest):
                 'name': 'line_edited',
                 'data': {'id': line_id},
             },
-            routing_key='config.line.edited',
         )
 
         reset_confd()

--- a/wazo_calld/bus.py
+++ b/wazo_calld/bus.py
@@ -83,9 +83,6 @@ class CoreBusConsumer(ConsumerMixin):
     def provide_status(self, status):
         status['bus_consumer']['status'] = Status.ok if self.is_running() else Status.fail
 
-    def on_ami_event(self, event_type, callback):
-        self.on_event(event_type, callback)
-
     def on_event(self, event_name, callback):
         logger.debug('Added callback on event "%s"', event_name)
         self._queue.bindings.add(

--- a/wazo_calld/collectd.py
+++ b/wazo_calld/collectd.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2016 Avencall
+# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -31,8 +31,8 @@ class CoreCollectd:
         bus_url = 'amqp://{username}:{password}@{host}:{port}//'.format(**self.config)
         bus_connection = Connection(bus_url)
         same_exchange_arguments_as_collectd = {'arguments': {'auto_delete': True}, 'durable': False}
-        bus_exchange = Exchange(self.config['exchange_name'],
-                                type=self.config['exchange_type'],
+        bus_exchange = Exchange(self.config['subscribe_exchange_name'],
+                                type=self.config['subscribe_exchange_type'],
                                 **same_exchange_arguments_as_collectd)
         bus_producer = Producer(bus_connection, exchange=bus_exchange, auto_declare=True)
         bus_marshaler = CollectdMarshaler(self._uuid)

--- a/wazo_calld/config.py
+++ b/wazo_calld/config.py
@@ -54,11 +54,13 @@ _DEFAULT_CONFIG = {
         'password': 'guest',
         'host': 'localhost',
         'port': 5672,
-        'exchange_name': 'xivo',
-        'exchange_type': 'topic',
+        'subscribe_exchange_name': 'wazo-headers',
+        'subscribe_exchange_type': 'headers',
+        'publish_exchange_name': 'xivo',
+        'publish_exchange_type': 'topic',
     },
     'collectd': {
-        'exchange_name': 'collectd',
+        'publish_exchange_name': 'collectd',
     },
     'confd': {
         'host': 'localhost',

--- a/wazo_calld/plugins/calls/bus_consume.py
+++ b/wazo_calld/plugins/calls/bus_consume.py
@@ -32,18 +32,18 @@ class CallsBusEventHandler:
         self.notifier = notifier
 
     def subscribe(self, bus_consumer):
-        bus_consumer.on_ami_event('Newchannel', self._add_sip_call_id)
-        bus_consumer.on_ami_event('Newchannel', self._relay_channel_created)
-        bus_consumer.on_ami_event('Newchannel', self._collectd_channel_created)
-        bus_consumer.on_ami_event('Newstate', self._relay_channel_updated)
-        bus_consumer.on_ami_event('Newstate', self._relay_channel_answered)
-        bus_consumer.on_ami_event('NewConnectedLine', self._relay_channel_updated)
-        bus_consumer.on_ami_event('Hold', self._channel_hold)
-        bus_consumer.on_ami_event('Unhold', self._channel_unhold)
-        bus_consumer.on_ami_event('Hangup', self._relay_channel_hung_up)
-        bus_consumer.on_ami_event('Hangup', self._collectd_channel_ended)
-        bus_consumer.on_ami_event('UserEvent', self._set_dial_echo_result)
-        bus_consumer.on_ami_event('DTMFEnd', self._relay_dtmf)
+        bus_consumer.on_event('Newchannel', self._add_sip_call_id)
+        bus_consumer.on_event('Newchannel', self._relay_channel_created)
+        bus_consumer.on_event('Newchannel', self._collectd_channel_created)
+        bus_consumer.on_event('Newstate', self._relay_channel_updated)
+        bus_consumer.on_event('Newstate', self._relay_channel_answered)
+        bus_consumer.on_event('NewConnectedLine', self._relay_channel_updated)
+        bus_consumer.on_event('Hold', self._channel_hold)
+        bus_consumer.on_event('Unhold', self._channel_unhold)
+        bus_consumer.on_event('Hangup', self._relay_channel_hung_up)
+        bus_consumer.on_event('Hangup', self._collectd_channel_ended)
+        bus_consumer.on_event('UserEvent', self._set_dial_echo_result)
+        bus_consumer.on_event('DTMFEnd', self._relay_dtmf)
 
     def _add_sip_call_id(self, event):
         channel_id = event['Uniqueid']

--- a/wazo_calld/plugins/conferences/bus_consume.py
+++ b/wazo_calld/plugins/conferences/bus_consume.py
@@ -18,13 +18,13 @@ class ConferencesBusEventHandler:
         self._service = service
 
     def subscribe(self, bus_consumer):
-        bus_consumer.on_ami_event('ConfbridgeJoin', self._notify_participant_joined)
-        bus_consumer.on_ami_event('ConfbridgeLeave', self._notify_participant_left)
-        bus_consumer.on_ami_event('ConfbridgeMute', self._notify_participant_muted)
-        bus_consumer.on_ami_event('ConfbridgeUnmute', self._notify_participant_unmuted)
-        bus_consumer.on_ami_event('ConfbridgeRecord', self._notify_record_started)
-        bus_consumer.on_ami_event('ConfbridgeStopRecord', self._notify_record_stopped)
-        bus_consumer.on_ami_event('ConfbridgeTalking', self._notify_participant_talking)
+        bus_consumer.on_event('ConfbridgeJoin', self._notify_participant_joined)
+        bus_consumer.on_event('ConfbridgeLeave', self._notify_participant_left)
+        bus_consumer.on_event('ConfbridgeMute', self._notify_participant_muted)
+        bus_consumer.on_event('ConfbridgeUnmute', self._notify_participant_unmuted)
+        bus_consumer.on_event('ConfbridgeRecord', self._notify_record_started)
+        bus_consumer.on_event('ConfbridgeStopRecord', self._notify_record_stopped)
+        bus_consumer.on_event('ConfbridgeTalking', self._notify_participant_talking)
 
     def _notify_participant_joined(self, event):
         conference_id = int(event['Conference'])

--- a/wazo_calld/plugins/endpoints/bus.py
+++ b/wazo_calld/plugins/endpoints/bus.py
@@ -12,10 +12,10 @@ class EventHandler:
         self._confd_cache = confd_cache
 
     def subscribe(self, consumer):
-        consumer.on_ami_event('Hangup', self.on_hangup)
-        consumer.on_ami_event('Newchannel', self.on_new_channel)
-        consumer.on_ami_event('PeerStatus', self.on_peer_status)
-        consumer.on_ami_event('Registry', self.on_registry)
+        consumer.on_event('Hangup', self.on_hangup)
+        consumer.on_event('Newchannel', self.on_new_channel)
+        consumer.on_event('PeerStatus', self.on_peer_status)
+        consumer.on_event('Registry', self.on_registry)
         consumer.on_event('custom_endpoint_updated', self.on_endpoint_custom_updated)
         consumer.on_event('iax_endpoint_updated', self.on_trunk_endpoint_iax_updated)
         consumer.on_event('line_edited', self.on_line_edited)

--- a/wazo_calld/plugins/faxes/bus_consume.py
+++ b/wazo_calld/plugins/faxes/bus_consume.py
@@ -14,7 +14,7 @@ class FaxesBusEventHandler:
         self._notifier = notifier
 
     def subscribe(self, bus_consumer):
-        bus_consumer.on_ami_event('UserEvent', self._fax_result)
+        bus_consumer.on_event('UserEvent', self._fax_result)
 
     def _fax_result(self, event):
         if event['UserEvent'] != 'FaxProgress':

--- a/wazo_calld/plugins/mobile/bus_consume.py
+++ b/wazo_calld/plugins/mobile/bus_consume.py
@@ -16,7 +16,7 @@ class PushNotificationBusEventHandler(object):
         self.bus_publisher = bus_publisher
 
     def subscribe(self, bus_consumer):
-        bus_consumer.on_ami_event('UserEvent', self._user_event)
+        bus_consumer.on_event('UserEvent', self._user_event)
 
     def _user_event(self, event):
         if event['UserEvent'] != 'Pushmobile':

--- a/wazo_calld/plugins/voicemails/bus_consume.py
+++ b/wazo_calld/plugins/voicemails/bus_consume.py
@@ -23,7 +23,7 @@ class VoicemailsBusEventHandler:
         self._voicemail_cache = voicemail_cache
 
     def subscribe(self, bus_consumer):
-        bus_consumer.on_ami_event('MessageWaiting', self._voicemail_updated)
+        bus_consumer.on_event('MessageWaiting', self._voicemail_updated)
 
     def _voicemail_updated(self, event):
         number, context = event['Mailbox'].split('@', 1)


### PR DESCRIPTION
bus: remove useless method on_ami_event
bus: subscribe to event names directly instead of routing keys

Jira-Issue: https://wazo-dev.atlassian.net/browse/WAZO-1448

Jira-Issue: https://wazo-dev.atlassian.net/browse/WAZO-1448