### PR TITLE
line/trunk status: get the username from the auth_section_options

### DIFF
--- a/wazo_calld/plugins/endpoints/services.py
+++ b/wazo_calld/plugins/endpoints/services.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -248,7 +248,12 @@ class ConfdCache:
             if trunk.get('endpoint_sip'):
                 techno = 'sip'
                 name = trunk['endpoint_sip']['name']
-                username = trunk['endpoint_sip']['username']
+                for key, value in trunk['endpoint_sip'].get('auth_section_options', []):
+                    if key == 'username':
+                        username = value
+                        break
+                else:
+                    username = None
             elif trunk.get('endpoint_iax'):
                 techno = 'iax'
                 name = trunk['endpoint_iax']['name']

--- a/wazo_calld/plugins/endpoints/services.py
+++ b/wazo_calld/plugins/endpoints/services.py
@@ -248,7 +248,7 @@ class ConfdCache:
             if trunk.get('endpoint_sip'):
                 techno = 'sip'
                 name = trunk['endpoint_sip']['name']
-                for key, value in trunk['endpoint_sip'].get('auth_section_options', []):
+                for key, value in trunk['endpoint_sip']['auth_section_options']:
                     if key == 'username':
                         username = value
                         break

--- a/wazo_calld/plugins/endpoints/tests/test_services.py
+++ b/wazo_calld/plugins/endpoints/tests/test_services.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
@@ -145,7 +145,10 @@ class TestCachingConfdClient(TestCase):
                 'id': s.line_id,
                 'protocol': 'sip',
                 'name': s.name,
-                'endpoint_sip': {'name': s.name, 'username': s.username},
+                'endpoint_sip': {
+                    'name': s.name,
+                    'auth_section_options': [['username', s.username]],
+                },
                 'tenant_uuid': s.tenant_uuid,
             },
         ])
@@ -159,7 +162,10 @@ class TestCachingConfdClient(TestCase):
         self._set_cache(trunks=[
             {
                 'id': s.trunk_id,
-                'endpoint_sip': {'name': s.name, 'username': s.username},
+                'endpoint_sip': {
+                    'name': s.name,
+                    'auth_section_options': [['username', s.username]],
+                },
                 'tenant_uuid': s.tenant_uuid,
             },
         ])
@@ -178,7 +184,10 @@ class TestCachingConfdClient(TestCase):
                 'id': s.line_id,
                 'protocol': 'sip',
                 'name': s.name,
-                'endpoint_sip': {'name': s.name, 'username': s.username},
+                'endpoint_sip': {
+                    'name': s.name,
+                    'auth_section_options': [['username', s.username]],
+                },
                 'tenant_uuid': s.tenant_uuid,
             },
         ])
@@ -200,7 +209,10 @@ class TestCachingConfdClient(TestCase):
         self._set_cache(trunks=[
             {
                 'id': s.trunk_id,
-                'endpoint_sip': {'name': s.name, 'username': s.username},
+                'endpoint_sip': {
+                    'name': s.name,
+                    'auth_section_options': [['username', s.username]],
+                },
                 'tenant_uuid': s.tenant_uuid,
             },
         ])
@@ -283,7 +295,10 @@ class TestCachingConfdClient(TestCase):
         self._set_cache([
             {
                 'id': 1,
-                'endpoint_sip': {'name': s.name_1, 'username': s.username_1},
+                'endpoint_sip': {
+                    'name': s.name_1,
+                    'auth_section_options': [['username', s.username_1]],
+                },
                 'tenant_uuid': s.tenant_uuid,
             },
             {
@@ -298,7 +313,10 @@ class TestCachingConfdClient(TestCase):
             },
             {
                 'id': 4,
-                'endpoint_sip': {'name': s.ignored_name, 'username': s.ignored_username},
+                'endpoint_sip': {
+                    'name': s.ignored_name,
+                    'auth_section_options': [['username', s.ignored_username]],
+                },
                 'tenant_uuid': s.other_tenant_uuid,
             },
         ])


### PR DESCRIPTION
username is not a top level field of an endpoint SIP anymore.