### PR TITLE
Add two fields in calld; one for the pick up time of a call, and another for the hang up time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## 22.04
 
+* The `answer_time` field has been added to the following resources:
+
+  * GET `/calls`
+  * GET `/calls/<call-id>`
+  * GET `/users/me/calls`
+  
+* The `answer_time` field have been added to the following events:
+
+  * `call_created`
+  * `call_updated`
+  * `call_answered`
+  * `call_ended`
+  
 * The `ivr_extension` and `wait_time` fields have been added to the following resources:
 
   * POST `/faxes`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@
   * GET `/calls`
   * GET `/calls/<call-id>`
   * GET `/users/me/calls`
+
+* The `hangup_time` field has been added to the following resources:
+
+  * GET `/calls`
+  * GET `/calls/<call-id>`
+  * GET `/users/me/calls`
   
-* The `answer_time` field have been added to the following events:
+* The `answer_time` and `hangup_time` fields have been added to the following events:
 
   * `call_created`
   * `call_updated`

--- a/integration_tests/assets/ari_data/mock_ari.py
+++ b/integration_tests/assets/ari_data/mock_ari.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -169,7 +169,7 @@ def list_endpoints():
     return make_response(json.dumps(result), 200, {'Content-Type': 'application/json'})
 
 
-@app.route('/ari/channels/<channel_id>/variable')
+@app.route('/ari/channels/<channel_id>/variable', methods=['GET'])
 def channel_variable(channel_id):
     variable = request.args['variable']
     if channel_id not in _responses['channel_variables']:
@@ -179,6 +179,18 @@ def channel_variable(channel_id):
     return jsonify({
         'value': _responses['channel_variables'][channel_id][variable]
     })
+
+
+@app.route('/ari/channels/<channel_id>/variable', methods=['POST'])
+def post_channel_variable(channel_id):
+    variable = request.args['variable']
+    value = request.args['value']
+    if channel_id not in _responses['channels']:
+        return '', 404
+    if channel_id not in _responses['channel_variables']:
+        _responses['channel_variables'][channel_id] = {}
+    _responses['channel_variables'][channel_id][variable] = value
+    return '', 204
 
 
 @app.route('/ari/applications/<application_name>/subscription', methods=['POST'])

--- a/integration_tests/suite/helpers/hamcrest_.py
+++ b/integration_tests/suite/helpers/hamcrest_.py
@@ -1,10 +1,13 @@
 # Copyright 2016-2018 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from datetime import datetime
+
 from hamcrest import all_of
 from hamcrest import instance_of
 from hamcrest import is_in
 from hamcrest import not_
+from hamcrest.core.base_matcher import BaseMatcher
 
 from ari.exceptions import ARINotFound
 
@@ -61,3 +64,20 @@ class HamcrestARIBridge:
     def is_found(self):
         bridge_ids = (bridge.id for bridge in self._ari.bridges.list())
         return is_in(list(bridge_ids))
+
+
+class ATimeStamp(BaseMatcher):
+
+    def _matches(self, item):
+        try:
+            datetime.fromisoformat(item)
+            return True
+        except (ValueError, TypeError):
+            return False
+
+    def describe_to(self, description):
+        description.append_text('a valid date')
+
+
+def a_timestamp():
+    return ATimeStamp()

--- a/integration_tests/suite/helpers/hamcrest_.py
+++ b/integration_tests/suite/helpers/hamcrest_.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from datetime import datetime

--- a/integration_tests/suite/helpers/stasis.py
+++ b/integration_tests/suite/helpers/stasis.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import requests
@@ -132,7 +132,8 @@ class StasisClient:
         sip_call_id=None,
         creation_time=None,
         timestamp=None,
-        connected_number=''
+        connected_number='',
+        answer_time=None,
     ):
         url = self.url('_send_ws_event')
         creation_time = creation_time or "2016-02-04T15:10:21.225-0500"
