### PR TITLE
nginx: remove specific location for max_body_size

### DIFF
--- a/etc/nginx/locations/https-available/wazo-calld
+++ b/etc/nginx/locations/https-available/wazo-calld
@@ -1,10 +1,8 @@
 location ^~ /api/calld/ {
     proxy_pass http://127.0.0.1:9500/;
 
-    location ~ /api/calld/1.0/(.*)/greetings/(.*) {
-        proxy_pass http://127.0.0.1:9500/1.0/$1/greetings/$2;
-        client_max_body_size 16m;
-    }
+    # Mostly used for voicemail greetings
+    client_max_body_size 16m;
 
     proxy_set_header    Host                $http_host;
     proxy_set_header    X-Script-Name       /api/calld;


### PR DESCRIPTION
reason: The old configuration didn't keep the query string when
forwarded to wazo-calld. Since this sub location wasn't really useful,
we can remove it