### PR TITLE
Pull request for WAZO-1929-adhoc-conference-refactor

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -10,7 +10,7 @@ build-calld: egg-info
 build-ari:
 	test -d $(CHAN_TEST_DIR)
 	docker build -t ari-mock -f docker/Dockerfile-ari-mock .
-	docker build -t ari-real -f $(CHAN_TEST_DIR)/Dockerfile $(CHAN_TEST_DIR)
+	docker build -t ari-real --pull -f $(CHAN_TEST_DIR)/Dockerfile $(CHAN_TEST_DIR)
 
 clean:
 	docker rmi -f wazopbx/wazo-calld

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -131,7 +131,7 @@ class IntegrationTest(AssetLaunchingTestCase):
         token_id = str(uuid.uuid4())
         tenant_uuid = tenant_uuid or str(uuid.uuid4())
         cls.auth.set_token(MockUserToken(token_id, tenant_uuid=tenant_uuid, user_uuid=user_uuid))
-        return CalldClient('localhost', cls.service_port(9500, 'calld'), prefix=None, https=False, token=token_id)
+        return cls.make_calld(token=token_id)
 
     @classmethod
     @contextmanager

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -15,7 +15,7 @@ from xivo_test_helpers.asset_launching_test_case import NoSuchPort
 
 from .amid import AmidClient
 from .ari_ import ARIClient
-from .auth import AuthClient
+from .auth import AuthClient, MockUserToken
 from .bus import BusClient
 from .confd import ConfdClient
 from .constants import ASSET_ROOT, VALID_TOKEN
@@ -125,6 +125,13 @@ class IntegrationTest(AssetLaunchingTestCase):
     @classmethod
     def make_calld(cls, token=VALID_TOKEN):
         return CalldClient('localhost', cls.service_port(9500, 'calld'), prefix=None, https=False, token=token)
+
+    @classmethod
+    def make_user_calld(cls, user_uuid, tenant_uuid=None):
+        token_id = str(uuid.uuid4())
+        tenant_uuid = tenant_uuid or str(uuid.uuid4())
+        cls.auth.set_token(MockUserToken(token_id, tenant_uuid=tenant_uuid, user_uuid=user_uuid))
+        return CalldClient('localhost', cls.service_port(9500, 'calld'), prefix=None, https=False, token=token_id)
 
     @classmethod
     @contextmanager

--- a/integration_tests/suite/test_adhoc_conferences.py
+++ b/integration_tests/suite/test_adhoc_conferences.py
@@ -48,6 +48,9 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         self.auth.set_token(MockUserToken(token_id, tenant_uuid=tenant_uuid, user_uuid=user_uuid))
         return token_id
 
+    def adhoc_conference_events_for_user(self, user_uuid):
+        return self.bus.accumulator('adhoc_conferences.users.{}.#'.format(user_uuid))
+
     def given_adhoc_conference(self, *user_uuids, participant_count):
         participant_call_ids = []
         user_uuids = list(user_uuids)
@@ -144,7 +147,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         participant2_uuid = make_user_uuid()
         token = self.make_user_token(host_uuid)
         self.calld_client.set_token(token)
-        host_events = self.bus.accumulator('conferences.users.{}.adhoc.#'.format(host_uuid))
+        host_events = self.adhoc_conference_events_for_user(host_uuid)
 
         host_call1_id, participant1_call_id = self.real_asterisk.given_bridged_call_stasis(caller_uuid=host_uuid, callee_uuid=participant1_uuid)
         host_call2_id, participant2_call_id = self.real_asterisk.given_bridged_call_stasis(caller_uuid=host_uuid, callee_uuid=participant2_uuid)
@@ -381,8 +384,8 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         self.calld_client.set_token(token)
         adhoc_conference_id, call_ids = self.given_adhoc_conference(host_uuid, participant1_uuid, participant2_uuid, participant_count=3)
         host_call_id, participant1_call_id, participant2_call_id = call_ids
-        host_events = self.bus.accumulator('conferences.users.{}.adhoc.#'.format(host_uuid))
-        participant1_events = self.bus.accumulator('conferences.users.{}.adhoc.#'.format(participant1_uuid))
+        host_events = self.adhoc_conference_events_for_user(host_uuid)
+        participant1_events = self.adhoc_conference_events_for_user(participant1_uuid)
 
         self.ari.channels.hangup(channelId=participant2_call_id)
 
@@ -419,7 +422,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         self.calld_client.set_token(token)
         adhoc_conference_id, call_ids = self.given_adhoc_conference(user_uuid, participant_count=2)
         host_call_id, participant1_call_id = call_ids
-        host_events = self.bus.accumulator('conferences.users.{}.adhoc.#'.format(user_uuid))
+        host_events = self.adhoc_conference_events_for_user(user_uuid)
 
         self.ari.channels.hangup(channelId=participant1_call_id)
 
@@ -443,7 +446,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         self.calld_client.set_token(token)
         adhoc_conference_id, call_ids = self.given_adhoc_conference(user_uuid, participant_count=3)
         host_call_id, participant1_call_id, participant2_call_id = call_ids
-        host_events = self.bus.accumulator('conferences.users.{}.adhoc.#'.format(user_uuid))
+        host_events = self.adhoc_conference_events_for_user(user_uuid)
 
         self.ari.channels.hangup(channelId=host_call_id)
 
@@ -524,7 +527,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         host_call1_id, participant1_call_id = call_ids
         participant2_uuid = make_user_uuid()
         host_call2_id, participant2_call_id = self.real_asterisk.given_bridged_call_stasis(caller_uuid=host_uuid, callee_uuid=participant2_uuid)
-        host_events = self.bus.accumulator('conferences.users.{}.adhoc.#'.format(host_uuid))
+        host_events = self.adhoc_conference_events_for_user(host_uuid)
         host_connected_line_before = self.ari.channels.getChannelVar(channelId=host_call1_id, variable='CONNECTEDLINE(all)')['value']
 
         self.calld_client.adhoc_conferences.add_participant_from_user(adhoc_conference_id, participant2_call_id)
@@ -720,8 +723,8 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         self.calld_client.set_token(token)
         adhoc_conference_id, call_ids = self.given_adhoc_conference(host_uuid, participant1_uuid, participant2_uuid, participant_count=3)
         host_call_id, participant1_call_id, participant2_call_id = call_ids
-        host_events = self.bus.accumulator('conferences.users.{}.adhoc.#'.format(host_uuid))
-        participant1_events = self.bus.accumulator('conferences.users.{}.adhoc.#'.format(participant1_uuid))
+        host_events = self.adhoc_conference_events_for_user(host_uuid)
+        participant1_events = self.adhoc_conference_events_for_user(participant1_uuid)
 
         self.calld_client.adhoc_conferences.remove_participant_from_user(adhoc_conference_id, participant2_call_id)
 

--- a/integration_tests/suite/test_adhoc_conferences.py
+++ b/integration_tests/suite/test_adhoc_conferences.py
@@ -49,7 +49,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         return token_id
 
     def adhoc_conference_events_for_user(self, user_uuid):
-        return self.bus.accumulator('adhoc_conferences.users.{}.#'.format(user_uuid))
+        return self.bus.accumulator('conferences.users.{}.adhoc.#'.format(user_uuid))
 
     def given_adhoc_conference(self, *user_uuids, participant_count):
         participant_call_ids = []
@@ -632,11 +632,11 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         another_uuid = make_user_uuid()
         token = self.make_user_token(another_uuid)
         self.calld_client.set_token(token)
-        _, call_ids = self.given_adhoc_conference(another_uuid, participant_count=3)
+        _, call_ids = self.given_adhoc_conference(another_uuid, participant_count=2)
         host_uuid = make_user_uuid()
         token = self.make_user_token(host_uuid)
         self.calld_client.set_token(token)
-        adhoc_conference_id, _ = self.given_adhoc_conference(host_uuid, participant_count=3)
+        adhoc_conference_id, _ = self.given_adhoc_conference(host_uuid, participant_count=2)
         _, participant1_call_id, __ = call_ids
 
         # response should not be different than a non-existing call, to avoid malicious call discovery

