### PR TITLE
tests: fix the try except with wrong client

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -35,12 +35,18 @@ if os.environ.get('TEST_LOGS') != 'verbose':
     logging.getLogger('docker.utils.config').setLevel(logging.INFO)
 
 
+class ClientCreateException(Exception):
+
+    def __init__(self, client_name):
+        super().__init__(f'Could not create client {client_name}')
+
+
 class WrongClient:
     def __init__(self, client_name):
         self.client_name = client_name
 
     def __getattr__(self, member):
-        raise Exception('Could not create client {}'.format(self.client_name))
+        raise ClientCreateException(self.client_name)
 
 
 class IntegrationTest(AssetLaunchingTestCase):
@@ -182,7 +188,7 @@ class IntegrationTest(AssetLaunchingTestCase):
         super().setUp()
         try:
             self.calld_client.set_token(VALID_TOKEN)
-        except WrongClient:
+        except ClientCreateException:
             pass
 
 


### PR DESCRIPTION
on zuul or dev, hosts are too fast to see this problem and the client
have time to be created. But on slow host (Jenkins), wazo-calld can be
killed before executing this code and a WrongClient will be instantiate