### PR TITLE
conference: ignore joins for unknown conferences

### DIFF
--- a/wazo_calld/plugin_helpers/confd.py
+++ b/wazo_calld/plugin_helpers/confd.py
@@ -122,7 +122,7 @@ class Conference:
         try:
             conference = confd_client.conferences.get(conference_id)
         except HTTPError as e:
-            if e.response and e.response.status_code == 404:
+            if e.response is not None and e.response.status_code == 404:
                 raise NoSuchConferenceID(conference_id)
             raise
         return cls(conference['tenant_uuid'],

--- a/wazo_calld/plugin_helpers/exceptions.py
+++ b/wazo_calld/plugin_helpers/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_calld.exceptions import APIException
@@ -26,7 +26,7 @@ class NotEnoughChannels(Exception):
 class NoSuchConferenceID(Exception):
     def __init__(self, conference_id):
         self.conference_id = conference_id
-        super('No such conference ID "{}"'.format(conference_id))
+        super().__init__('No such conference ID "{}"'.format(conference_id))
 
 
 class UserMissingMainLine(APIException):


### PR DESCRIPTION
Why:

* Pagings create confbridge conferences that are not found in
wazo-confd.
* We want to avoid tracebacks when that happens.