### PR TITLE
trunk registrations: match Registry events to SIP trunks

### DIFF
--- a/integration_tests/suite/test_endpoints_bus_consume.py
+++ b/integration_tests/suite/test_endpoints_bus_consume.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that
@@ -39,7 +39,7 @@ class TestTrunkBusConsume(IntegrationTest):
                 trunk_id,
                 endpoint_sip={
                     'name': name,
-                    'auth_section_options': [['username', 'the-username']],
+                    'registration_section_options': [['client_uri', 'sip:the-username@hostname']],
                 },
                 tenant_uuid=tenant_uuid,
             )
@@ -79,7 +79,7 @@ class TestTrunkBusConsume(IntegrationTest):
                 trunk_id,
                 endpoint_sip={
                     'name': name,
-                    'auth_section_options': [['username', 'the-username']],
+                    'registration_section_options': [['client_uri', 'the-username']],
                 },
                 tenant_uuid=tenant_uuid,
             )
@@ -119,7 +119,7 @@ class TestTrunkBusConsume(IntegrationTest):
                 trunk_id,
                 endpoint_sip={
                     'name': name,
-                    'auth_section_options': [['username', 'the-username']],
+                    'registration_section_options': [['client_uri', 'the-username']],
                 },
                 tenant_uuid=tenant_uuid,
             )
@@ -166,7 +166,7 @@ class TestTrunkBusConsume(IntegrationTest):
         trunk_id = 42
         tenant_uuid = 'the_tenant_uuid'
         name = 'abcdef'
-        username = 'the-username'
+        client_uri = 'sip:the-username@hostname'
 
         self.ari.set_endpoints(
             MockEndpoint('PJSIP', name, 'offline'),
@@ -176,7 +176,7 @@ class TestTrunkBusConsume(IntegrationTest):
                 trunk_id,
                 endpoint_sip={
                     'name': name,
-                    'auth_section_options': [['username', username]],
+                    'registration_section_options': [['client_uri', client_uri]],
                 },
                 tenant_uuid=tenant_uuid,
             )
@@ -188,7 +188,7 @@ class TestTrunkBusConsume(IntegrationTest):
         self.reset_clients()
         self.wait_strategy.wait(self)
         self.bus.send_ami_registry_event(
-            'PJSIP', 'sip:here', 'Registered', 'sip:{}@here'.format(username),
+            'PJSIP', 'sip:here', 'Registered', client_uri,
         )
 
         def assert_function():
@@ -206,7 +206,7 @@ class TestTrunkBusConsume(IntegrationTest):
         until.assert_(assert_function, tries=5)
 
         self.bus.send_ami_registry_event(
-            'PJSIP', 'sip:here', 'Unregistered', 'sip:{}@here'.format(username),
+            'PJSIP', 'sip:here', 'Unregistered', client_uri,
         )
 
         def assert_function():
@@ -227,7 +227,7 @@ class TestTrunkBusConsume(IntegrationTest):
         trunk_id = 42
         tenant_uuid = 'the_tenant_uuid'
         name = 'abcdef'
-        username = 'the-username'
+        client_uri = 'sip:the-username@hostname'
 
         self.ari.set_endpoints(
             MockEndpoint('PJSIP', name, 'offline', channel_ids=[]),
@@ -246,7 +246,7 @@ class TestTrunkBusConsume(IntegrationTest):
                 trunk_id,
                 endpoint_sip={
                     'name': name,
-                    'auth_section_options': [['username', username]],
+                    'registration_section_options': [['client_uri', client_uri]],
                 },
                 tenant_uuid=tenant_uuid,
             )
@@ -254,7 +254,7 @@ class TestTrunkBusConsume(IntegrationTest):
         self.bus.send_trunk_endpoint_associated_event(trunk_id, endpoint_id=3)
 
         self.bus.send_ami_registry_event(
-            'PJSIP', 'sip:here', 'Registered', 'sip:{}@here'.format(username),
+            'PJSIP', 'sip:here', 'Registered', client_uri,
         )
 
         def assert_function():

--- a/wazo_calld/plugins/endpoints/bus.py
+++ b/wazo_calld/plugins/endpoints/bus.py
@@ -71,8 +71,13 @@ class EventHandler:
                 return
 
         trunk = self._confd_cache.get_trunk_by_username(techno, username)
+        registered = event['Status'] == 'Registered'
+        if not trunk and not registered:
+            # The trunk as already been dissociated from the trunk
+            return
+
         with self._endpoint_status_cache.update(techno, trunk['name']) as endpoint:
-            endpoint.registered = event['Status'] == 'Registered'
+            endpoint.registered = registered
 
     def _extract_sip_option(self, section, option):
         for key, value in section:

--- a/wazo_calld/plugins/endpoints/services.py
+++ b/wazo_calld/plugins/endpoints/services.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -248,8 +248,8 @@ class ConfdCache:
             if trunk.get('endpoint_sip'):
                 techno = 'sip'
                 name = trunk['endpoint_sip']['name']
