### PR TITLE
WP-465-group-mobile-not-ringing

### DIFF
--- a/integration_tests/assets/etc/asterisk/extensions.conf
+++ b/integration_tests/assets/etc/asterisk/extensions.conf
@@ -89,7 +89,7 @@ exten = joiner-uuid,1,NoOp
 same = n,Dial(Test/joiner/autoanswer)
 same = n,Hangup
 
-exten = eaa18a7f-3f49-419a-9abb-b445b8ba2e03,hint,Custom:eaa18a7f-3f49-419a-9abb-b445b8ba2e03
+exten = eaa18a7f-3f49-419a-9abb-b445b8ba2e03,hint,Custom:eaa18a7f-3f49-419a-9abb-b445b8ba2e03-mobile
 
 exten = _[0-9a-f].,1,NoOp(Placeholder mimicking the real dialplan, where every UUID is an extension, and not only user UUIDs)
 same = n,Hangup

--- a/integration_tests/assets/etc/asterisk/extensions.conf
+++ b/integration_tests/assets/etc/asterisk/extensions.conf
@@ -89,6 +89,8 @@ exten = joiner-uuid,1,NoOp
 same = n,Dial(Test/joiner/autoanswer)
 same = n,Hangup
 
+exten = eaa18a7f-3f49-419a-9abb-b445b8ba2e03,hint,Custom:eaa18a7f-3f49-419a-9abb-b445b8ba2e03
+
 exten = _[0-9a-f].,1,NoOp(Placeholder mimicking the real dialplan, where every UUID is an extension, and not only user UUIDs)
 same = n,Hangup
 

--- a/integration_tests/suite/helpers/auth.py
+++ b/integration_tests/suite/helpers/auth.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import requests
@@ -20,6 +20,10 @@ class AuthClient:
     def set_token(self, token):
         url = self.url('_set_token')
         requests.post(url, json=token.to_dict())
+
+    def set_refresh_tokens(self, refresh_tokens):
+        url = self.url('_set_refresh_tokens')
+        requests.post(url, json=refresh_tokens)
 
 
 class MockUserToken:

--- a/integration_tests/suite/test_push_mobile.py
+++ b/integration_tests/suite/test_push_mobile.py
@@ -109,7 +109,7 @@ class TestPushMobile(RealAsteriskIntegrationTest):
         )
 
         def user_hint_updated():
