### PR TITLE
pin jinja2 and marksupsafe to buster version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,10 @@ flask-restful==0.3.7
 flask==1.0.2
 iso8601==0.1.11
 itsdangerous==0.24  # from flask
+jinja2==2.10  # from flask
 jsonpatch==1.21
 kombu==4.6.11
+markupsafe==1.1.0 # from flask
 marshmallow==3.10.0
 python-consul==0.7.1
 pyyaml==3.13  # from xivo-lib-python


### PR DESCRIPTION
why: latest jinja2 version (3.1.0) is incompatible with flask 1.0.2
(from buster)

and newer markupsafe versions (> 2) are incompatible with buster jinja2