### PR TITLE
ami: set_variable_ami add parameters to the exception

### DIFF
--- a/wazo_calld/plugin_helpers/ami.py
+++ b/wazo_calld/plugin_helpers/ami.py
@@ -3,6 +3,7 @@
 
 import logging
 import re
+import json
 
 from requests import RequestException
 from wazo_amid_client.exceptions import AmidProtocolError
@@ -21,7 +22,7 @@ def set_variable_ami(amid, channel_id, variable, value):
                       'Value': value}
         amid.action('Setvar', parameters)
     except RequestException as e:
-        raise WazoAmidError(amid, e)
+        raise WazoAmidError(amid, '{} {}'.format(e, json.dumps(parameters)))
 
 
 def unset_variable_ami(amid, channel_id, variable):

--- a/wazo_calld/plugin_helpers/ami.py
+++ b/wazo_calld/plugin_helpers/ami.py
@@ -3,7 +3,6 @@
 
 import logging
 import re
-import json
 
 from requests import RequestException
 from wazo_amid_client.exceptions import AmidProtocolError
@@ -22,7 +21,7 @@ def set_variable_ami(amid, channel_id, variable, value):
                       'Value': value}
         amid.action('Setvar', parameters)
     except RequestException as e:
-        raise WazoAmidError(amid, '{} {}'.format(e, json.dumps(parameters)))
+        raise WazoAmidError(amid, e, {'original_parameters': parameters})
 
 
 def unset_variable_ami(amid, channel_id, variable):

--- a/wazo_calld/plugin_helpers/exceptions.py
+++ b/wazo_calld/plugin_helpers/exceptions.py
@@ -130,17 +130,21 @@ class NoSuchVoicemail(APIException):
 
 class WazoAmidError(APIException):
 
-    def __init__(self, wazo_amid_client, error):
-        super().__init__(
-            status_code=503,
-            message='wazo-amid request error',
-            error_id='wazo-amid-error',
-            details={
+    def __init__(self, wazo_amid_client, error, details=None):
+        details = dict(details or {})
+        details.update(
+            {
                 'wazo_amid_config': {'host': wazo_amid_client.host,
                                      'port': wazo_amid_client.port,
                                      'timeout': wazo_amid_client.timeout},
                 'original_error': str(error),
             }
+        )
+        super().__init__(
+            status_code=503,
+            message='wazo-amid request error',
+            error_id='wazo-amid-error',
+            details=details,
         )
 
 


### PR DESCRIPTION
This error has been crippling me for a while now and I cannot seem to figure out how to reproduce it.

```
2021-11-23 07:53:48,554 [80910] (ERROR) (xivo.pubsub): (<wazo_amid_client.client.AmidClient object at 0x
7efcf677c0f0>, AmidProtocolError('No such channel'))
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/wazo_calld/plugin_helpers/ami.py", line 22, in set_variable_ami
    amid.action('Setvar', parameters)
  File "/usr/lib/python3/dist-packages/wazo_amid_client/commands/action.py", line 22, in __call__
    self.raise_from_protocol(r)
  File "/usr/lib/python3/dist-packages/wazo_amid_client/command.py", line 27, in raise_from_protocol
    raise AmidProtocolError(response)
wazo_amid_client.exceptions.AmidProtocolError: No such channel

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/xivo/pubsub.py", line 39, in publish_one
    callback(message)
  File "/usr/lib/python3/dist-packages/wazo_calld/plugins/calls/bus_consume.py", line 149, in _channel_unhold
    ami.unset_variable_ami(self.ami, channel_id, 'XIVO_ON_HOLD')
  File "/usr/lib/python3/dist-packages/wazo_calld/plugin_helpers/ami.py", line 28, in unset_variable_ami
    set_variable_ami(amid, channel_id, variable, '')
  File "/usr/lib/python3/dist-packages/wazo_calld/plugin_helpers/ami.py", line 24, in set_variable_ami
    raise WazoAmidError(amid, e)
wazo_calld.plugin_helpers.exceptions.WazoAmidError: (<wazo_amid_client.client.AmidClient object at 0x7efcf677c0f0>, AmidProtocolError('No such channel'))
2021-11-23 07:53:48,582 [80910] (ERROR) (xivo.pubsub): (<wazo_amid_client.client.AmidClient object at 0x7efcf677c0f0>, AmidProtocolError('No such channel'))
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/wazo_calld/plugin_helpers/ami.py", line 22, in set_variable_ami
    amid.action('Setvar', parameters)
  File "/usr/lib/python3/dist-packages/wazo_amid_client/commands/action.py", line 22, in __call__
    self.raise_from_protocol(r)
  File "/usr/lib/python3/dist-packages/wazo_amid_client/command.py", line 27, in raise_from_protocol
    raise AmidProtocolError(response)
wazo_amid_client.exceptions.AmidProtocolError: No such channel

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/xivo/pubsub.py", line 39, in publish_one
    callback(message)
  File "/usr/lib/python3/dist-packages/wazo_calld/plugins/calls/bus_consume.py", line 149, in _channel_unhold
    ami.unset_variable_ami(self.ami, channel_id, 'XIVO_ON_HOLD')
  File "/usr/lib/python3/dist-packages/wazo_calld/plugin_helpers/ami.py", line 28, in unset_variable_ami
    set_variable_ami(amid, channel_id, variable, '')
  File "/usr/lib/python3/dist-packages/wazo_calld/plugin_helpers/ami.py", line 24, in set_variable_ami
    raise WazoAmidError(amid, e)
wazo_calld.plugin_helpers.exceptions.WazoAmidError: (<wazo_amid_client.client.AmidClient object at 0x7efcf677c0f0>, AmidProtocolError('No such channel'))
```

This will add the parameters of the command to the `original_message`