-            result = self.amid.action('Getvar', {'Variable': f'DEVICE_STATE(Custom:{user_uuid})'})
+            result = self.amid.action('Getvar', {'Variable': f'DEVICE_STATE(Custom:{user_uuid}-mobile)'})
             assert_that(result, contains(has_entries(
                 Response='Success',
                 Value='NOT_INUSE',
@@ -130,7 +130,7 @@ class TestPushMobile(RealAsteriskIntegrationTest):
         )
 
         def user_hint_updated():
-            result = self.amid.action('Getvar', {'Variable': f'DEVICE_STATE(Custom:{user_uuid})'})
+            result = self.amid.action('Getvar', {'Variable': f'DEVICE_STATE(Custom:{user_uuid}-mobile)'})
             assert_that(result, contains(has_entries(
                 Response='Success',
                 Value='UNAVAILABLE',

--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -3,6 +3,7 @@ https://github.com/wazo-platform/ari-py/archive/0.4.0.zip
 https://github.com/wazo-platform/wazo-lib-rest-client/archive/master.zip
 https://github.com/wazo-platform/wazo-calld-client/archive/master.zip
 https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip
+https://github.com/wazo-platform/wazo-amid-client/archive/master.zip
 kombu
 openapi-spec-validator
 psycopg2-binary

--- a/wazo_calld/bus.py
+++ b/wazo_calld/bus.py
@@ -49,7 +49,8 @@ ROUTING_KEY_MAPPING = {
     'user_line_associated': 'config.users.*.lines.*.updated',
     'user_line_dissociated': 'config.users.*.lines.*.deleted',
     'users_services_dnd_updated': 'config.users.*.services.dnd.updated',
-    'auth_user_sessions_updated': 'auth.users.*.sessions.updated',
+    'auth_refresh_token_created': 'auth.users.*.tokens.*.created',
+    'auth_refresh_token_deleted': 'auth.users.*.tokens.*.deleted',
 }
 
 

--- a/wazo_calld/bus.py
+++ b/wazo_calld/bus.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import kombu
@@ -49,6 +49,7 @@ ROUTING_KEY_MAPPING = {
     'user_line_associated': 'config.users.*.lines.*.updated',
     'user_line_dissociated': 'config.users.*.lines.*.deleted',
     'users_services_dnd_updated': 'config.users.*.services.dnd.updated',
+    'auth_user_sessions_updated': 'auth.users.*.sessions.updated',
 }
 
 

--- a/wazo_calld/plugins/dial_mobile/bus_consume.py
+++ b/wazo_calld/plugins/dial_mobile/bus_consume.py
@@ -1,0 +1,20 @@
+# Copyright 2022 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+class EventHandler:
+    def __init__(self, service):
+        self._service = service
+
+    def subscribe(self, bus_consumer):
+        bus_consumer.on_event('auth_user_sessions_updated', self._on_auth_user_sessions_updated)
+
+    def _on_auth_user_sessions_updated(self, event):
+        user_uuid = event['user_uuid']
+        has_mobile = False
+        for session in event['sessions']:
+            if session['mobile']:
+                has_mobile = True
+                break
+
+        self._service.set_user_hint(user_uuid, has_mobile)

--- a/wazo_calld/plugins/dial_mobile/bus_consume.py
+++ b/wazo_calld/plugins/dial_mobile/bus_consume.py
@@ -7,14 +7,17 @@ class EventHandler:
         self._service = service
 
     def subscribe(self, bus_consumer):
-        bus_consumer.on_event('auth_user_sessions_updated', self._on_auth_user_sessions_updated)
+        bus_consumer.on_event('auth_refresh_token_created', self._on_refresh_token_created)
+        bus_consumer.on_event('auth_refresh_token_deleted', self._on_refresh_token_deleted)
 
-    def _on_auth_user_sessions_updated(self, event):
-        user_uuid = event['user_uuid']
-        has_mobile = False
-        for session in event['sessions']:
-            if session['mobile']:
-                has_mobile = True
-                break
+    def _on_refresh_token_created(self, event):
+        if not event['mobile']:
+            return
 
-        self._service.set_user_hint(user_uuid, has_mobile)
+        self._service.on_mobile_refresh_token_created(event['user_uuid'])
+
+    def _on_refresh_token_deleted(self, event):
+        if not event['mobile']:
+            return
+
+        self._service.on_mobile_refresh_token_deleted(event['user_uuid'])

--- a/wazo_calld/plugins/dial_mobile/plugin.py
+++ b/wazo_calld/plugins/dial_mobile/plugin.py
@@ -1,10 +1,12 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from wazo_amid_client import Client as AmidClient
 from xivo.pubsub import CallbackCollector
 
 from .stasis import DialMobileStasis
 from .services import DialMobileService
+from .bus_consume import EventHandler
 
 
 class Plugin:
@@ -12,8 +14,14 @@ class Plugin:
     def load(self, dependencies):
         ari = dependencies['ari']
         pubsub = dependencies['pubsub']
+        bus_consumer = dependencies['bus_consumer']
+        token_changed_subscribe = dependencies['token_changed_subscribe']
+        config = dependencies['config']
 
-        service = DialMobileService(ari)
+        amid_client = AmidClient(**config['amid'])
+        token_changed_subscribe(amid_client.set_token)
+
+        service = DialMobileService(ari, amid_client)
         pubsub.subscribe('stopping', lambda _: service.on_calld_stopping())
 
         stasis = DialMobileStasis(ari, service)
@@ -21,3 +29,6 @@ class Plugin:
         startup_callback_collector = CallbackCollector()
         ari.client_initialized_subscribe(startup_callback_collector.new_source())
         startup_callback_collector.subscribe(stasis.initialize)
+
+        event_handler = EventHandler(service)
+        event_handler.subscribe(bus_consumer)

--- a/wazo_calld/plugins/dial_mobile/plugin.py
+++ b/wazo_calld/plugins/dial_mobile/plugin.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_amid_client import Client as AmidClient
+from wazo_auth_client import Client as AuthClient
 from xivo.pubsub import CallbackCollector
 
 from .stasis import DialMobileStasis
@@ -21,7 +22,10 @@ class Plugin:
         amid_client = AmidClient(**config['amid'])
         token_changed_subscribe(amid_client.set_token)
 
-        service = DialMobileService(ari, amid_client)
+        auth_client = AuthClient(**config['auth'])
+        token_changed_subscribe(auth_client.set_token)
+
+        service = DialMobileService(ari, amid_client, auth_client)
         pubsub.subscribe('stopping', lambda _: service.on_calld_stopping())
 
         stasis = DialMobileStasis(ari, service)

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -231,8 +231,8 @@ class DialMobileService:
     def on_mobile_refresh_token_deleted(self, user_uuid):
         try:
             response = self._auth_client.token.list(user_uuid, mobile=True)
-        except requests.HTTPError:
-            logger.info('failed to check if %s still has a mobile refresh token', user_uuid)
+        except requests.HTTPError as e:
+            logger.error('failed to check if user %s still has a mobile refresh token: %s: %s', user_uuid, type(e).__name__, e)
             return
 
         mobile = response['filtered'] > 0

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
@@ -136,8 +136,9 @@ class _PollingContactDialer:
 
 class DialMobileService:
 
-    def __init__(self, ari):
+    def __init__(self, ari, amid_client):
         self._ari = ari.client
+        self._amid_client = amid_client
         self._contact_dialers = {}
         self._outgoing_calls = {}
 
@@ -212,3 +213,12 @@ class DialMobileService:
     def on_calld_stopping(self):
         for dialer in self._contact_dialers.values():
             dialer.stop()
+
+    def set_user_hint(self, user_uuid, has_mobile_sessions):
+        self._amid_client.action(
+            'Setvar',
+            {
+                'Variable': f'DEVICE_STATE(Custom:{user_uuid})',
+                'Value': 'NOT_INUSE' if has_mobile_sessions else 'UNAVAILABLE',
+            },
+        )

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -218,7 +218,7 @@ class DialMobileService:
         self._amid_client.action(
             'Setvar',
             {
-                'Variable': f'DEVICE_STATE(Custom:{user_uuid})',
+                'Variable': f'DEVICE_STATE(Custom:{user_uuid}-mobile)',
                 'Value': 'NOT_INUSE' if has_mobile_sessions else 'UNAVAILABLE',
             },
         )

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -183,7 +183,7 @@ class DialMobileServiceTestCase(DialerTestCase):
 
         self.amid_client.action.assert_called_once_with(
             'Setvar',
-            {'Variable': 'DEVICE_STATE(Custom:<the-uuid>)', 'Value': 'UNAVAILABLE'},
+            {'Variable': 'DEVICE_STATE(Custom:<the-uuid>-mobile)', 'Value': 'UNAVAILABLE'},
         )
 
     def test_set_user_hint_with_mobile_session(self):
@@ -191,5 +191,5 @@ class DialMobileServiceTestCase(DialerTestCase):
 
         self.amid_client.action.assert_called_once_with(
             'Setvar',
-            {'Variable': 'DEVICE_STATE(Custom:<the-uuid>)', 'Value': 'NOT_INUSE'},
+            {'Variable': 'DEVICE_STATE(Custom:<the-uuid>-mobile)', 'Value': 'NOT_INUSE'},
         )


### PR DESCRIPTION
this hint is defined by wazo-confgend. it is meant to be used to monitor the
state of the usersharedline extensions. The custom hint is set to NOT_INUSE when
a mobile sessions exists for a given user. This change means that a
usersharedline will be seen as available in a group or a queue if the user has a
mobile session. Allowing the user to receive calls from the group.

Depends-On: https://github.com/wazo-platform/xivo-dao/pull/169
Depends-On: https://github.com/wazo-platform/wazo-test-helpers/pull/71
Depends-On: https://github.com/wazo-platform/wazo-auth-keys/pull/59