### PR TITLE
calls: add call_answered event

### DIFF
--- a/integration_tests/suite/helpers/bus.py
+++ b/integration_tests/suite/helpers/bus.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -60,11 +60,12 @@ class BusClient(bus_helper.BusClient):
             }
         }, 'ami.Newchannel')
 
-    def send_ami_newstate_event(self, channel_id):
+    def send_ami_newstate_event(self, channel_id, state='Up'):
         self.send_event({
             'data': {
                 'Event': 'Newstate',
                 'Uniqueid': channel_id,
+                'ChannelStateDesc': state,
             }
         }, 'ami.Newstate')
 

--- a/integration_tests/suite/test_calls_bus_consume.py
+++ b/integration_tests/suite/test_calls_bus_consume.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that
@@ -101,6 +101,22 @@ class TestBusConsume(IntegrationTest):
         def assert_function():
             assert_that(events.accumulate(), has_item(has_entries({
                 'name': 'call_updated',
+                'origin_uuid': XIVO_UUID,
+                'data': has_entries({'call_id': call_id, 'status': 'Up'})
+            })))
+
+        until.assert_(assert_function, tries=5)
+
+    def test_when_channel_answered_then_bus_event(self):
+        call_id = new_call_id()
+        self.ari.set_channels(MockChannel(id=call_id, state='Up'))
+        events = self.bus.accumulator(routing_key='calls.call.answered')
+
+        self.bus.send_ami_newstate_event(call_id, state='Up')
+
+        def assert_function():
+            assert_that(events.accumulate(), has_item(has_entries({
+                'name': 'call_answered',
                 'origin_uuid': XIVO_UUID,
                 'data': has_entries({'call_id': call_id, 'status': 'Up'})
             })))

--- a/wazo_calld/plugins/calls/event.py
+++ b/wazo_calld/plugins/calls/event.py
@@ -82,3 +82,19 @@ class CallUpdated:
 
     def marshal(self):
         return self._body
+
+
+class CallAnswered:
+
+    name = 'call_answered'
+    routing_key = 'calls.call.answered'
+    required_acl = 'events.calls.{user_uuid}'
+
+    def __init__(self, call):
+        self.required_acl = self.required_acl.format(
+            user_uuid=call['user_uuid']
+        )
+        self._body = call
+
+    def marshal(self):
+        return self._body

--- a/wazo_calld/plugins/calls/notifier.py
+++ b/wazo_calld/plugins/calls/notifier.py
@@ -3,10 +3,9 @@
 
 import logging
 
-from .schemas import (
-    call_schema,
-)
+from .schemas import call_schema
 from .event import (
+    CallAnswered,
     CallUpdated,
 )
 
@@ -14,7 +13,6 @@ logger = logging.getLogger(__name__)
 
 
 class CallNotifier:
-
     def __init__(self, bus):
         self._bus = bus
 
@@ -22,5 +20,12 @@ class CallNotifier:
         call_serialized = call_schema.dump(call)
         self._bus.publish(
             CallUpdated(call_serialized),
-            headers={'user_uuid:{uuid}'.format(uuid=call.user_uuid): True}
+            headers={'user_uuid:{uuid}'.format(uuid=call.user_uuid): True},
+        )
+
+    def call_answered(self, call):
+        call_serialized = call_schema.dump(call)
+        self._bus.publish(
+            CallAnswered(call_serialized),
+            headers={'user_uuid:{uuid}'.format(uuid=call.user_uuid): True},
         )


### PR DESCRIPTION
Why:

* the call_updated event does not allow to detect exactly when a call
has been answered because it may be sent multiple times after the call
is answered.