@@ -152,9 +153,10 @@ class StasisClient:
                     "number": connected_number
                 },
                 "channelvars": {
+                    'WAZO_ANSWER_TIME': answer_time,
+                    'WAZO_CHANNEL_DIRECTION': channel_direction,
                     "WAZO_LINE_ID": line_id,
                     'WAZO_SIP_CALL_ID': sip_call_id,
-                    'WAZO_CHANNEL_DIRECTION': channel_direction,
                 },
                 "creationtime": creation_time,
                 "dialplan": {

--- a/integration_tests/suite/test_calls_bus_consume.py
+++ b/integration_tests/suite/test_calls_bus_consume.py
@@ -72,6 +72,7 @@ class TestBusConsume(IntegrationTest):
                 'data': has_entries({
                     'call_id': call_id,
                     'status': 'Up',
+                    'hangup_time': None,
                     'answer_time': is_(a_timestamp()),
                     'is_video': True,
                 })
@@ -93,6 +94,7 @@ class TestBusConsume(IntegrationTest):
                 'data': has_entries({
                     'call_id': call_id,
                     'status': 'Up',
+                    'hangup_time': None,
                     'answer_time': is_(a_timestamp()),
                 })
             })))

--- a/integration_tests/suite/test_calls_bus_consume.py
+++ b/integration_tests/suite/test_calls_bus_consume.py
@@ -6,6 +6,7 @@ from hamcrest import (
     assert_that,
     has_entries,
     has_item,
+    is_,
 )
 from wazo_test_helpers import until
 
@@ -13,6 +14,7 @@ from .helpers.base import IntegrationTest
 from .helpers.ari_ import MockChannel
 from .helpers.calld import new_call_id
 from .helpers.constants import XIVO_UUID
+from .helpers.hamcrest_ import a_timestamp
 from .helpers.wait_strategy import CalldEverythingOkWaitStrategy
 
 
@@ -58,7 +60,7 @@ class TestBusConsume(IntegrationTest):
 
     def test_when_channel_updated_then_bus_event(self):
         call_id = new_call_id()
-        self.ari.set_channels(MockChannel(id=call_id, state='Up', channelvars={'CHANNEL(videonativeformat)': '(vp8)'}))
+        self.ari.set_channels(MockChannel(id=call_id, state='Up', channelvars={'CHANNEL(videonativeformat)': '(vp8)', 'WAZO_ANSWER_TIME': '2022-03-08T03:49:00+00:00'}))
         events = self.bus.accumulator(routing_key='calls.call.updated')
 
         self.bus.send_ami_newstate_event(call_id)
@@ -67,14 +69,19 @@ class TestBusConsume(IntegrationTest):
             assert_that(events.accumulate(), has_item(has_entries({
                 'name': 'call_updated',
                 'origin_uuid': XIVO_UUID,
-                'data': has_entries({'call_id': call_id, 'status': 'Up', 'is_video': True})
+                'data': has_entries({
+                    'call_id': call_id,
+                    'status': 'Up',
+                    'answer_time': is_(a_timestamp()),
+                    'is_video': True,
+                })
             })))
 
         until.assert_(assert_function, tries=5)
 
     def test_when_channel_answered_then_bus_event(self):
         call_id = new_call_id()
-        self.ari.set_channels(MockChannel(id=call_id, state='Up'))
+        self.ari.set_channels(MockChannel(id=call_id, state='Up', channelvars={'WAZO_ANSWER_TIME': '2022-03-08T03:48:00+00:00'}))
         events = self.bus.accumulator(routing_key='calls.call.answered')
 
         self.bus.send_ami_newstate_event(call_id, state='Up')
@@ -83,7 +90,11 @@ class TestBusConsume(IntegrationTest):
             assert_that(events.accumulate(), has_item(has_entries({
                 'name': 'call_answered',
                 'origin_uuid': XIVO_UUID,
-                'data': has_entries({'call_id': call_id, 'status': 'Up'})
+                'data': has_entries({
+                    'call_id': call_id,
+                    'status': 'Up',
+                    'answer_time': is_(a_timestamp()),
+                })
             })))
 
         until.assert_(assert_function, tries=5)
