### PR TITLE
dial_mobile: automatically hang up channel left alone

### DIFF
--- a/wazo_calld/plugins/dial_mobile/stasis.py
+++ b/wazo_calld/plugins/dial_mobile/stasis.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -35,6 +35,14 @@ class DialMobileStasis:
             future_bridge_uuid = args[1]
             self._service.join_bridge(channel_id, future_bridge_uuid)
 
+    def on_channel_left_bridge(self, channel, event):
+        if event['application'] != self._app_name:
+            return
+
+        bridge_id = event['bridge']['id']
+
+        self._service.clean_bridge(bridge_id)
+
     def _add_ari_application(self):
         self._core_ari.register_application(self._app_name)
         self._core_ari.reload()
@@ -44,6 +52,7 @@ class DialMobileStasis:
 
     def _subscribe(self):
         self._ari.on_channel_event('StasisStart', self.stasis_start)
+        self._ari.on_channel_event('ChannelLeftBridge', self.on_channel_left_bridge)
         self._ari.on_channel_event('ChannelDestroyed', self.channel_destroyed)
 
     def initialize(self):

--- a/wazo_calld/plugins/dial_mobile/tests/test_stasis.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_stasis.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
@@ -73,3 +73,14 @@ class TestStasisStart(TestCase):
 
         self.service.dial_all_contacts.assert_not_called()
         self.service.join_bridge.called_once_with(s.channel_id, s.bridge_uuid)
+
+    def channel_left(self):
+        self.stasis.on_channel_left_bridge(
+            Mock(),
+            {
+                'application': DialMobileStasis._app_name,
+                'bridge': {'id': s.bridge_uuid},
+            },
+        )
+
+        self.service.clean_bridge.assert_called_once_with(s.bridge_uuid)


### PR DESCRIPTION
Why:

* When in a 1 on 1 conversation, if one party hangs up, the other party
should be hungup too.
* Automatic hangup has been restricted to the callcontrol Stasis
application in 2ed02320913c721eab126ab8f7272b523469da73
