### PR TITLE
exceptions: include original error message from ARI

### DIFF
--- a/integration_tests/assets/docker-compose.failing_ari.override.yml
+++ b/integration_tests/assets/docker-compose.failing_ari.override.yml
@@ -3,12 +3,13 @@ services:
   sync:
     depends_on:
       - auth
+      - amid
       - ari
       - confd
       - calld
       - rabbitmq
     environment:
-      TARGETS: "ari:5039 rabbitmq:5672 confd:9486 auth:9497 calld:9500"
+      TARGETS: "amid:9491 ari:5039 rabbitmq:5672 confd:9486 auth:9497 calld:9500"
 
   ari:
     command: "python /usr/local/share/ari/mock_ari_fail.py 5039"

--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       # - "${LOCAL_GIT_REPOS}/wazo-confd-client/wazo_confd_client:/opt/venv/lib/python3.7/site-packages/wazo_confd_client"
       # - "${LOCAL_GIT_REPOS}/xivo-bus/xivo_bus:/opt/venv/lib/python3.7/site-packages/xivo_bus"
       # - "${LOCAL_GIT_REPOS}/xivo-lib-python/xivo:/opt/venv/lib/python3.7/site-packages/xivo"
+      # - "${LOCAL_GIT_REPOS}/ari-py/ari:/opt/venv/lib/python3.7/site-packages/ari"
     ports:
       - 9500
     environment:

--- a/integration_tests/suite/test_calls.py
+++ b/integration_tests/suite/test_calls.py
@@ -1377,8 +1377,9 @@ class TestFailingARI(IntegrationTest):
     def test_given_no_ari_when_originate_then_503(self):
         self.confd.set_users(MockUser(uuid='user-uuid', line_ids=['line-id']))
         self.confd.set_lines(MockLine(id='line-id', name='line-name', protocol=CONFD_SIP_PROTOCOL))
+        self.amid.set_valid_exten('context', 'extension')
         call_args = {
-            'source': {'user': 'userr-uuid'},
+            'source': {'user': 'user-uuid'},
             'destination': {
                 'priority': SOME_PRIORITY,
                 'extension': 'extension',
@@ -1389,7 +1390,7 @@ class TestFailingARI(IntegrationTest):
             calling(self.calld_client.calls.make_call).with_args(call_args),
             raises(CalldError).matching(has_properties(
                 status_code=503,
-                error_id='wazo-amid-error',
+                error_id='asterisk-ari-error',
             ))
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 https://github.com/rsichny/swagger-py/archive/master.zip  # the digium release does not support python3
-https://github.com/wazo-platform/ari-py/archive/0.4.0.zip
+https://github.com/wazo-platform/ari-py/archive/master.zip
 https://github.com/wazo-platform/wazo-lib-rest-client/archive/master.zip
 https://github.com/wazo-platform/wazo-amid-client/archive/master.zip
 https://github.com/wazo-platform/wazo-auth-client/archive/master.zip

--- a/wazo_calld/exceptions.py
+++ b/wazo_calld/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -21,28 +21,28 @@ class ARIUnreachable(Exception):
 
 class AsteriskARIUnreachable(APIException):
 
-    def __init__(self, asterisk_ari_config, error):
+    def __init__(self, asterisk_ari_config, original_error, original_message):
         super().__init__(
             status_code=503,
             message='Asterisk ARI server unreachable',
             error_id='asterisk-ari-unreachable',
             details={
                 'asterisk_ari_config': asterisk_ari_config,
-                'original_error': str(error),
+                'original_error': f'{original_error}: {original_message}',
             }
         )
 
 
 class AsteriskARIError(APIException):
 
-    def __init__(self, asterisk_ari_config, error):
+    def __init__(self, asterisk_ari_config, original_error, original_message):
         super().__init__(
             status_code=503,
             message='Asterisk ARI internal error',
             error_id='asterisk-ari-error',
             details={
                 'asterisk_ari_config': asterisk_ari_config,
-                'original_error': str(error),
+                'original_error': f'{original_error}: {original_message}',
             }
         )
 

--- a/wazo_calld/http.py
+++ b/wazo_calld/http.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ari.exceptions import (
@@ -29,9 +29,9 @@ def handle_ari_exception(func):
         try:
             return func(*args, **kwargs)
         except ARIHTTPError as e:
-            raise AsteriskARIError({'base_url': e.client.base_url}, e.original_error)
+            raise AsteriskARIError({'base_url': e.client.base_url}, e.original_error, e.original_message)
         except ARIException as e:
-            raise AsteriskARIUnreachable({'base_url': e.client.base_url}, e.original_error)
+            raise AsteriskARIUnreachable({'base_url': e.client.base_url}, e.original_error, e.original_message)
     return wrapper
 
 


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/ari-py/pull/1

Why:

* Can help find the underlying problem of an Asterisk error