### PR TITLE
adhoc conference: fix race condition during test

### DIFF
--- a/wazo_calld/plugin_helpers/ari_.py
+++ b/wazo_calld/plugin_helpers/ari_.py
@@ -319,3 +319,12 @@ class Bridge:
         except ARINotFound:
             return False
         return True
+
+
+class BridgeSnapshot(Bridge):
+    def __init__(self, snapshot, ari):
+        self._snapshot = snapshot
+        super().__init__(snapshot['id'], ari)
+
+    def valid_user_uuids(self):
+        return set(Channel(channel_id, self._ari).user() for channel_id in self._snapshot['channels'])

--- a/wazo_calld/plugins/adhoc_conferences/stasis.py
+++ b/wazo_calld/plugins/adhoc_conferences/stasis.py
@@ -80,9 +80,6 @@ class AdhocConferencesStasis:
             return
 
         bridge_helper = Bridge(adhoc_conference_id, self._ari)
-        participant_call = CallsService.make_call_from_channel(self._ari, channel)
-        other_participant_uuids = bridge_helper.valid_user_uuids()
-        self._notifier.participant_joined(adhoc_conference_id, other_participant_uuids, participant_call)
 
         if is_adhoc_conference_host:
             bridge_helper.global_variables.set('WAZO_HOST_CHANNEL_ID', channel_id)
@@ -93,6 +90,10 @@ class AdhocConferencesStasis:
 
             logger.debug('adhoc conference %s: setting host connectedline', adhoc_conference_id)
             self._set_host_connectedline(channel_id, adhoc_conference_id)
+
+        participant_call = CallsService.make_call_from_channel(self._ari, channel)
+        other_participant_uuids = bridge_helper.valid_user_uuids()
+        self._notifier.participant_joined(adhoc_conference_id, other_participant_uuids, participant_call)
 
     def _notify_host_of_channels_already_present(self, adhoc_conference_id, channel_ids, host_user_uuid):
         for channel_id in channel_ids:

--- a/wazo_calld/plugins/adhoc_conferences/stasis.py
+++ b/wazo_calld/plugins/adhoc_conferences/stasis.py
@@ -4,7 +4,7 @@
 import threading
 
 from ari.exceptions import ARINotFound
-from wazo_calld.plugin_helpers.ari_ import Bridge, Channel
+from wazo_calld.plugin_helpers.ari_ import Bridge, BridgeSnapshot, Channel
 from wazo_calld.plugins.calls.services import CallsService
 
 import logging
@@ -79,7 +79,7 @@ class AdhocConferencesStasis:
             logger.error('adhoc conference %s: channel %s hungup too early or variable not found', adhoc_conference_id, channel_id)
             return
 
-        bridge_helper = Bridge(adhoc_conference_id, self._ari)
+        bridge_helper = BridgeSnapshot(event['bridge'], self._ari)
 
         if is_adhoc_conference_host:
             bridge_helper.global_variables.set('WAZO_HOST_CHANNEL_ID', channel_id)


### PR DESCRIPTION
Why:

* The test test_user_remove_participant_no_call was failing due to 404
status code, as the adhoc conference variables were not yet initialized
* The two participants were already talking together, but the adhoc
conference variables not yet initialized

How:

* Assert adhoc conference events
* Send join conference events as late as possible