### PR TITLE
Wazo-2638: Migration of wazo-calld from Marshmallow 3.0.0b14 to stable version 3.10.0

### DIFF
--- a/integration_tests/suite/test_voicemail.py
+++ b/integration_tests/suite/test_voicemail.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -108,7 +108,7 @@ class TestVoicemails(RealAsteriskIntegrationTest):
                         constraint=has_entry("choices", equal_to(
                             ["unavailable", "busy", "name"]
                         )),
-                        message="Not a valid choice."
+                        message='Must be one of: unavailable, busy, name.'
 
 
                     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ iso8601==0.1.11
 itsdangerous==0.24  # from flask
 jsonpatch==1.21
 kombu==4.6.11
-marshmallow==3.0.0b14
+marshmallow==3.10.0
 python-consul==0.7.1
 pyyaml==3.13  # from xivo-lib-python
 requests==2.21.0

--- a/wazo_calld/plugin_helpers/mallow.py
+++ b/wazo_calld/plugin_helpers/mallow.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import fields
@@ -11,12 +11,12 @@ class StrictDict(fields.Dict):
         self.key_field = key_field
         self.value_field = value_field
 
-    def _deserialize(self, value, attr, data):
-        value = super()._deserialize(value, attr, data)
+    def _deserialize(self, value, attr, data, **kwargs):
+        value = super()._deserialize(value, attr, data, **kwargs)
 
         result = {}
         for key, inner_value in value.items():
-            new_key = self.key_field.deserialize(key, attr, data)
-            new_value = self.value_field.deserialize(inner_value, attr, data)
+            new_key = self.key_field.deserialize(key, attr, data, **kwargs)
+            new_value = self.value_field.deserialize(inner_value, attr, data, **kwargs)
             result[new_key] = new_value
         return result

--- a/wazo_calld/plugins/applications/schemas.py
+++ b/wazo_calld/plugins/applications/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import (
@@ -22,7 +22,7 @@ class BaseSchema(Schema):
         unknown = EXCLUDE
 
     @pre_load
-    def ensure_dict(self, data):
+    def ensure_dict(self, data, **kwargs):
         return data or {}
 
 
@@ -41,7 +41,7 @@ class ApplicationCallRequestSchema(BaseSchema):
     displayed_caller_id_number = fields.String(missing='', validate=Length(max=256))
 
     @post_load
-    def remove_extension_whitespace(self, call_request):
+    def remove_extension_whitespace(self, call_request, **kwargs):
         call_request['exten'] = ''.join(call_request['exten'].split())
         return call_request
 

--- a/wazo_calld/plugins/calls/schemas.py
+++ b/wazo_calld/plugins/calls/schemas.py
@@ -34,10 +34,8 @@ class CallRequestDestinationSchema(CallBaseSchema):
 
 
 class CallRequestSchema(CallBaseSchema):
-    source = fields.Nested('CallRequestSourceSchema', required=True,
-                           unknown=EXCLUDE)
-    destination = fields.Nested('CallRequestDestinationSchema', required=True,
-                                unknown=EXCLUDE)
+    source = fields.Nested('CallRequestSourceSchema', required=True)
+    destination = fields.Nested('CallRequestDestinationSchema', required=True)
     variables = StrictDict(key_field=fields.String(required=True, validate=Length(min=1)),
                            value_field=fields.String(required=True, validate=Length(min=1)),
                            missing=dict)

--- a/wazo_calld/plugins/calls/schemas.py
+++ b/wazo_calld/plugins/calls/schemas.py
@@ -28,7 +28,7 @@ class CallRequestDestinationSchema(CallBaseSchema):
     priority = fields.Integer(validate=Range(min=1), required=True)
 
     @post_load
-    def remove_extension_whitespace(self, call_request):
+    def remove_extension_whitespace(self, call_request, **kwargs):
         call_request['extension'] = ''.join(call_request['extension'].split())
         return call_request
 
@@ -54,7 +54,7 @@ class UserCallRequestSchema(CallBaseSchema):
     auto_answer_caller = fields.Boolean(missing=False)
 
     @post_load
-    def remove_extension_whitespace(self, call_request):
+    def remove_extension_whitespace(self, call_request, **kwargs):
         call_request['extension'] = ''.join(call_request['extension'].split())
         return call_request
 
@@ -85,7 +85,7 @@ class CallSchema(CallBaseSchema):
     line_id = fields.Integer()
 
     @post_dump()
-    def default_peer_caller_id_number(self, call):
+    def default_peer_caller_id_number(self, call, **kwargs):
         if call['peer_caller_id_number'] == '':
             call['peer_caller_id_number'] = call['dialed_extension']
         return call

--- a/wazo_calld/plugins/faxes/schemas.py
+++ b/wazo_calld/plugins/faxes/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import post_load
@@ -13,7 +13,7 @@ class FaxCreationRequestSchema(Schema):
     caller_id = fields.String(missing='Wazo Fax')
 
     @post_load
-    def remove_extension_whitespace(self, call_request):
+    def remove_extension_whitespace(self, call_request, **kwargs):
         call_request['extension'] = ''.join(call_request['extension'].split())
         return call_request
 
@@ -23,7 +23,7 @@ class UserFaxCreationRequestSchema(Schema):
     caller_id = fields.String(missing='Wazo Fax')
 
     @post_load
-    def remove_extension_whitespace(self, call_request):
+    def remove_extension_whitespace(self, call_request, **kwargs):
         call_request['extension'] = ''.join(call_request['extension'].split())
         return call_request
 

--- a/wazo_calld/plugins/relocates/schemas.py
+++ b/wazo_calld/plugins/relocates/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import (
@@ -32,7 +32,7 @@ class LocationField(fields.Field):
         'mobile': None,
     }
 
-    def _deserialize(self, value, attr, data):
+    def _deserialize(self, value, attr, data, **kwargs):
         destination = data.get('destination')
         try:
             concrete_location = self.locations.get(destination)

--- a/wazo_calld/plugins/relocates/schemas.py
+++ b/wazo_calld/plugins/relocates/schemas.py
@@ -28,7 +28,7 @@ class LocationField(fields.Field):
         unknown = EXCLUDE
 
     locations = {
-        'line': fields.Nested(LineLocationSchema, unknown=EXCLUDE),
+        'line': fields.Nested(LineLocationSchema),
         'mobile': None,
     }
 

--- a/wazo_calld/plugins/transfers/schemas.py
+++ b/wazo_calld/plugins/transfers/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import Schema, fields, post_load
@@ -19,7 +19,7 @@ class TransferRequestSchema(Schema):
     timeout = fields.Integer(missing=None, min=1, allow_none=True)
 
     @post_load
-    def remove_extension_whitespace(self, call_request):
+    def remove_extension_whitespace(self, call_request, **kwargs):
         call_request['exten'] = ''.join(call_request['exten'].split())
         return call_request
 
@@ -34,7 +34,7 @@ class UserTransferRequestSchema(Schema):
     timeout = fields.Integer(missing=None, min=1, allow_none=True)
 
     @post_load
-    def remove_extension_whitespace(self, call_request):
+    def remove_extension_whitespace(self, call_request, **kwargs):
         call_request['exten'] = ''.join(call_request['exten'].split())
         return call_request
 


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/xivo-lib-python/pull/93