--- a/integration_tests/suite/test_adhoc_conferences.py
+++ b/integration_tests/suite/test_adhoc_conferences.py
@@ -63,7 +63,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         host_call_id, participant_call_id = self.real_asterisk.given_bridged_call_stasis(caller_uuid=host_uuid, callee_uuid=participant_uuid)
         participant_call_ids.append(participant_call_id)
 
-        for _ in range(participant_count - 2):
+        for _ in range(participant_count - 1):
             try:
                 participant_uuid = user_uuids.pop(0)
             except IndexError:
@@ -79,7 +79,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         def calls_are_bridged():
             host_call1 = self.calld_client.calls.get_call(host_call_id)
             assert_that(host_call1, has_entries({
-                'talking_to': has_length(participant_count - 1)
+                'talking_to': has_length(participant_count)
             }))
         until.assert_(calls_are_bridged, timeout=10)
 
@@ -209,7 +209,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         user_uuid = make_user_uuid()
         token = self.make_user_token(user_uuid)
         self.calld_client.set_token(token)
-        adhoc_conference_id, call_ids = self.given_adhoc_conference(user_uuid, participant_count=3)
+        adhoc_conference_id, call_ids = self.given_adhoc_conference(user_uuid, participant_count=2)
         host_call_id, participant_call_id, _ = call_ids
 
         assert_that(calling(self.calld_client.adhoc_conferences.create_from_user)
@@ -321,7 +321,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         user_uuid = make_user_uuid()
         token = self.make_user_token(user_uuid)
         self.calld_client.set_token(token)
-        adhoc_conference_id, _ = self.given_adhoc_conference(user_uuid, participant_count=2)
+        adhoc_conference_id, _ = self.given_adhoc_conference(user_uuid, participant_count=1)
         another_user_uuid = make_user_uuid()
         another_token = self.make_user_token(another_user_uuid)
         self.calld_client.set_token(another_token)
@@ -340,7 +340,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         participant_uuid = make_user_uuid()
         token = self.make_user_token(host_uuid)
         self.calld_client.set_token(token)
-        adhoc_conference_id, call_ids = self.given_adhoc_conference(host_uuid, participant_uuid, participant_count=2)
+        adhoc_conference_id, call_ids = self.given_adhoc_conference(host_uuid, participant_uuid, participant_count=1)
         host_call_id, participant_call_id = call_ids
         host_events = self.bus.accumulator('conferences.users.{}.adhoc.#'.format(host_uuid))
 
@@ -382,7 +382,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         participant2_uuid = make_user_uuid()
         token = self.make_user_token(host_uuid)
         self.calld_client.set_token(token)
-        adhoc_conference_id, call_ids = self.given_adhoc_conference(host_uuid, participant1_uuid, participant2_uuid, participant_count=3)
+        adhoc_conference_id, call_ids = self.given_adhoc_conference(host_uuid, participant1_uuid, participant2_uuid, participant_count=2)
         host_call_id, participant1_call_id, participant2_call_id = call_ids
         host_events = self.adhoc_conference_events_for_user(host_uuid)
         participant1_events = self.adhoc_conference_events_for_user(participant1_uuid)
@@ -420,7 +420,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         user_uuid = make_user_uuid()
         token = self.make_user_token(user_uuid)
         self.calld_client.set_token(token)
-        adhoc_conference_id, call_ids = self.given_adhoc_conference(user_uuid, participant_count=2)
+        adhoc_conference_id, call_ids = self.given_adhoc_conference(user_uuid, participant_count=1)
         host_call_id, participant1_call_id = call_ids
         host_events = self.adhoc_conference_events_for_user(user_uuid)
 
@@ -444,7 +444,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         user_uuid = make_user_uuid()
         token = self.make_user_token(user_uuid)
         self.calld_client.set_token(token)
-        adhoc_conference_id, call_ids = self.given_adhoc_conference(user_uuid, participant_count=3)
+        adhoc_conference_id, call_ids = self.given_adhoc_conference(user_uuid, participant_count=2)
         host_call_id, participant1_call_id, participant2_call_id = call_ids
         host_events = self.adhoc_conference_events_for_user(user_uuid)
 
@@ -491,7 +491,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         user_uuid = make_user_uuid()
         token = self.make_user_token(user_uuid)
         self.calld_client.set_token(token)
-        adhoc_conference_id, call_ids = self.given_adhoc_conference(user_uuid, participant_count=2)
+        adhoc_conference_id, call_ids = self.given_adhoc_conference(user_uuid, participant_count=1)
 
         assert_that(calling(self.calld_client.adhoc_conferences.add_participant_from_user)
                     .with_args(adhoc_conference_id, SOME_CALL_ID),
@@ -504,7 +504,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         user_uuid = make_user_uuid()
         token = self.make_user_token(user_uuid)
         self.calld_client.set_token(token)
-        adhoc_conference_id, _ = self.given_adhoc_conference(user_uuid, participant_count=2)
+        adhoc_conference_id, _ = self.given_adhoc_conference(user_uuid, participant_count=1)
         _, participant_call_id = self.real_asterisk.given_bridged_call_stasis(caller_uuid=user_uuid)
         another_user_uuid = make_user_uuid()
         another_token = self.make_user_token(another_user_uuid)
@@ -523,7 +523,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         host_uuid = make_user_uuid()
         token = self.make_user_token(host_uuid)
         self.calld_client.set_token(token)
-        adhoc_conference_id, call_ids = self.given_adhoc_conference(host_uuid, participant_count=2)
+        adhoc_conference_id, call_ids = self.given_adhoc_conference(host_uuid, participant_count=1)
         host_call1_id, participant1_call_id = call_ids
         participant2_uuid = make_user_uuid()
         host_call2_id, participant2_call_id = self.real_asterisk.given_bridged_call_stasis(caller_uuid=host_uuid, callee_uuid=participant2_uuid)
@@ -564,7 +564,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         host_uuid = make_user_uuid()
         token = self.make_user_token(host_uuid)
         self.calld_client.set_token(token)
-        adhoc_conference_id, call_ids = self.given_adhoc_conference(host_uuid, participant_count=2)
+        adhoc_conference_id, call_ids = self.given_adhoc_conference(host_uuid, participant_count=1)
         host_call1_id, participant1_call_id = call_ids
         host_call2_id, participant2_call_id = self.real_asterisk.given_bridged_call_not_stasis(caller_uuid=host_uuid)
 
@@ -585,7 +585,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         host_uuid = make_user_uuid()
         token = self.make_user_token(host_uuid)
         self.calld_client.set_token(token)
-        adhoc_conference_id, call_ids = self.given_adhoc_conference(host_uuid, participant_count=2)
+        adhoc_conference_id, call_ids = self.given_adhoc_conference(host_uuid, participant_count=1)
         host_call_id, participant_call_id = call_ids
         lone_call_id = self.real_asterisk.stasis_channel().id
 
@@ -602,7 +602,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         another_uuid = make_user_uuid()
         token = self.make_user_token(host_uuid)
         self.calld_client.set_token(token)
-        adhoc_conference_id, call_ids = self.given_adhoc_conference(host_uuid, participant_count=2)
+        adhoc_conference_id, call_ids = self.given_adhoc_conference(host_uuid, participant_count=1)
         _, participant2_call_id = self.real_asterisk.given_bridged_call_stasis(caller_uuid=another_uuid)
 
         # response should not be different than a non-existing call, to avoid malicious call discovery
@@ -617,7 +617,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         host_uuid = make_user_uuid()
         token = self.make_user_token(host_uuid)
         self.calld_client.set_token(token)
-        adhoc_conference_id, call_ids = self.given_adhoc_conference(host_uuid, participant_count=3)
+        adhoc_conference_id, call_ids = self.given_adhoc_conference(host_uuid, participant_count=2)
         host_call_id, participant1_call_id, _ = call_ids
 
         assert_that(calling(self.calld_client.adhoc_conferences.add_participant_from_user)
@@ -672,7 +672,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         user_uuid = make_user_uuid()
         token = self.make_user_token(user_uuid)
         self.calld_client.set_token(token)
-        adhoc_conference_id, call_ids = self.given_adhoc_conference(user_uuid, participant_count=2)
+        adhoc_conference_id, call_ids = self.given_adhoc_conference(user_uuid, participant_count=1)
 
         assert_that(calling(self.calld_client.adhoc_conferences.remove_participant_from_user)
                     .with_args(adhoc_conference_id, SOME_CALL_ID),
@@ -685,7 +685,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         user_uuid = make_user_uuid()
         token = self.make_user_token(user_uuid)
         self.calld_client.set_token(token)
-        adhoc_conference_id, call_ids = self.given_adhoc_conference(user_uuid, participant_count=2)
+        adhoc_conference_id, call_ids = self.given_adhoc_conference(user_uuid, participant_count=1)
         host_call_id, participant_call_id = self.real_asterisk.given_bridged_call_stasis(caller_uuid=user_uuid)
 
         # response should not be different than a non-existing call, to avoid malicious call discovery
@@ -700,7 +700,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         user_uuid = make_user_uuid()
         token = self.make_user_token(user_uuid)
         self.calld_client.set_token(token)
-        adhoc_conference_id, _ = self.given_adhoc_conference(user_uuid, participant_count=2)
+        adhoc_conference_id, _ = self.given_adhoc_conference(user_uuid, participant_count=1)
         _, participant_call_id = self.real_asterisk.given_bridged_call_stasis(caller_uuid=user_uuid)
         another_user_uuid = make_user_uuid()
         another_token = self.make_user_token(another_user_uuid)
@@ -721,7 +721,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         participant2_uuid = make_user_uuid()
         token = self.make_user_token(host_uuid)
         self.calld_client.set_token(token)
-        adhoc_conference_id, call_ids = self.given_adhoc_conference(host_uuid, participant1_uuid, participant2_uuid, participant_count=3)
+        adhoc_conference_id, call_ids = self.given_adhoc_conference(host_uuid, participant1_uuid, participant2_uuid, participant_count=2)
         host_call_id, participant1_call_id, participant2_call_id = call_ids
         host_events = self.adhoc_conference_events_for_user(host_uuid)
         participant1_events = self.adhoc_conference_events_for_user(participant1_uuid)

--- a/integration_tests/suite/test_adhoc_conferences.py
+++ b/integration_tests/suite/test_adhoc_conferences.py
@@ -71,13 +71,14 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
             _, participant_call_id = self.real_asterisk.given_bridged_call_stasis(caller_uuid=host_uuid, callee_uuid=participant_uuid)
             participant_call_ids.append(participant_call_id)
 
-        adhoc_conference = self.calld_client.adhoc_conferences.create_from_user(
+        calld_client = self.make_user_calld(host_uuid)
+        adhoc_conference = calld_client.adhoc_conferences.create_from_user(
             host_call_id,
             *participant_call_ids
         )
 
         def calls_are_bridged():
-            host_call1 = self.calld_client.calls.get_call(host_call_id)
+            host_call1 = calld_client.calls.get_call(host_call_id)
             assert_that(host_call1, has_entries({
                 'talking_to': has_length(participant_count)
             }))

--- a/integration_tests/suite/test_calls.py
+++ b/integration_tests/suite/test_calls.py
@@ -231,18 +231,14 @@ class TestUserListCalls(IntegrationTest):
         self.confd.reset()
 
     def test_given_no_calls_when_list_calls_then_empty_list(self):
-        token = 'my-token'
         user_uuid = 'user-uuid'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
-        self.calld_client.set_token(token)
-        calls = self.calld_client.calls.list_calls_from_user()
+        calld_client = self.make_user_calld(user_uuid)
+        calls = calld_client.calls.list_calls_from_user()
 
         assert_that(calls, has_entry('items', contains()))
 
     def test_given_some_calls_with_user_id_when_list_my_calls_then_calls_are_filtered_by_user(self):
-        token = 'my-token'
         user_uuid = 'user-uuid'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
         self.ari.set_channels(MockChannel(id='my-call'),
                               MockChannel(id='my-second-call'),
                               MockChannel(id='others-call'),
@@ -252,9 +248,9 @@ class TestUserListCalls(IntegrationTest):
                                        'others-call': {'XIVO_USERUUID': 'user2-uuid'}})
         self.confd.set_users(MockUser(uuid=user_uuid),
                              MockUser(uuid='user2-uuid'))
+        calld_client = self.make_user_calld(user_uuid)
 
-        self.calld_client.set_token(token)
-        calls = self.calld_client.calls.list_calls_from_user()
+        calls = calld_client.calls.list_calls_from_user()
 
         assert_that(calls, has_entry('items', contains_inanyorder(
             has_entries({'call_id': 'my-call',
@@ -263,9 +259,7 @@ class TestUserListCalls(IntegrationTest):
                          'user_uuid': user_uuid}))))
 
     def test_given_some_calls_when_list_calls_by_application_then_list_of_calls_is_filtered(self):
-        token = 'my-token'
         user_uuid = 'user-uuid'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
         self.ari.set_channels(MockChannel(id='first-id'),
                               MockChannel(id='second-id'),
                               MockChannel(id='third-id'))
@@ -273,32 +267,28 @@ class TestUserListCalls(IntegrationTest):
         self.ari.set_channel_variable({'first-id': {'XIVO_USERUUID': user_uuid},
                                        'second-id': {'XIVO_USERUUID': user_uuid},
                                        'third-id': {'XIVO_USERUUID': user_uuid}})
+        calld_client = self.make_user_calld(user_uuid)
 
-        self.calld_client.set_token(token)
-        calls = self.calld_client.calls.list_calls_from_user(application='my-app')
+        calls = calld_client.calls.list_calls_from_user(application='my-app')
 
         assert_that(calls, has_entry('items', contains_inanyorder(
             has_entries({'call_id': 'first-id'}),
             has_entries({'call_id': 'third-id'}))))
 
     def test_given_some_calls_and_no_applications_when_list_calls_by_application_then_no_calls(self):
-        token = 'my-token'
         user_uuid = 'user-uuid'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
         self.ari.set_channels(MockChannel(id='first-id'),
                               MockChannel(id='second-id'))
         self.ari.set_channel_variable({'first-id': {'XIVO_USERUUID': user_uuid},
                                        'second-id': {'XIVO_USERUUID': user_uuid}})
+        calld_client = self.make_user_calld(user_uuid)
 
-        self.calld_client.set_token(token)
-        calls = self.calld_client.calls.list_calls_from_user(application='my-app')
+        calls = calld_client.calls.list_calls_from_user(application='my-app')
 
         assert_that(calls, has_entry('items', empty()))
 
     def test_given_some_calls_when_list_calls_by_application_instance_then_list_of_calls_is_filtered(self):
-        token = 'my-token'
         user_uuid = 'user-uuid'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
         self.ari.set_channels(MockChannel(id='first-id'),
                               MockChannel(id='second-id'),
                               MockChannel(id='third-id'),
@@ -317,9 +307,9 @@ class TestUserListCalls(IntegrationTest):
                                        'XIVO_CHANNELS_third-id': json.dumps({'app': 'my-app',
                                                                              'app_instance': 'appX',
                                                                              'state': 'talking'})})
+        calld_client = self.make_user_calld(user_uuid)
 
-        self.calld_client.set_token(token)
-        calls = self.calld_client.calls.list_calls_from_user(
+        calls = calld_client.calls.list_calls_from_user(
             application='my-app',
             application_instance='appX',
         )
@@ -329,16 +319,14 @@ class TestUserListCalls(IntegrationTest):
             has_entries({'call_id': 'third-id'}))))
 
     def test_given_local_channels_when_list_then_local_channels_are_ignored(self):
-        token = 'my-token'
         user_uuid = 'user-uuid'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
         self.ari.set_channels(MockChannel(id='first-id'),
                               MockChannel(id='second-id', name=SOME_LOCAL_CHANNEL_NAME))
         self.ari.set_channel_variable({'first-id': {'XIVO_USERUUID': user_uuid},
                                        'second-id': {'XIVO_USERUUID': user_uuid}})
+        calld_client = self.make_user_calld(user_uuid)
 
-        self.calld_client.set_token(token)
-        calls = self.calld_client.calls.list_calls_from_user()
+        calls = calld_client.calls.list_calls_from_user()
 
         assert_that(calls, has_entry('items', contains_inanyorder(
             has_entries({'call_id': 'first-id'}))))

--- a/integration_tests/suite/test_fax.py
+++ b/integration_tests/suite/test_fax.py
@@ -17,7 +17,6 @@ from xivo_test_helpers import until
 from xivo_test_helpers.hamcrest.raises import raises
 from wazo_calld_client.exceptions import CalldError
 
-from .helpers.auth import MockUserToken
 from .helpers.confd import (
     MockLine,
     MockUser,
@@ -207,15 +206,13 @@ class TestFax(RealAsteriskIntegrationTest):
 
     def test_send_fax_from_user_unknown(self):
         user_uuid = 'some-user-id'
-        token = 'my-user-token'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid, tenant_uuid='my-tenant'))
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
         with open(os.path.join(ASSET_ROOT, 'fax', 'fax.pdf'), 'rb') as fax_file:
             fax_content = fax_file.read()
 
         assert_that(
-            calling(self.calld_client.faxes.send_from_user).with_args(
+            calling(calld_client.faxes.send_from_user).with_args(
                 fax_content,
                 extension='recipient-fax',
                 caller_id='fax wait'
@@ -227,16 +224,14 @@ class TestFax(RealAsteriskIntegrationTest):
 
     def test_send_fax_from_user_without_line(self):
         user_uuid = 'some-user-id'
-        token = 'my-user-token'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid, tenant_uuid='my-tenant'))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[]))
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
         with open(os.path.join(ASSET_ROOT, 'fax', 'fax.pdf'), 'rb') as fax_file:
             fax_content = fax_file.read()
 
         assert_that(
-            calling(self.calld_client.faxes.send_from_user).with_args(
+            calling(calld_client.faxes.send_from_user).with_args(
                 fax_content,
                 extension='recipient-fax',
                 caller_id='fax wait'
@@ -249,19 +244,17 @@ class TestFax(RealAsteriskIntegrationTest):
     def test_send_fax_pdf_from_user(self):
         user_uuid = 'some-user-id'
         context = 'user-context'
-        token = 'my-user-token'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid, tenant_uuid='my-tenant'))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=['some-line-id']))
         self.confd.set_lines(MockLine(id='some-line-id', name='line-name', protocol='pjsip', context=context))
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
         with open(os.path.join(ASSET_ROOT, 'fax', 'fax.pdf'), 'rb') as fax_file:
             fax_content = fax_file.read()
 
         try:
