### PR TITLE
dial_mobile: fix the connected line ID of the caller

### DIFF
--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -176,8 +176,11 @@ class DialMobileService:
             type='mixing',
             bridgeId=future_bridge_uuid,
         )
-        bridge.addChannel(channel=channel_id)
-        bridge.addChannel(channel=outgoing_channel_id)
+        # Without the inhibitConnectedLineUpdates everyone in the bridge will receive a new
+        # connected line update with the caller ID of the caller when PAI is trusted, including
+        # the caller...
+        bridge.addChannel(channel=channel_id, inhibitConnectedLineUpdates=True)
+        bridge.addChannel(channel=outgoing_channel_id, inhibitConnectedLineUpdates=True)
 
     def notify_channel_gone(self, channel_id):
         to_remove = None


### PR DESCRIPTION
the inhibitConnectedLineUpdates parameter avoids sending an update to the
connected line to all member of the bridge when the channel are added.

This avoids the caller from seeing itself as its contact

Depends-On: https://github.com/wazo-platform/asterisk/pull/51