### PR TITLE
config: remove timeout for wazo-auth

### DIFF
--- a/etc/wazo-calld/config.yml
+++ b/etc/wazo-calld/config.yml
@@ -34,7 +34,6 @@ rest_api:
 auth:
   host: localhost
   port: 9497
-  timeout: 2
   prefix: null
   https: false
   key_file: /var/lib/wazo-auth-keys/wazo-calld-key.yml

--- a/integration_tests/assets/etc/wazo-calld/conf.d/50-base.yml
+++ b/integration_tests/assets/etc/wazo-calld/conf.d/50-base.yml
@@ -12,7 +12,6 @@ ari:
 
 auth:
   host: auth
-  timeout: 2
   key_file: /etc/wazo-calld/key.yml
 
 bus:


### PR DESCRIPTION
Why:

* In some installs, 2 seconds can be too short for a token creation.
* There is no reason to have a shorter timeout than the default 10
seconds.