-            self.calld_client.faxes.send_from_user(fax_content,
-                                                   extension='recipient-fax',
-                                                   caller_id='fax wait')
+            calld_client.faxes.send_from_user(fax_content,
+                                              extension='recipient-fax',
+                                              caller_id='fax wait')
         except Exception as e:
             raise AssertionError('Sending fax raised an exception: {}'.format(e))
 
@@ -273,20 +266,18 @@ class TestFax(RealAsteriskIntegrationTest):
     def test_send_fax_from_user_events_success(self):
         user_uuid = 'some-user-id'
         context = 'user-context'
-        token = 'my-user-token'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid, tenant_uuid='my-tenant'))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=['some-line-id']))
         self.confd.set_lines(MockLine(id='some-line-id', name='line-name', protocol='pjsip', context=context))
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid, tenant_uuid='my-tenant')
 
         with open(os.path.join(ASSET_ROOT, 'fax', 'fax.pdf'), 'rb') as fax_file:
             fax_content = fax_file.read()
 
         events = self.bus.accumulator('faxes.outbound.users.some-user-id.#')
 
-        result = self.calld_client.faxes.send_from_user(fax_content,
-                                                        extension='recipient-fax',
-                                                        caller_id='fax success')
+        result = calld_client.faxes.send_from_user(fax_content,
+                                                   extension='recipient-fax',
+                                                   caller_id='fax success')
         fax_id = result['id']
 
         def bus_events_received():