@@ -109,7 +120,9 @@ class TestBusConsume(IntegrationTest):
             assert_that(events.accumulate(), has_item(has_entries({
                 'name': 'call_held',
                 'origin_uuid': XIVO_UUID,
-                'data': has_entries({'call_id': call_id})
+                'data': has_entries({
+                    'call_id': call_id,
+                })
             })))
 
         until.assert_(assert_function, tries=5)
@@ -135,7 +148,9 @@ class TestBusConsume(IntegrationTest):
             assert_that(events.accumulate(), has_item(has_entries({
                 'name': 'call_resumed',
                 'origin_uuid': XIVO_UUID,
-                'data': has_entries({'call_id': call_id})
+                'data': has_entries({
+                    'call_id': call_id,
+                })
             })))
 
         until.assert_(assert_function, tries=5)

--- a/integration_tests/suite/test_calls_stasis.py
+++ b/integration_tests/suite/test_calls_stasis.py
@@ -121,6 +121,7 @@ class TestDialedFrom(IntegrationTest):
                     'reason_code': 0,
                     'is_caller': True,
                     'answer_time': is_(a_timestamp()),
+                    'hangup_time': is_(a_timestamp()),
                 })})))
 
         until.assert_(assert_function, tries=5)
@@ -149,6 +150,7 @@ class TestDialedFrom(IntegrationTest):
                     'line_id': 2,
                     'reason_code': 0,
                     'is_caller': False,
+                    'hangup_time': is_(a_timestamp()),
                 })})))
 
         until.assert_(assert_function, tries=5)
@@ -173,6 +175,7 @@ class TestDialedFrom(IntegrationTest):
                     'creation_time': '2016-02-01T15:00:00.000-0500',
                     'sip_call_id': '',
                     'line_id': None,
+                    'hangup_time': is_(a_timestamp()),
                 })})))
 
         until.assert_(assert_function, tries=5)

--- a/integration_tests/suite/test_calls_stasis.py
+++ b/integration_tests/suite/test_calls_stasis.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -9,6 +9,7 @@ from hamcrest import (
     has_entry,
     has_item,
     has_items,
+    is_,
 )
 from wazo_test_helpers import until
 
@@ -17,6 +18,7 @@ from .helpers.base import IntegrationTest
 from .helpers.constants import SOME_STASIS_APP, SOME_STASIS_APP_INSTANCE, XIVO_UUID
 from .helpers.calld import new_call_id
 from .helpers.confd import MockLine, MockUser
+from .helpers.hamcrest_ import a_timestamp
 
 STASIS_APP = 'callcontrol'
 
@@ -102,7 +104,8 @@ class TestDialedFrom(IntegrationTest):
             stasis_app=STASIS_APP,
             line_id=2,
             sip_call_id='foobar',
-            creation_time='2016-02-01T15:00:00.000-0500',
+            creation_time='2016-02-01T15:00:00.000-05:00',
+            answer_time='2022-03-08T04:09:00-05:00',
             cause=0,
             channel_direction='to-wazo',
         )
@@ -112,11 +115,12 @@ class TestDialedFrom(IntegrationTest):
                 'name': 'call_ended',
                 'origin_uuid': XIVO_UUID,
                 'data': has_entries({
-                    'creation_time': '2016-02-01T15:00:00.000-0500',
+                    'creation_time': '2016-02-01T15:00:00.000-05:00',
                     'sip_call_id': 'foobar',
                     'line_id': 2,
                     'reason_code': 0,
                     'is_caller': True,
+                    'answer_time': is_(a_timestamp()),
                 })})))
 
         until.assert_(assert_function, tries=5)

--- a/wazo_calld/plugins/calls/api.yml
+++ b/wazo_calld/plugins/calls/api.yml
@@ -579,6 +579,9 @@ definitions:
       answer_time:
         type: string
         format: date-time
+      hangup_time:
+        type: string
+        format: date-time
       caller_id_name:
         type: string
       caller_id_number:

--- a/wazo_calld/plugins/calls/api.yml
+++ b/wazo_calld/plugins/calls/api.yml
@@ -576,6 +576,9 @@ definitions:
       creation_time:
         type: string
         format: date-time
