### PR TITLE
conference: optimize confd calls

### DIFF
--- a/wazo_calld/bus.py
+++ b/wazo_calld/bus.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import kombu
@@ -18,6 +18,9 @@ from xivo_bus import PublishingQueue
 logger = logging.getLogger(__name__)
 
 ROUTING_KEY_MAPPING = {
+    'conference_edited': 'config.conferences.edited',
+    'conference_created': 'config.conferences.created',
+    'conference_deleted': 'config.conferences.deleted',
     'line_endpoint_sip_associated': 'config.lines.*.endpoints.sip.*.updated',
     'line_endpoint_sip_dissociated': 'config.lines.*.endpoints.sip.*.deleted',
     'line_endpoint_sccp_associated': 'config.lines.*.endpoints.sccp.*.updated',

--- a/wazo_calld/plugins/conferences/bus_consume.py
+++ b/wazo_calld/plugins/conferences/bus_consume.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -26,6 +26,10 @@ class ConferencesBusEventHandler:
         bus_consumer.on_ami_event('ConfbridgeRecord', self._notify_record_started)
         bus_consumer.on_ami_event('ConfbridgeStopRecord', self._notify_record_stopped)
         bus_consumer.on_ami_event('ConfbridgeTalking', self._notify_participant_talking)
+
+        bus_consumer.on_event('conference_edited', Conference.reset_cache)
+        bus_consumer.on_event('conference_created', Conference.reset_cache)
+        bus_consumer.on_event('conference_deleted', Conference.reset_cache)
 
     def _notify_participant_joined(self, event):
         conference_id = int(event['Conference'])


### PR DESCRIPTION
Given the same conference ID avoid doing multiple queries on wazo-confd. This is
especially useful when a paging is used. In these scenario each members of the
paging will generate 2 confd calls which will then generate 1 auth call.

For a paging with 100 members this reduces the number of HTTP requests from 400
to 2.

The cache is reset whenever a conference is added, updated or deleted