### PR TITLE
meeting: handle more errors when kicking all participants

### DIFF
--- a/wazo_calld/plugins/meetings/services.py
+++ b/wazo_calld/plugins/meetings/services.py
@@ -93,7 +93,10 @@ class MeetingsService:
                 },
             )
         except AmidProtocolError as e:
-            if e.message == 'No Conference by that name found.':
+            if e.message in [
+                'No Conference by that name found.',  # This conference is not running at this time.
+                'No active conferences.',    # No conferences are taking place at this time.
+            ]:
                 logger.debug(
                     'No participants found to kick out of meeting %s', meeting_uuid
                 )


### PR DESCRIPTION
"No conference by that name found." is returned by Asterisk when the conference
does not exist
"No active conferences." is returned by Asterisk when NO conference are
currently happening