### PR TITLE
Pull request for WAZO-1955-adhoc-conference-connectedline-update

### DIFF
--- a/wazo_calld/plugins/adhoc_conferences/stasis.py
+++ b/wazo_calld/plugins/adhoc_conferences/stasis.py
@@ -62,7 +62,7 @@ class AdhocConferencesStasis:
 
         channel_id = event['channel']['id']
         logger.debug('adhoc conference %s: bridging participant %s', adhoc_conference_id, channel_id)
-        bridge.addChannel(channel=channel_id)
+        bridge.addChannel(channel=channel_id, inhibitConnectedLineUpdates=True)
 
     def on_channel_entered_bridge(self, channel, event):
         if event['application'] != ADHOC_CONFERENCE_STASIS_APP:


### PR DESCRIPTION
## adhoc conference: prevent connected line updates from participant

Why:

* in some cases, with send_pai = yes, the participant will see her own
caller id

## tests: fix adhoc bus event names