### PR TITLE
test: do not use deprecated acls

### DIFF
--- a/integration_tests/suite/helpers/auth.py
+++ b/integration_tests/suite/helpers/auth.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import requests
@@ -24,10 +24,10 @@ class AuthClient:
 
 class MockUserToken:
 
-    def __init__(self, token, user_uuid, acls=None, tenant_uuid=None):
+    def __init__(self, token, user_uuid, acl=None, tenant_uuid=None):
         self._token = token
         self._user_uuid = user_uuid
-        self._acls = acls
+        self._acl = acl
         self._tenant_uuid = tenant_uuid
 
     def to_dict(self):
@@ -36,8 +36,8 @@ class MockUserToken:
             'auth_id': self._user_uuid,
             'metadata': {},
         }
-        if self._acls:
-            result['acls'] = self._acls
+        if self._acl:
+            result['acl'] = self._acl
         if self._tenant_uuid:
             result['metadata']['tenant_uuid'] = self._tenant_uuid
         if self._user_uuid:


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/xivo-test-helpers/pull/50