### PR TITLE
calls: add option "initialization_confd_timeout"

### DIFF
--- a/wazo_calld/plugins/calls/plugin.py
+++ b/wazo_calld/plugins/calls/plugin.py
@@ -55,7 +55,7 @@ class Plugin:
         token_changed_subscribe(amid_client.set_token)
 
         auth_client = AuthClient(**config['auth'])
-        confd_client = ConfdClient(**config['confd'])
+        confd_client = ConfdClient(timeout=90, **config['confd'])
         phoned_client = PhonedClient(**config['phoned'])
 
         token_changed_subscribe(confd_client.set_token)


### PR DESCRIPTION
Why:

* Initializing DND for all users need to get all the users from
wazo-confd
* This can take a long time, depending on the number of users
* The default timeout is 10 seconds, which may no be enough