-                for key, value in trunk['endpoint_sip']['auth_section_options']:
-                    if key == 'username':
+                for key, value in trunk['endpoint_sip']['registration_section_options']:
+                    if key == 'client_uri':
                         username = value
                         break
                 else:

--- a/wazo_calld/plugins/endpoints/tests/test_bus.py
+++ b/wazo_calld/plugins/endpoints/tests/test_bus.py
@@ -4,7 +4,7 @@
 from contextlib import contextmanager
 from unittest import TestCase
 from unittest.mock import Mock, sentinel as s
-from hamcrest import assert_that, has_properties
+from hamcrest import assert_that, calling, raises, has_properties, not_
 
 from ..bus import EventHandler
 from ..services import Endpoint, ConfdCache
@@ -74,6 +74,22 @@ class TestBusEvent(TestCase):
         assert_that(
             self.updated_endpoint,
             has_properties(techno='PJSIP', name='foobar', registered=False),
+        )
+
+    def test_on_trunk_dissociated_deregistering(self):
+        self.confd_cache.get_trunk_by_username.return_value = None
+        event = {
+            'ChannelType': 'PJSIP',
+            'Domain': 'sip:wazo-dev-gateway.lan.wazo.io',
+            'Event': 'Registry',
+            'Privilege': 'system,all',
+            'Status': 'Unregistered',
+            'Username': 'sip:dev_370@wazo-dev-gateway.lan.wazo.io',
+        }
+
+        assert_that(
+            calling(self.handler.on_registry).with_args(event),
+            not_(raises(Exception)),
         )
 
     def test_on_peer_status_pjsip_registering(self):

--- a/wazo_calld/plugins/endpoints/tests/test_bus.py
+++ b/wazo_calld/plugins/endpoints/tests/test_bus.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from contextlib import contextmanager
@@ -207,7 +207,7 @@ class TestBusEvent(TestCase):
                 'id': 45,
                 'name': name,
                 'tenant_uuid': tenant_uuid,
-                'auth_section_options': [['username', username]],
+                'registration_section_options': [['client_uri', username]],
             },
             'trunk': {
                 'id': trunk_id,
@@ -423,7 +423,7 @@ class TestBusEvent(TestCase):
             'id': s.endpoint_id,
             'name': s.name,
             'tenant_uuid': s.tenant_uuid,
-            'auth_section_options': [['username', s.username]],
+            'registration_section_options': [['client_uri', s.username]],
             'trunk': {'id': s.trunk_id},
             'line': None,
         }

--- a/wazo_calld/plugins/endpoints/tests/test_services.py
+++ b/wazo_calld/plugins/endpoints/tests/test_services.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
@@ -164,7 +164,7 @@ class TestCachingConfdClient(TestCase):
                 'id': s.trunk_id,
                 'endpoint_sip': {
                     'name': s.name,
-                    'auth_section_options': [['username', s.username]],
+                    'registration_section_options': [['client_uri', s.username]],
                 },
                 'tenant_uuid': s.tenant_uuid,
             },
@@ -211,7 +211,7 @@ class TestCachingConfdClient(TestCase):
                 'id': s.trunk_id,
                 'endpoint_sip': {
                     'name': s.name,
-                    'auth_section_options': [['username', s.username]],
+                    'registration_section_options': [['client_uri', s.username]],
                 },
                 'tenant_uuid': s.tenant_uuid,
             },
@@ -297,7 +297,7 @@ class TestCachingConfdClient(TestCase):
                 'id': 1,
                 'endpoint_sip': {
                     'name': s.name_1,
-                    'auth_section_options': [['username', s.username_1]],
+                    'registration_section_options': [['client_uri', s.username_1]],
                 },
                 'tenant_uuid': s.tenant_uuid,
             },
@@ -315,7 +315,9 @@ class TestCachingConfdClient(TestCase):
                 'id': 4,
                 'endpoint_sip': {
                     'name': s.ignored_name,
-                    'auth_section_options': [['username', s.ignored_username]],
+                    'registration_section_options': [
+                        ['client_uri', s.ignored_username]
+                    ],
                 },
                 'tenant_uuid': s.other_tenant_uuid,
             },
@@ -346,7 +348,11 @@ class TestCachingConfdClient(TestCase):
                     "tenant_uuid": s.tenant_uuid,
                     "name": s.name_1,
                     "protocol": "sip",
-                    "endpoint_sip": {"id": 18, "username": "5h8osw24", "name": s.name_1},
+                    "endpoint_sip": {
+                        "id": 18,
+                        "name": s.name_1,
+                        'auth_section_options': [['username', '5h8osw24']],
+                    },
                     "endpoint_sccp": None,
                     "endpoint_custom": None,
                 },


### PR DESCRIPTION
The Username field of the Registry event matches the registry section client_uri
field for PJSIP endpoints.