### PR TITLE
Pull request for WAZO-2422-switchboard-timeout-asyncio

### DIFF
--- a/integration_tests/suite/test_switchboards.py
+++ b/integration_tests/suite/test_switchboards.py
@@ -317,7 +317,7 @@ class TestSwitchboardCallsQueued(TestSwitchboards):
             try:
                 result = queued_channel.getChannelVar(variable='CHANNEL_WAS_FORWARDED')
             except ARINotFound:
-                raise AssertionError('Variable CHANNEL_WAS_FORWARDED on channel {queued_channel.id} not found')
+                raise AssertionError(f'Variable CHANNEL_WAS_FORWARDED on channel {queued_channel.id} not found')
 
             assert_that(result, has_entry('value', 'yes'))
         until.assert_(call_was_forwarded, timeout=4)

--- a/wazo_calld/asyncio_.py
+++ b/wazo_calld/asyncio_.py
@@ -1,0 +1,33 @@
+# Copyright 2021 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class CoreAsyncio:
+
+    def __init__(self):
+        self._loop = asyncio.new_event_loop()
+
+    def run(self):
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+
+    def call_later(self, delay, callback, *args):
+
+        # This function will run within the asyncio thread
+        def delay_wrapper():
+            self._loop.call_later(delay, callback, *args)
+
+        self._loop.call_soon_threadsafe(delay_wrapper)
+
+    def stop(self):
+        if not self._loop:
+            return
+
+        self._loop.stop()
+        self._loop.close()
+        self._loop = asyncio.new_event_loop()

--- a/wazo_calld/asyncio_.py
+++ b/wazo_calld/asyncio_.py
@@ -25,9 +25,4 @@ class CoreAsyncio:
         self._loop.call_soon_threadsafe(delay_wrapper)
 
     def stop(self):
-        if not self._loop:
-            return
-
-        self._loop.stop()
-        self._loop.close()
-        self._loop = asyncio.new_event_loop()
+        self._loop.call_soon_threadsafe(self._loop.stop)

--- a/wazo_calld/plugins/switchboards/plugin.py
+++ b/wazo_calld/plugins/switchboards/plugin.py
@@ -26,6 +26,7 @@ class Plugin:
     def load(self, dependencies):
         api = dependencies['api']
         ari = dependencies['ari']
+        asyncio = dependencies['asyncio']
         bus_publisher = dependencies['bus_publisher']
         bus_consumer = dependencies['bus_consumer']
         config = dependencies['config']
@@ -50,7 +51,7 @@ class Plugin:
 
         switchboards_notifier = SwitchboardsNotifier(bus_publisher)
         switchboards_service = SwitchboardsService(
-            ari.client, confd_client, switchboards_notifier
+            ari.client, asyncio, confd_client, switchboards_notifier
         )
 
         switchboards_stasis = SwitchboardsStasis(

--- a/wazo_calld/plugins/switchboards/services.py
+++ b/wazo_calld/plugins/switchboards/services.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
-import threading
 
 from ari.exceptions import ARINotFound
 
@@ -35,8 +34,9 @@ logger = logging.getLogger(__name__)
 
 
 class SwitchboardsService:
-    def __init__(self, ari, confd, notifier):
+    def __init__(self, ari, asyncio, confd, notifier):
         self._ari = ari
+        self._asyncio = asyncio
         self._confd = confd
         self._notifier = notifier
 
@@ -113,12 +113,13 @@ class SwitchboardsService:
             channel_id,
             noanswer_timeout,
         )
-        timer = threading.Timer(
+        self._asyncio.call_later(
             noanswer_timeout,
             self.on_queued_call_noanswer_timeout,
-            args=(tenant_uuid, switchboard_uuid, channel_id),
+            tenant_uuid,
+            switchboard_uuid,
+            channel_id,
         )
-        timer.start()
 
     def on_queued_call_noanswer_timeout(self, tenant_uuid, switchboard_uuid, call_id):
         logger.debug(

--- a/wazo_calld/plugins/switchboards/tests/test_services.py
+++ b/wazo_calld/plugins/switchboards/tests/test_services.py
@@ -10,10 +10,11 @@ from wazo_calld.plugins.switchboards.services import SwitchboardsService
 class TestSwitchboardService(TestCase):
     def setUp(self):
         self.ari = Mock()
+        self.asyncio = Mock()
         self.confd = Mock()
         self.notifier = Mock()
 
-        self.service = SwitchboardsService(self.ari, self.confd, self.notifier)
+        self.service = SwitchboardsService(self.ari, self.asyncio, self.confd, self.notifier)
 
     def test_moh_on_new_queued_call_when_defined(self):
         self.confd.switchboards.get.return_value = {'queue_music_on_hold': s.moh_class}


### PR DESCRIPTION
## tests: fix f-string


## switchboards: replace threading.Timer with asyncio thread

Why:

* One thread per queued call may take a significant amount of resources,
given enough calls.
* asyncio is the standard way to go