### PR TITLE
call: send same event when call is updated

### DIFF
--- a/wazo_calld/plugins/calls/event.py
+++ b/wazo_calld/plugins/calls/event.py
@@ -68,22 +68,17 @@ class ConnectCallEvent(StartCallEvent):
         return event['args'][2]
 
 
-class _BaseEvent:
+class CallUpdated:
 
-    required_acl = 'events.{}'
+    name = 'call_updated'
+    routing_key = 'calls.call.updated'
+    required_acl = 'events.calls.{user_uuid}'
+
+    def __init__(self, call):
+        self.required_acl = self.required_acl.format(
+            user_uuid=call['user_uuid']
+        )
+        self._body = call
 
     def marshal(self):
         return self._body
-
-
-class _BaseCallItemEvent(_BaseEvent):
-
-    def __init__(self, call):
-        self.routing_key = self.routing_key.format(call['call_id'])
-        self.required_acl = self.required_acl.format(self.routing_key)
-        self._body = call
-
-
-class CallUpdated(_BaseCallItemEvent):
-    name = 'call_updated'
-    routing_key = 'calls.{}.updated'

--- a/wazo_calld/plugins/calls/notifier.py
+++ b/wazo_calld/plugins/calls/notifier.py
@@ -19,7 +19,8 @@ class CallNotifier:
         self._bus = bus
 
     def call_updated(self, call):
-        logger.debug('Call (%s) updated', call.id_)
         call_serialized = call_schema.dump(call)
-        event = CallUpdated(call_serialized)
-        self._bus.publish(event)
+        self._bus.publish(
+            CallUpdated(call_serialized),
+            headers={'user_uuid:{uuid}'.format(uuid=call.user_uuid): True}
+        )

--- a/wazo_calld/plugins/calls/plugin.py
+++ b/wazo_calld/plugins/calls/plugin.py
@@ -54,7 +54,16 @@ class Plugin:
         ari.client_initialized_subscribe(startup_callback_collector.new_source())
         startup_callback_collector.subscribe(calls_stasis.initialize)
 
-        calls_bus_event_handler = CallsBusEventHandler(amid_client, ari.client, collectd, bus_publisher, calls_service, config['uuid'], dial_echo_manager)
+        calls_bus_event_handler = CallsBusEventHandler(
+            amid_client,
+            ari.client,
+            collectd,
+            bus_publisher,
+            calls_service,
+            config['uuid'],
+            dial_echo_manager,
+            notifier,
+        )
         calls_bus_event_handler.subscribe(bus_consumer)
 
         api.add_resource(CallsResource, '/calls', resource_class_args=[calls_service])

--- a/wazo_calld/plugins/calls/services.py
+++ b/wazo_calld/plugins/calls/services.py
@@ -187,6 +187,8 @@ class CallsService:
 
         ami.mute(self._ami, call_id)
 
+        # NOTE(fblackburn): asterisk should send back an event
+        # instead of falsy pretend that channel is muted
         call = self.make_call_from_channel(self._ari, channel)
         self._notifier.call_updated(call)
 
@@ -199,6 +201,8 @@ class CallsService:
 
         ami.unmute(self._ami, call_id)
 
+        # NOTE(fblackburn): asterisk should send back an event
+        # instead of falsy pretend that channel is unmuted
         call = self.make_call_from_channel(self._ari, channel)
         self._notifier.call_updated(call)
 


### PR DESCRIPTION
The event on mute/unmute wasn't readable by user and his ACL

Since mute/unmute don't trigger ami event, we cannot send event by the
CallsBusEventHandler

Another solution should be to fix asterisk to send event when channel is
muted since this solution can be false for a fraction of second