--- a/integration_tests/suite/test_relocates.py
+++ b/integration_tests/suite/test_relocates.py
@@ -19,7 +19,6 @@ from xivo_test_helpers import until
 from xivo_test_helpers.hamcrest.raises import raises
 from wazo_calld_client.exceptions import CalldError
 
-from .helpers.auth import MockUserToken
 from .helpers.real_asterisk import RealAsteriskIntegrationTest, RealAsterisk
 from .helpers.confd import MockUser
 from .helpers.confd import MockLine
@@ -49,10 +48,9 @@ class TestRelocates(RealAsteriskIntegrationTest):
         line_id = SOME_LINE_ID
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id], mobile='mobile-autoanswer'))
         self.confd.set_lines(MockLine(id=line_id, name=SOME_LINE_NAME, protocol='local', context='local'))
-        token = self.given_user_token(user_uuid)
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
-        call = self.calld_client.calls.make_call_from_user(
+        call = calld_client.calls.make_call_from_user(
             extension='dial-autoanswer',
             from_mobile=True,
             variables={'CALLEE_XIVO_USERUUID': user_uuid}
@@ -71,23 +69,16 @@ class TestRelocates(RealAsteriskIntegrationTest):
 
         return call['call_id'], callee, user_uuid
 
-    def given_user_token(self, user_uuid):
-        token = 'my-token'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
-
-        return token
-
     def given_ringing_user_relocate(self):
         user_uuid = str(uuid.uuid4())
         relocated_channel_id, initiator_channel_id = self.real_asterisk.given_bridged_call_stasis(callee_uuid=user_uuid)
         line_id = SOME_LINE_ID
-        token = self.given_user_token(user_uuid)
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='recipient@local', protocol='local', context=SOME_CONTEXT))
-        self.calld_client.set_token(token)
         destination = 'line'
         location = {'line_id': line_id}
-        relocate = self.calld_client.relocates.create_from_user(initiator_channel_id, destination, location)
+        calld_client = self.make_user_calld(user_uuid)
+        relocate = calld_client.relocates.create_from_user(initiator_channel_id, destination, location)
 
         return relocate, user_uuid, destination, location
 
@@ -95,13 +86,12 @@ class TestRelocates(RealAsteriskIntegrationTest):
         user_uuid = str(uuid.uuid4())
         relocated_channel_id, initiator_channel_id = self.real_asterisk.given_bridged_call_not_stasis(callee_uuid=user_uuid, caller_variables={'WAIT_BEFORE_STASIS': '60'})
         line_id = SOME_LINE_ID
-        token = self.given_user_token(user_uuid)
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='recipient_autoanswer@local', protocol='local', context=SOME_CONTEXT))
-        self.calld_client.set_token(token)
         destination = 'line'
         location = {'line_id': line_id}
-        relocate = self.calld_client.relocates.create_from_user(initiator_channel_id, destination, location)
+        calld_client = self.make_user_calld(user_uuid)
+        relocate = calld_client.relocates.create_from_user(initiator_channel_id, destination, location)
 
         def relocate_waiting_relocated():
             assert_that(relocated_channel_id, self.c.is_talking(), 'relocated channel not talking')
@@ -116,15 +106,14 @@ class TestRelocates(RealAsteriskIntegrationTest):
         user_uuid = SOME_USER_UUID
         relocated_channel_id, initiator_channel_id = self.real_asterisk.given_bridged_call_stasis(callee_uuid=user_uuid)
         line_id = SOME_LINE_ID
-        token = self.given_user_token(user_uuid)
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='recipient_autoanswer@local', protocol='local', context=SOME_CONTEXT))
-        self.calld_client.set_token(token)
         events = self.bus.accumulator('calls.relocate.*')
         destination = 'line'
         location = {'line_id': line_id}
         completions = ['api']
