### PR TITLE
integration tests: restore hamcrest latest version

### DIFF
--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -7,7 +7,7 @@ docker-compose
 kombu
 openapi-spec-validator
 psycopg2-binary
-pyhamcrest<1.10 # Version 1.10 is broken
+pyhamcrest
 pytest
 requests
 stevedore  # from wazo-calld-client


### PR DESCRIPTION
Why:

* Incompatibility should be fixed now