### PR TITLE
adhoc conferences: forbid adding same participant

### DIFF
--- a/wazo_calld/plugins/adhoc_conferences/exceptions.py
+++ b/wazo_calld/plugins/adhoc_conferences/exceptions.py
@@ -55,6 +55,18 @@ class HostCallAlreadyInConference(AdhocConferenceException):
         )
 
 
+class ParticipantCallAlreadyInConference(AdhocConferenceException):
+    def __init__(self, participant_call_id):
+        super().__init__(
+            status_code=409,
+            message='Adhoc conference error: participant already in conference',
+            error_id='participant-already-in-conference',
+            details={
+                'participant_call_id': participant_call_id,
+            }
+        )
+
+
 class ParticipantCallNotFound(AdhocConferenceException):
     def __init__(self, participant_call_id):
         super().__init__(

--- a/wazo_calld/plugins/adhoc_conferences/services.py
+++ b/wazo_calld/plugins/adhoc_conferences/services.py
@@ -14,6 +14,7 @@ from .exceptions import (
     AdhocConferenceNotFound,
     HostCallNotFound,
     HostCallAlreadyInConference,
+    ParticipantCallAlreadyInConference,
     ParticipantCallNotFound,
 )
 
@@ -180,6 +181,10 @@ class AdhocConferencesService:
 
         if bridge_helper.global_variables.get(variable='WAZO_HOST_USER_UUID') != user_uuid:
             raise AdhocConferenceNotFound(adhoc_conference_id)
+
+        current_participant_call_ids = self._ari.bridges.get(bridgeId=adhoc_conference_id).json['channels']
+        if participant_call_id in current_participant_call_ids:
+            raise ParticipantCallAlreadyInConference(participant_call_id)
 
         try:
             discarded_host_wazo_channel = self._find_peer_channel(participant_call_id)


### PR DESCRIPTION
Why:

* When adding a participant of an adhoc conference with only the host,
the host would be hungup