+      answer_time:
+        type: string
+        format: date-time
       caller_id_name:
         type: string
       caller_id_number:

--- a/wazo_calld/plugins/calls/bus_consume.py
+++ b/wazo_calld/plugins/calls/bus_consume.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -122,6 +122,7 @@ class CallsBusEventHandler:
             return
 
         logger.debug('Relaying to bus: channel %s answered', channel_id)
+        self.services.set_answered_time(channel_id)
         try:
             channel = self.ari.channels.get(channelId=channel_id)
         except ARINotFound:

--- a/wazo_calld/plugins/calls/call.py
+++ b/wazo_calld/plugins/calls/call.py
@@ -25,3 +25,4 @@ class Call:
         self.line_id = None
         self.is_video = False
         self.answer_time = None
+        self.hangup_time = None

--- a/wazo_calld/plugins/calls/call.py
+++ b/wazo_calld/plugins/calls/call.py
@@ -24,3 +24,4 @@ class Call:
         self.sip_call_id = None
         self.line_id = None
         self.is_video = False
+        self.answer_time = None

--- a/wazo_calld/plugins/calls/events.yml
+++ b/wazo_calld/plugins/calls/events.yml
@@ -93,6 +93,10 @@ definitions:
       conversation_id:
         type: string
         description: The ID shared by all calls in the same conversation
+      answer_time:
+        type: string
+        format: date-time
+        description: The date when this call was answered. This field is reliable for an inbound call. For outbound calls, early-media, IVR, voicemails and other telephony services may introduce errors in the date.
   UserMissedCall:
     type: object
     properties:

--- a/wazo_calld/plugins/calls/events.yml
+++ b/wazo_calld/plugins/calls/events.yml
@@ -97,6 +97,10 @@ definitions:
         type: string
         format: date-time
         description: The date when this call was answered. This field is reliable for an inbound call. For outbound calls, early-media, IVR, voicemails and other telephony services may introduce errors in the date.
+      hangup_time:
+        type: string
+        format: date-time
+        description: The date when this call was hung up. This field is useful only in the `call_ended` event.
   UserMissedCall:
     type: object
     properties:

--- a/wazo_calld/plugins/calls/events.yml
+++ b/wazo_calld/plugins/calls/events.yml
@@ -24,13 +24,13 @@ events:
     routing_key: calls.hold.created
     required_acl: events.calls.{user_uuid}
     schema:
-      '$ref': '#/definitions/Call'
+      '$ref': '#/definitions/CallHeld'
   call_resumed:
     summary: A call has been resumed
     routing_key: calls.hold.deleted
     required_acl: events.calls.{user_uuid}
     schema:
-      '$ref': '#/definitions/Call'
+      '$ref': '#/definitions/CallHeld'
   call_dtmf_created:
     summary: A DTMF has been sent to Wazo
     routing_key: calls.dtmf.created
@@ -119,3 +119,10 @@ definitions:
       conversation_id:
         type: string
         description: The ID shared by all calls in the same conversation
+  CallHeld:
+    type: object
+    properties:
+        call_id:
+          type: string
+        user_uuid:
+          type: string

--- a/wazo_calld/plugins/calls/schemas.py
+++ b/wazo_calld/plugins/calls/schemas.py
@@ -81,6 +81,7 @@ class CallSchema(CallBaseSchema):
     dialed_extension = fields.String()
     sip_call_id = fields.String()
     line_id = fields.Integer()
+    answer_time = fields.String()
 
     @post_dump()
     def default_peer_caller_id_number(self, call, **kwargs):

--- a/wazo_calld/plugins/calls/schemas.py
+++ b/wazo_calld/plugins/calls/schemas.py
@@ -82,6 +82,7 @@ class CallSchema(CallBaseSchema):
     sip_call_id = fields.String()
     line_id = fields.Integer()
     answer_time = fields.String()
+    hangup_time = fields.String()
 
     @post_dump()
     def default_peer_caller_id_number(self, call, **kwargs):

