### PR TITLE
WAZO-1755 dial mobile: hang up all unanswered channels on answer

### DIFF
--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -71,7 +71,7 @@ class _PollingContactDialer:
 
             time.sleep(0.25)
 
-        self._remove_ringing_channels()
+        self._remove_unanswered_channels()
 
     def _channel_is_up(self, channel_id):
         try:
@@ -97,12 +97,13 @@ class _PollingContactDialer:
         self._called_contacts.add(contact)
         self._dialed_channels.add(channel)
 
-    def _remove_ringing_channels(self):
+    def _remove_unanswered_channels(self):
         for channel in self._dialed_channels:
             try:
                 channel_info = channel.get()
-                if channel_info.json['state'] == 'Ringing':
-                    self._ari.channels.hangup(channelId=channel.id)
+                if channel_info.json['state'] == 'Up':
+                    continue
+                self._ari.channels.hangup(channelId=channel.id)
             except ARINotFound:
                 continue  # The channel has already been hung up
 


### PR DESCRIPTION
When calling a user with multiple contacts when the first one gets answered or
when the called hangs up all devices that did not answer the call must be hung
up.

If a device is not hung up, it will keep ringing.

Instead of hanging up all channels with a state "Ringing" this change hangs up
all channels that are not in state "Up".

One of the case I have observed is that the channel will have a state "Down"
before it starts ringing. In that case, that device will keep ringing after the
phone got answered elsewhere or got hung up by the caller.