### PR TITLE
Pull request for WAZO-2245-optimize-calld

### DIFF
--- a/integration_tests/suite/helpers/bus.py
+++ b/integration_tests/suite/helpers/bus.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -60,9 +60,10 @@ class BusClient(bus_helper.BusClient):
             }
         }, 'ami.Newchannel')
 
-    def send_ami_newstate_event(self, channel_id, state='Up'):
+    def send_ami_newstate_event(self, channel_id, state='Up', channel=None):
         self.send_event({
             'data': {
+                'Channel': channel or 'PJSIP/abcdef-00000001',
                 'Event': 'Newstate',
                 'Uniqueid': channel_id,
                 'ChannelStateDesc': state,

--- a/wazo_calld/plugin_helpers/ari_.py
+++ b/wazo_calld/plugin_helpers/ari_.py
@@ -266,7 +266,10 @@ class Channel:
     def sip_call_id(self):
         if not self.is_sip():
             return
+        return self.sip_call_id_unsafe()
 
+    def sip_call_id_unsafe(self):
+        '''This method expects a SIP channel'''
         try:
             return self._get_var('CHANNEL(pjsip,call-id)')
         except ARINotFound:

--- a/wazo_calld/plugin_helpers/ari_.py
+++ b/wazo_calld/plugin_helpers/ari_.py
@@ -233,14 +233,13 @@ class Channel:
 
     def dialed_extension(self):
         try:
-            channel = self._ari.channels.get(channelId=self.id)
+            return self._ari.channels.getChannelVar(channelId=self.id, variable='XIVO_BASE_EXTEN')['value']
         except ARINotFound:
-            return
-
-        try:
-            return channel.getChannelVar(variable='XIVO_BASE_EXTEN')['value']
-        except ARINotFound:
-            return channel.json['dialplan']['exten']
+            try:
+                channel = self._ari.channels.get(channelId=self.id)
+                return channel.json['dialplan']['exten']
+            except ARINotFound:
+                return
 
     def on_hold(self):
         try:

--- a/wazo_calld/plugins/calls/bus_consume.py
+++ b/wazo_calld/plugins/calls/bus_consume.py
@@ -70,6 +70,9 @@ class CallsBusEventHandler:
 
     def _relay_channel_created(self, event):
         channel_id = event['Uniqueid']
+        if event['Channel'].startswith('Local/'):
+            logger.debug('Ignoring local channel creation: %s', channel_id)
+            return
         logger.debug('Relaying to bus: channel %s created', channel_id)
         try:
             channel = self.ari.channels.get(channelId=channel_id)
@@ -92,6 +95,9 @@ class CallsBusEventHandler:
 
     def _relay_channel_updated(self, event):
         channel_id = event['Uniqueid']
+        if event['Channel'].startswith('Local/'):
+            logger.debug('Ignoring local channel update: %s', channel_id)
+            return
         logger.debug('Relaying to bus: channel %s updated', channel_id)
         try:
             channel = self.ari.channels.get(channelId=channel_id)
@@ -104,8 +110,11 @@ class CallsBusEventHandler:
     def _relay_channel_answered(self, event):
         if event['ChannelStateDesc'] != 'Up':
             return
-
         channel_id = event['Uniqueid']
+        if event['Channel'].startswith('Local/'):
+            logger.debug('Ignoring local channel answer: %s', channel_id)
+            return
+
         logger.debug('Relaying to bus: channel %s answered', channel_id)
         try:
             channel = self.ari.channels.get(channelId=channel_id)
@@ -117,6 +126,9 @@ class CallsBusEventHandler:
 
     def _relay_channel_hung_up(self, event):
         channel_id = event['Uniqueid']
+        if event['Channel'].startswith('Local/'):
+            logger.debug('Ignoring local channel hangup: %s', channel_id)
+            return
         logger.debug('Relaying to bus: channel %s ended', channel_id)
         call = self.services.make_call_from_ami_event(event)
         bus_event = ArbitraryEvent(

--- a/wazo_calld/plugins/calls/bus_consume.py
+++ b/wazo_calld/plugins/calls/bus_consume.py
@@ -50,9 +50,11 @@ class CallsBusEventHandler:
         bus_consumer.on_ami_event('MixMonitorStop', self._mix_monitor_stop)
 
     def _add_sip_call_id(self, event):
+        if not event['Channel'].startswith('PJSIP/'):
+            return
         channel_id = event['Uniqueid']
         channel = Channel(channel_id, self.ari)
-        sip_call_id = channel.sip_call_id()
+        sip_call_id = channel.sip_call_id_unsafe()
         if not sip_call_id:
             return
 


### PR DESCRIPTION
## calls: optimize sip_call_id setting


## calls: ignore events for local channels


## ari helper: avoid unnecessary call to ARI

Why:

* Purpose: make make_call_from_channel faster