### PR TITLE
switchboards: confd_cache: dont raise when invalidating unknown entry

### DIFF
--- a/wazo_calld/plugins/switchboards/confd_client_cache.py
+++ b/wazo_calld/plugins/switchboards/confd_client_cache.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -28,7 +28,7 @@ class ConfdClientGetUUIDCacheDecorator:
     def invalidate_cache_entry(self, uuid):
         with self._lock:
             logger.debug('Removing %s %s from cache', self._resource_name, uuid)
-            del self._cache[uuid]
+            self._cache.pop(uuid, None)
 
     def _make_key(self, args, kwargs):
         # See lru_cache code for more details:

--- a/wazo_calld/plugins/switchboards/tests/test_confd_client_cache.py
+++ b/wazo_calld/plugins/switchboards/tests/test_confd_client_cache.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -57,3 +57,9 @@ class TestConfdCacheGetUUID(TestCase):
 
         result = self.cache_get('some-uuid')
         assert_that(result, equal_to('some-new-response'))
+
+    def test_invalidate_unknown_entry(self):
+        try:
+            self.cache_get.invalidate_cache_entry('some-uuid')
+        except KeyError:
+            self.fail('invalidate_cache_entry raised KeyError')


### PR DESCRIPTION
Why:

* The switchboards cache is a partial cache: it does not contain entries
that haven't already been used. The cache receives events related
to all resources, including the resources it does not know about. In
this case, we can just ignore the event.