--- a/wazo_calld/plugins/calls/services.py
+++ b/wazo_calld/plugins/calls/services.py
@@ -1,13 +1,14 @@
 # Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import datetime
 import logging
 import uuid
 
 from ari.exceptions import ARINotFound
 from wazo_calld.ari_ import DEFAULT_APPLICATION_NAME
 from wazo_calld.plugin_helpers import ami
-from wazo_calld.plugin_helpers.ari_ import AUTO_ANSWER_VARIABLES, Channel, set_channel_var_sync
+from wazo_calld.plugin_helpers.ari_ import AUTO_ANSWER_VARIABLES, Channel, set_channel_var_sync, set_channel_id_var_sync
 from wazo_calld.plugin_helpers.confd import User
 from wazo_calld.plugin_helpers.exceptions import (
     InvalidExtension,
@@ -25,6 +26,7 @@ from .dial_echo import DialEchoTimeout
 logger = logging.getLogger(__name__)
 
 CALL_RECORDING_FILENAME_TEMPLATE = '/var/lib/wazo/sounds/tenants/{tenant_uuid}/monitor/{recording_uuid}.wav'
+LOCAL_TIMEZONE = datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
 
 
 class CallsService:
@@ -268,6 +270,7 @@ class CallsService:
         call = Call(channel.id)
         call.conversation_id = channel_helper.conversation_id()
         call.creation_time = channel.json['creationtime']
+        call.answer_time = channel_variables.get('WAZO_ANSWER_TIME') or None
         call.status = channel.json['state']
         call.caller_id_name = channel.json['caller']['name']
         call.caller_id_number = channel.json['caller']['number']
@@ -310,6 +313,7 @@ class CallsService:
         call.sip_call_id = channel_variables.get('WAZO_SIP_CALL_ID')
         call.line_id = channel_variables.get('WAZO_LINE_ID') or None
         call.creation_time = channel.get('creationtime')
+        call.answer_time = channel_variables.get('WAZO_ANSWER_TIME') or None
         call.is_video = channel_variables.get('CHANNEL(videonativeformat)') != '(nothing)'
         direction = channel_variables.get('WAZO_CHANNEL_DIRECTION')
         call.is_caller = True if direction == 'to-wazo' else False
@@ -470,6 +474,19 @@ class CallsService:
     def answer_user(self, call_id, user_uuid):
         self._verify_user(call_id, user_uuid)
         self.answer(call_id)
+
+    def set_answered_time(self, channel_id):
+        try:
+            set_channel_id_var_sync(
+                self._ari,
+                channel_id,
+                'WAZO_ANSWER_TIME',
+                datetime.datetime.now(LOCAL_TIMEZONE).isoformat(),
+                bypass_stasis=True,
+            )
+        except ARINotFound:
+            logger.debug('channel %s not found', channel_id)
+            raise NoSuchCall(channel_id)
 
     def _verify_user(self, call_id, user_uuid):
         channel = Channel(call_id, self._ari)

--- a/wazo_calld/plugins/calls/services.py
+++ b/wazo_calld/plugins/calls/services.py
@@ -314,6 +314,7 @@ class CallsService:
         call.line_id = channel_variables.get('WAZO_LINE_ID') or None
         call.creation_time = channel.get('creationtime')
         call.answer_time = channel_variables.get('WAZO_ANSWER_TIME') or None
+        call.hangup_time = datetime.datetime.now(LOCAL_TIMEZONE).isoformat()
         call.is_video = channel_variables.get('CHANNEL(videonativeformat)') != '(nothing)'
         direction = channel_variables.get('WAZO_CHANNEL_DIRECTION')
         call.is_caller = True if direction == 'to-wazo' else False


### PR DESCRIPTION
We would like to have two fields in wazo-calld about each call:

* One called answer_time which will tells us when the call was picked up by the other end,

* The second one called hangup_time which will tell us when the call was ended.

* Write all the necessary test functions (possible scenarios), if needed.

Depends-On: https://github.com/wazo-platform/wazo-asterisk-config/pull/44