-        relocate = self.calld_client.relocates.create_from_user(initiator_channel_id, destination, location, completions)
+        calld_client = self.make_user_calld(user_uuid)
+        relocate = calld_client.relocates.create_from_user(initiator_channel_id, destination, location, completions)
 
         def all_talking():
             assert_that(relocate['relocated_call'], self.c.is_talking(), 'relocated channel not talking')
@@ -147,13 +136,12 @@ class TestRelocates(RealAsteriskIntegrationTest):
         user_uuid = SOME_USER_UUID
         relocated_channel_id, initiator_channel_id = self.real_asterisk.given_bridged_call_stasis(callee_uuid=user_uuid)
         line_id = SOME_LINE_ID
-        token = self.given_user_token(user_uuid)
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='recipient_autoanswer@local', protocol='local', context=SOME_CONTEXT))
-        self.calld_client.set_token(token)
         destination = 'line'
         location = {'line_id': line_id}
-        relocate = self.calld_client.relocates.create_from_user(initiator_channel_id, destination, location)
+        calld_client = self.make_user_calld(user_uuid)
+        relocate = calld_client.relocates.create_from_user(initiator_channel_id, destination, location)
 
         until.assert_(
             self.assert_relocate_is_completed,
@@ -192,20 +180,18 @@ class TestListUserRelocate(TestRelocates):
 
     def test_given_no_relocates_when_list_then_list_empty(self):
         user_uuid = SOME_USER_UUID
-        token = self.given_user_token(user_uuid)
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
-        result = self.calld_client.relocates.list_from_user()
+        result = calld_client.relocates.list_from_user()
 
         assert_that(result['items'], empty())
 
     def test_given_one_relocate_when_list_then_all_fields_are_listed(self):
         user_uuid = SOME_USER_UUID
-        token = self.given_user_token(user_uuid)
         relocate, user_uuid, destination, location = self.given_ringing_user_relocate()
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
-        result = self.calld_client.relocates.list_from_user()
+        result = calld_client.relocates.list_from_user()
 
         assert_that(result['items'], contains({
             'uuid': relocate['uuid'],
@@ -219,21 +205,19 @@ class TestListUserRelocate(TestRelocates):
 
     def test_given_one_completed_relocate_when_list_then_relocate_not_found(self):
         user_uuid = SOME_USER_UUID
-        token = self.given_user_token(user_uuid)
-        self.calld_client.set_token(token)
         relocate, user_uuid = self.given_completed_user_relocate()
+        calld_client = self.make_user_calld(user_uuid)
 
-        relocates = self.calld_client.relocates.list_from_user()
+        relocates = calld_client.relocates.list_from_user()
 
         assert_that(relocates['items'], not_(contains(has_entry('uuid', relocate['uuid']))))
 
     def test_given_two_relocates_when_list_then_relocates_are_filtered_by_user(self):
         relocate1, user_uuid1, _, __ = self.given_ringing_user_relocate()
         relocate2, user_uuid2, _, __ = self.given_ringing_user_relocate()
-        token = self.given_user_token(user_uuid2)
-        self.calld_client.set_token(token)
+        user2_calld_client = self.make_user_calld(user_uuid2)
 
-        result = self.calld_client.relocates.list_from_user()
+        result = user2_calld_client.relocates.list_from_user()
 
         assert_that(result['items'], contains(has_entries({
             'uuid': relocate2['uuid'],
@@ -243,21 +227,21 @@ class TestListUserRelocate(TestRelocates):
 class TestGetUserRelocate(TestRelocates):
 
     def test_given_no_relocate_when_get_then_error_404(self):
-        token = self.given_user_token(SOME_USER_UUID)
-        self.calld_client.set_token(token)
+        user_uuid = SOME_USER_UUID
+        calld_client = self.make_user_calld(user_uuid)
 
-        assert_that(calling(self.calld_client.relocates.get_from_user).with_args(relocate_uuid='not-found'),
+        assert_that(calling(calld_client.relocates.get_from_user).with_args(relocate_uuid='not-found'),
                     raises(CalldError).matching(has_properties({
                         'status_code': 404,
                         'error_id': 'no-such-relocate',
                     })))
 
     def test_given_other_relocate_when_get_then_404(self):
-        relocate, user_uuid, _, __ = self.given_ringing_user_relocate()
-        token = self.given_user_token(SOME_USER_UUID)
-        self.calld_client.set_token(token)
+        relocate, _, __, ___ = self.given_ringing_user_relocate()
+        user_uuid = SOME_USER_UUID
+        calld_client = self.make_user_calld(user_uuid)
 
-        assert_that(calling(self.calld_client.relocates.get_from_user).with_args(relocate['uuid']),
+        assert_that(calling(calld_client.relocates.get_from_user).with_args(relocate['uuid']),
                     raises(CalldError).matching(has_properties({
                         'status_code': 404,
                         'error_id': 'no-such-relocate',
@@ -265,10 +249,9 @@ class TestGetUserRelocate(TestRelocates):
 
     def test_given_relocate_when_get_then_result(self):
         relocate, user_uuid, _, __ = self.given_ringing_user_relocate()
-        token = self.given_user_token(user_uuid)
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
-        result = self.calld_client.relocates.get_from_user(relocate['uuid'])
+        result = calld_client.relocates.get_from_user(relocate['uuid'])
 
         assert_that(result, has_entries({
             'uuid': relocate['uuid'],
@@ -289,22 +272,19 @@ class TestCreateUserRelocate(TestRelocates):
 
     def test_given_invalid_request_when_relocate_then_400(self):
         user_uuid = SOME_USER_UUID
-        token = self.given_user_token(user_uuid)
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
-        assert_that(calling(self.calld_client.relocates.create_from_user).with_args(SOME_CALL_ID, 'wrong-destination'),
+        assert_that(calling(calld_client.relocates.create_from_user).with_args(SOME_CALL_ID, 'wrong-destination'),
                     raises(CalldError).matching(has_properties({
                         'status_code': 400,
                         'error_id': 'invalid-data',
                     })))
 
     def test_given_token_without_user_when_relocate_then_400(self):
-        token = 'some-token'
-        self.auth.set_token(MockUserToken(token, user_uuid=None))
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(None)
 
         assert_that(
-            calling(self.calld_client.relocates.create_from_user).with_args(
+            calling(calld_client.relocates.create_from_user).with_args(
                 SOME_CALL_ID,
                 'line',
                 {'line_id': SOME_LINE_ID}
@@ -316,11 +296,10 @@ class TestCreateUserRelocate(TestRelocates):
 
     def test_given_no_channel_when_relocate_then_403(self):
         user_uuid = SOME_USER_UUID
-        token = self.given_user_token(user_uuid)
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
         assert_that(
-            calling(self.calld_client.relocates.create_from_user).with_args(
+            calling(calld_client.relocates.create_from_user).with_args(
                 SOME_CALL_ID,
                 'line',
                 {'line_id': SOME_LINE_ID}
@@ -333,12 +312,11 @@ class TestCreateUserRelocate(TestRelocates):
 
     def test_given_channel_does_not_belong_to_user_when_relocate_then_403(self):
         user_uuid = SOME_USER_UUID
-        token = self.given_user_token(user_uuid)
         relocated_channel_id, initiator_channel_id = self.real_asterisk.given_bridged_call_stasis()
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
         assert_that(
-            calling(self.calld_client.relocates.create_from_user).with_args(
+            calling(calld_client.relocates.create_from_user).with_args(
                 initiator_channel_id,
                 'line',
                 {'line_id': SOME_LINE_ID}
@@ -352,12 +330,11 @@ class TestCreateUserRelocate(TestRelocates):
     def test_given_invalid_user_when_relocate_then_400(self):
         user_uuid = SOME_USER_UUID
         line_id = SOME_LINE_ID
-        token = self.given_user_token(user_uuid)
         relocated_channel_id, initiator_channel_id = self.real_asterisk.given_bridged_call_stasis(callee_uuid=user_uuid)
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
         assert_that(
-            calling(self.calld_client.relocates.create_from_user).with_args(
+            calling(calld_client.relocates.create_from_user).with_args(
                 initiator_channel_id,
                 'line',
                 {'line_id': line_id}
@@ -371,13 +348,12 @@ class TestCreateUserRelocate(TestRelocates):
     def test_given_invalid_line_when_relocate_then_400(self):
         user_uuid = SOME_USER_UUID
         line_id = SOME_LINE_ID
-        token = self.given_user_token(user_uuid)
         relocated_channel_id, initiator_channel_id = self.real_asterisk.given_bridged_call_stasis(callee_uuid=user_uuid)
         self.confd.set_users(MockUser(uuid=user_uuid))
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
         assert_that(
-            calling(self.calld_client.relocates.create_from_user).with_args(
+            calling(calld_client.relocates.create_from_user).with_args(
                 initiator_channel_id,
                 'line',
                 {'line_id': line_id}
@@ -391,15 +367,14 @@ class TestCreateUserRelocate(TestRelocates):
     def test_given_only_one_channel_when_relocate_then_400(self):
         user_uuid = SOME_USER_UUID
         line_id = SOME_LINE_ID
-        token = self.given_user_token(user_uuid)
         initiator_channel = self.real_asterisk.stasis_channel()
         initiator_channel.setChannelVar(variable='XIVO_USERUUID', value=user_uuid)
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='recipient_autoanswer@local', protocol='local', context=SOME_CONTEXT))
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
         assert_that(
-            calling(self.calld_client.relocates.create_from_user).with_args(
+            calling(calld_client.relocates.create_from_user).with_args(
                 initiator_channel.id,
                 'line',
                 {'line_id': line_id}
@@ -411,11 +386,10 @@ class TestCreateUserRelocate(TestRelocates):
 
     def test_given_relocate_started_when_relocate_again_then_409(self):
         relocate, user_uuid, destination, location = self.given_ringing_user_relocate()
-        token = self.given_user_token(user_uuid)
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
         assert_that(
-            calling(self.calld_client.relocates.create_from_user).with_args(
+            calling(calld_client.relocates.create_from_user).with_args(
                 relocate['initiator_call'],
                 destination,
                 location,
@@ -430,12 +404,11 @@ class TestCreateUserRelocate(TestRelocates):
         line_id = 12
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='recipient_autoanswer@local', protocol='local', context=SOME_CONTEXT))
-        token = self.given_user_token(user_uuid)
         relocated_channel_id, initiator_channel_id = self.real_asterisk.given_bridged_call_stasis(callee_uuid=user_uuid)
         events = self.bus.accumulator('calls.relocate.*')
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
-        relocate = self.calld_client.relocates.create_from_user(initiator_channel_id, 'line', {'line_id': line_id})
+        relocate = calld_client.relocates.create_from_user(initiator_channel_id, 'line', {'line_id': line_id})
 
         until.assert_(
             self.assert_relocate_is_completed,
@@ -473,12 +446,11 @@ class TestCreateUserRelocate(TestRelocates):
         line_id = 12
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='recipient_autoanswer@local', protocol='local', context=SOME_CONTEXT))
-        token = self.given_user_token(user_uuid)
         relocated_channel_id, initiator_channel_id = self.real_asterisk.given_bridged_call_not_stasis(callee_uuid=user_uuid)
         events = self.bus.accumulator('calls.relocate.*')
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
-        relocate = self.calld_client.relocates.create_from_user(initiator_channel_id, 'line', {'line_id': line_id})
+        relocate = calld_client.relocates.create_from_user(initiator_channel_id, 'line', {'line_id': line_id})
 
         until.assert_(
             self.assert_relocate_is_completed,
@@ -516,12 +488,11 @@ class TestCreateUserRelocate(TestRelocates):
         line_id = 12
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id], mobile=None))
         self.confd.set_lines(MockLine(id=line_id, context='local'))
-        token = self.given_user_token(user_uuid)
         relocated_channel_id, initiator_channel_id = self.real_asterisk.given_bridged_call_stasis(callee_uuid=user_uuid)
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
         assert_that(
-            calling(self.calld_client.relocates.create_from_user).with_args(
+            calling(calld_client.relocates.create_from_user).with_args(
                 initiator_channel_id,
                 'mobile',
             ),
@@ -535,11 +506,10 @@ class TestCreateUserRelocate(TestRelocates):
         line_id = 12
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id], mobile='recipient_autoanswer'))
         self.confd.set_lines(MockLine(id=line_id, context='local'))
-        token = self.given_user_token(user_uuid)
         relocated_channel_id, initiator_channel_id = self.real_asterisk.given_bridged_call_stasis(callee_uuid=user_uuid)
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
-        relocate = self.calld_client.relocates.create_from_user(initiator_channel_id, 'mobile')
+        relocate = calld_client.relocates.create_from_user(initiator_channel_id, 'mobile')
 
         until.assert_(
             self.assert_relocate_is_completed,
@@ -588,10 +558,9 @@ class TestCreateUserRelocate(TestRelocates):
 
     def test_given_relocate_ringing_when_api_cancel_then_relocate_cancelled(self):
         relocate, user_uuid, _, __ = self.given_ringing_user_relocate()
-        token = self.given_user_token(user_uuid)
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
-        self.calld_client.relocates.cancel_from_user(relocate['uuid'])
+        calld_client.relocates.cancel_from_user(relocate['uuid'])
 
         def relocate_cancelled():
             assert_that(relocate['relocated_call'], self.c.is_talking(), 'relocated not talking')
@@ -626,11 +595,10 @@ class TestCreateUserRelocate(TestRelocates):
 
     def test_given_relocate_waiting_relocated_when_api_cancel_then_400(self):
         relocate, user_uuid = self.given_waiting_relocated_user_relocate()
-        token = self.given_user_token(user_uuid)
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
         assert_that(
-            calling(self.calld_client.relocates.cancel_from_user).with_args(
+            calling(calld_client.relocates.cancel_from_user).with_args(
                 relocate['uuid'],
             ),
             raises(CalldError).matching(has_properties({
@@ -640,10 +608,9 @@ class TestCreateUserRelocate(TestRelocates):
 
     def test_given_relocate_completion_api_when_api_complete_then_relocate_completed(self):
         relocate, user_uuid = self.given_answered_user_relocate()
-        token = self.given_user_token(user_uuid)
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
-        self.calld_client.relocates.complete_from_user(relocate['uuid'])
+        calld_client.relocates.complete_from_user(relocate['uuid'])
 
         until.assert_(
             self.assert_relocate_is_completed,
@@ -656,10 +623,9 @@ class TestCreateUserRelocate(TestRelocates):
 
     def test_given_relocate_waiting_completion_when_api_cancel_then_relocate_cancelled(self):
         relocate, user_uuid = self.given_answered_user_relocate()
-        token = self.given_user_token(user_uuid)
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
-        self.calld_client.relocates.cancel_from_user(relocate['uuid'])
+        calld_client.relocates.cancel_from_user(relocate['uuid'])
 
         def relocate_cancelled():
             assert_that(relocate['relocated_call'], self.c.is_talking(), 'relocated not talking')
@@ -706,11 +672,10 @@ class TestCreateUserRelocate(TestRelocates):
 
     def test_given_ringing_relocate_when_api_complete_then_400(self):
         relocate, user_uuid, _, __ = self.given_ringing_user_relocate()
-        token = self.given_user_token(user_uuid)
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
         assert_that(
-            calling(self.calld_client.relocates.complete_from_user).with_args(
+            calling(calld_client.relocates.complete_from_user).with_args(
                 relocate['uuid'],
             ),
             raises(CalldError).matching(has_properties({
@@ -720,15 +685,14 @@ class TestCreateUserRelocate(TestRelocates):
 
     def test_given_mobile_call_when_relocate_to_line_then_relocate_completed(self):
         mobile_channel, other_channel, mobile_user_uuid = self.given_mobile_call()
-        token = self.given_user_token(mobile_user_uuid)
         line_id = SOME_LINE_ID
-        self.calld_client.set_token(token)
         self.confd.set_users(MockUser(uuid=mobile_user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='recipient_autoanswer@local', protocol='local', context=SOME_CONTEXT))
         destination = 'line'
         location = {'line_id': line_id}
+        calld_client = self.make_user_calld(mobile_user_uuid)
 
-        relocate = self.calld_client.relocates.create_from_user(mobile_channel, destination, location)
+        relocate = calld_client.relocates.create_from_user(mobile_channel, destination, location)
 
         until.assert_(
             self.assert_relocate_is_completed,
@@ -742,16 +706,15 @@ class TestCreateUserRelocate(TestRelocates):
     def test_given_call_when_relocate_to_mobile_and_relocate_to_line_then_relocate_completed(self):
         user_uuid = SOME_USER_UUID
         initiator_channel, callee_channel = self.real_asterisk.given_bridged_call_stasis(caller_uuid=user_uuid)
-        token = self.given_user_token(user_uuid)
         line_id = SOME_LINE_ID
-        self.calld_client.set_token(token)
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id], mobile='recipient_autoanswer'))
         self.confd.set_lines(MockLine(id=line_id, name='recipient_autoanswer@local', protocol='local', context='local'))
+        calld_client = self.make_user_calld(user_uuid)
 
-        relocate = self.calld_client.relocates.create_from_user(initiator_channel, destination='mobile')
+        relocate = calld_client.relocates.create_from_user(initiator_channel, destination='mobile')
 
         def relocate_finished(relocate):
-            assert_that(calling(self.calld_client.relocates.get_from_user).with_args(relocate['uuid']),
+            assert_that(calling(calld_client.relocates.get_from_user).with_args(relocate['uuid']),
                         raises(CalldError).matching(has_properties({
                             'status_code': 404,
                             'error_id': 'no-such-relocate',
@@ -767,7 +730,7 @@ class TestCreateUserRelocate(TestRelocates):
         destination = 'line'
         location = {'line_id': line_id}
 
-        relocate = self.calld_client.relocates.create_from_user(initiator_channel, destination, location)
+        relocate = calld_client.relocates.create_from_user(initiator_channel, destination, location)
 
         until.assert_(
             self.assert_relocate_is_completed,
@@ -783,17 +746,16 @@ class TestCreateUserRelocate(TestRelocates):
         line_id = 12
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='ring@local', protocol='local', context=SOME_CONTEXT))
-        token = self.given_user_token(user_uuid)
         relocated_channel_id, initiator_channel_id = self.real_asterisk.given_bridged_call_stasis(callee_uuid=user_uuid)
-        self.calld_client.set_token(token)
+        calld_client = self.make_user_calld(user_uuid)
 
-        relocate = self.calld_client.relocates.create_from_user(initiator_channel_id, 'line', {'line_id': line_id}, timeout=1)
+        relocate = calld_client.relocates.create_from_user(initiator_channel_id, 'line', {'line_id': line_id}, timeout=1)
 
         def relocate_cancelled():
             assert_that(relocate['relocated_call'], self.c.is_talking(), 'relocated not talking')
             assert_that(relocate['initiator_call'], self.c.is_talking(), 'initiator not talking')
             assert_that(relocate['recipient_call'], self.c.is_hungup(), 'recipient not hungup')
-            assert_that(calling(self.calld_client.relocates.get_from_user).with_args(relocate['uuid']),
+            assert_that(calling(calld_client.relocates.get_from_user).with_args(relocate['uuid']),
                         raises(CalldError).matching(has_properties({
                             'status_code': 404,
                             'error_id': 'no-such-relocate',

--- a/integration_tests/suite/test_voicemail.py
+++ b/integration_tests/suite/test_voicemail.py
@@ -19,7 +19,6 @@ from hamcrest import (
 from xivo_test_helpers.hamcrest.raises import raises
 from wazo_calld_client.exceptions import CalldError
 
-from .helpers.auth import MockUserToken
 from .helpers.confd import (
     MockUser,
     MockVoicemail,
@@ -49,7 +48,6 @@ class TestVoicemails(RealAsteriskIntegrationTest):
         self.confd.reset()
 
         self._voicemail_id = 1234
-        self._user_token = str(uuid.uuid4())
         self._user_uuid = str(uuid.uuid4())
 
         self.confd.set_users(MockUser(uuid=self._user_uuid,
@@ -58,9 +56,7 @@ class TestVoicemails(RealAsteriskIntegrationTest):
             MockVoicemail(self._voicemail_id, "8000", "voicemail-name",
                           "default", user_uuids=[self._user_uuid])
         )
-        self.auth.set_token(MockUserToken(self._user_token, user_uuid=self._user_uuid,
-                                          tenant_uuid=VALID_TENANT))
-        self.calld_client.set_token(self._user_token)
+        self.calld_client = self.make_user_calld(self._user_uuid, tenant_uuid=VALID_TENANT)
 
     def test_voicemail_head_greeting_invalid_voicemail(self):
         exists = self.calld_client.voicemails.voicemail_greeting_exists(

--- a/wazo_calld/plugins/adhoc_conferences/api.yml
+++ b/wazo_calld/plugins/adhoc_conferences/api.yml
@@ -9,14 +9,14 @@ paths:
         description: Parameters of the conference calls
         required: true
         schema:
-          $ref: '#/definitions/ConferenceAdhocCreation'
+          $ref: '#/definitions/AdhocConferenceCreation'
       tags:
       - adhoc_conferences
       responses:
         '201':
           description: Conference adhoc has been created
           schema:
-            $ref: '#/definitions/ConferenceAdhoc'
+            $ref: '#/definitions/AdhocConference'
         '400':
           $ref: '#/responses/InvalidRequest'
         '409':
@@ -35,7 +35,7 @@ paths:
         '204':
           description: Conference adhoc has been deleted
           schema:
-            $ref: '#/definitions/ConferenceAdhoc'
+            $ref: '#/definitions/AdhocConference'
         '404':
           $ref: '#/responses/NoSuchAdhocConference'
         '503':
@@ -76,7 +76,7 @@ paths:
         '503':
           $ref: '#/responses/AnotherServiceUnavailable'
 definitions:
-  ConferenceAdhocCreation:
+  AdhocConferenceCreation:
     type: object
     properties:
       host_call_id:
@@ -87,7 +87,7 @@ definitions:
         type: array
         items:
           type: string
-  ConferenceAdhoc:
+  AdhocConference:
     type: object
     properties:
       conference_id:

--- a/wazo_calld/plugins/adhoc_conferences/services.py
+++ b/wazo_calld/plugins/adhoc_conferences/services.py
@@ -73,7 +73,7 @@ class AdhocConferencesService:
         logger.debug('adhoc conference %s: remaining participants %s', adhoc_conference_id, remaining_participant_call_ids)
         for participant_call_id in remaining_participant_call_ids:
             logger.debug('adhoc conference %s: looking for peer of participant %s', adhoc_conference_id, participant_call_id)
-            discarded_host_channel_id = self._find_call_peer(participant_call_id)
+            discarded_host_channel_id = self._find_peer_channel(participant_call_id).id
 
             logger.debug('adhoc conference %s: processing participant %s and peer %s', adhoc_conference_id, participant_call_id, discarded_host_channel_id)
             self._redirect_participant(participant_call_id, discarded_host_channel_id, adhoc_conference_id)
@@ -81,14 +81,6 @@ class AdhocConferencesService:
         return {
             'conference_id': adhoc_conference_id,
         }
-
-    def _find_call_peer(self, call_id):
-        try:
-            return Channel(call_id, self._ari).only_connected_channel().id
-        except NotEnoughChannels:
-            raise AdhocConferenceCreationError(f'could not determine peer of call {call_id}: call has no peers')
-        except TooManyChannels:
-            raise HostCallAlreadyInConference(call_id)
 
     def _find_peer_channel(self, call_id):
         return Channel(call_id, self._ari).only_connected_channel()

--- a/wazo_calld/plugins/adhoc_conferences/stasis.py
+++ b/wazo_calld/plugins/adhoc_conferences/stasis.py
@@ -17,16 +17,16 @@ ADHOC_CONFERENCE_STASIS_APP = 'adhoc_conference'
 class AdhocConferencesStasis:
 
     def __init__(self, ari, notifier):
-        self.ari = ari.client
+        self._ari = ari.client
         self._core_ari = ari
         self._notifier = notifier
-        self.adhoc_conference_creation_lock = threading.Lock()
+        self._adhoc_conference_creation_lock = threading.Lock()
 
     def _subscribe(self):
-        self.ari.on_channel_event('StasisStart', self.on_stasis_start)
-        self.ari.on_channel_event('ChannelEnteredBridge', self.on_channel_entered_bridge)
-        self.ari.on_channel_event('ChannelLeftBridge', self.on_channel_left_bridge)
-        self.ari.on_bridge_event('BridgeDestroyed', self.on_bridge_destroyed)
+        self._ari.on_channel_event('StasisStart', self.on_stasis_start)
+        self._ari.on_channel_event('ChannelEnteredBridge', self.on_channel_entered_bridge)
+        self._ari.on_channel_event('ChannelLeftBridge', self.on_channel_left_bridge)
+        self._ari.on_bridge_event('BridgeDestroyed', self.on_bridge_destroyed)
 
     def initialize(self):
         self._subscribe()
@@ -46,16 +46,16 @@ class AdhocConferencesStasis:
                          event['args'])
             return
 
-        with self.adhoc_conference_creation_lock:
+        with self._adhoc_conference_creation_lock:
             try:
-                bridge = self.ari.bridges.get(bridgeId=adhoc_conference_id)
+                bridge = self._ari.bridges.get(bridgeId=adhoc_conference_id)
             except ARINotFound:
                 logger.debug('adhoc conference %s: creating bridge', adhoc_conference_id)
-                bridge = self.ari.bridges.createWithId(
+                bridge = self._ari.bridges.createWithId(
                     type='mixing',
                     bridgeId=adhoc_conference_id,
                 )
-                self.ari.applications.subscribe(
+                self._ari.applications.subscribe(
                     applicationName=ADHOC_CONFERENCE_STASIS_APP,
                     eventSource=f'bridge:{bridge.id}',
                 )
@@ -79,14 +79,14 @@ class AdhocConferencesStasis:
             logger.error('adhoc conference %s: channel %s hungup too early or variable not found', adhoc_conference_id, channel_id)
             return
 
-        bridge_helper = Bridge(adhoc_conference_id, self.ari)
-        participant_call = CallsService.make_call_from_channel(self. ari, channel)
+        bridge_helper = Bridge(adhoc_conference_id, self._ari)
+        participant_call = CallsService.make_call_from_channel(self._ari, channel)
         other_participant_uuids = bridge_helper.valid_user_uuids()
         self._notifier.participant_joined(adhoc_conference_id, other_participant_uuids, participant_call)
 
         if is_adhoc_conference_host:
             bridge_helper.global_variables.set('WAZO_HOST_CHANNEL_ID', channel_id)
-            host_user_uuid = Channel(channel_id, self.ari).user()
+            host_user_uuid = Channel(channel_id, self._ari).user()
             bridge_helper.global_variables.set('WAZO_HOST_USER_UUID', host_user_uuid)
 
             self._notify_host_of_channels_already_present(adhoc_conference_id, event['bridge']['channels'], host_user_uuid)
@@ -97,17 +97,17 @@ class AdhocConferencesStasis:
     def _notify_host_of_channels_already_present(self, adhoc_conference_id, channel_ids, host_user_uuid):
         for channel_id in channel_ids:
             try:
-                other_participant_channel = self.ari.channels.get(channelId=channel_id)
+                other_participant_channel = self._ari.channels.get(channelId=channel_id)
             except ARINotFound:
                 logger.error('adhoc conference %s: participant %s hanged up before host arrived', adhoc_conference_id, channel_id)
                 continue
-            other_participant_call = CallsService.make_call_from_channel(self.ari, other_participant_channel)
+            other_participant_call = CallsService.make_call_from_channel(self._ari, other_participant_channel)
             self._notifier.participant_joined(adhoc_conference_id, [host_user_uuid], other_participant_call)
 
     def _set_host_connectedline(self, channel_id, adhoc_conference_id):
         try:
-            host_caller_id_number = self.ari.channels.getChannelVar(channelId=channel_id, variable='CALLERID(number)')['value']
-            self.ari.channels.setChannelVar(channelId=channel_id, variable='CONNECTEDLINE(all)', value=f'"Conference" <{host_caller_id_number}>')
+            host_caller_id_number = self._ari.channels.getChannelVar(channelId=channel_id, variable='CALLERID(number)')['value']
+            self._ari.channels.setChannelVar(channelId=channel_id, variable='CONNECTEDLINE(all)', value=f'"Conference" <{host_caller_id_number}>')
         except ARINotFound:
             logger.error('adhoc conference %s: channel %s hungup too early or variable not found when setting connected line', adhoc_conference_id, channel_id)
             return
@@ -121,7 +121,7 @@ class AdhocConferencesStasis:
 
         logger.debug('adhoc conference %s: channel %s left', adhoc_conference_id, channel_id)
 
-        bridge_helper = Bridge(adhoc_conference_id, self.ari)
+        bridge_helper = Bridge(adhoc_conference_id, self._ari)
         try:
             host_user_uuid = bridge_helper.global_variables.get('WAZO_HOST_USER_UUID')
         except KeyError:
@@ -138,7 +138,7 @@ class AdhocConferencesStasis:
         elif bridge_helper.is_empty():
             logger.debug('adhoc conference %s: bridge is empty, destroying', adhoc_conference_id)
             try:
-                self.ari.bridges.destroy(bridgeId=adhoc_conference_id)
+                self._ari.bridges.destroy(bridgeId=adhoc_conference_id)
             except ARINotFound:
                 pass
         else:
@@ -153,7 +153,7 @@ class AdhocConferencesStasis:
 
     def _hangup_all_participants(self, adhoc_conference_id):
         try:
-            channel_ids = self.ari.bridges.get(bridgeId=adhoc_conference_id).json['channels']
+            channel_ids = self._ari.bridges.get(bridgeId=adhoc_conference_id).json['channels']
         except ARINotFound:
             logger.error('adhoc conference %s: bridge was destroyed too early when destroying', adhoc_conference_id)
             return
@@ -162,7 +162,7 @@ class AdhocConferencesStasis:
         for channel_id in channel_ids:
             logger.debug('adhoc conference %s: hanging up participant %s', adhoc_conference_id, channel_id)
             try:
-                self.ari.channels.hangup(channelId=channel_id)
+                self._ari.channels.hangup(channelId=channel_id)
             except ARINotFound:
                 pass
 
@@ -173,13 +173,13 @@ class AdhocConferencesStasis:
         logger.debug('adhoc conference %s: bridge was destroyed', bridge.id)
 
         try:
-            host_user_uuid = Bridge(bridge.id, self.ari).global_variables.get('WAZO_HOST_USER_UUID')
+            host_user_uuid = Bridge(bridge.id, self._ari).global_variables.get('WAZO_HOST_USER_UUID')
         except KeyError:
             logger.error('adhoc conference %s: could not retrieve host user uuid when destroying', bridge.id)
             return
 
         self._notifier.deleted(bridge.id, host_user_uuid)
 
-        bridge_helper = Bridge(bridge.id, self.ari)
+        bridge_helper = Bridge(bridge.id, self._ari)
         bridge_helper.global_variables.unset('WAZO_HOST_USER_UUID')
         bridge_helper.global_variables.unset('WAZO_HOST_CHANNEL_ID')


### PR DESCRIPTION
## adhoc conference tests: factorize events precondition


## adhoc conference: rename definitions

Why:

* Homogenize naming

## adhoc conference: fix private attribute names


## adhoc conference tests: change participant_count

Why:

* More symmetric with API definition

## adhoc conference tests: make preconditions independent of calld client

Why:

* Preconditions should be usable in any order
* If a test modifies self.calld_client, it should not fail the
precondition

## tests: use make_user_calld


## tests: avoid duplicating calld client instantiation


## adhoc conference: remove duplicate method find_call_peer