### PR TITLE
Pull request for fix-test-warnings

### DIFF
--- a/integration_tests/suite/test_applications.py
+++ b/integration_tests/suite/test_applications.py
@@ -4,7 +4,7 @@
 from hamcrest import (
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     equal_to,
@@ -228,7 +228,7 @@ class TestStasisTriggers(BaseApplicationTestCase):
                                 application_uuid=app_uuid,
                                 node=has_entries(
                                     uuid=app_uuid,
-                                    calls=contains(has_entries(id=channel.id)),
+                                    calls=contains_exactly(has_entries(id=channel.id)),
                                 )
                             )
                         ),
@@ -552,7 +552,7 @@ class TestApplication(BaseApplicationTestCase):
         calls = self.calld_client.applications.list_calls(self.no_node_app_uuid)['items']
         assert_that(
             calls,
-            contains(
+            contains_exactly(
                 has_entries(
                     id=channel.id,
                     status='Up',
@@ -790,7 +790,7 @@ class TestApplication(BaseApplicationTestCase):
                                 application_uuid=self.node_app_uuid,
                                 node=has_entries(
                                     uuid=self.node_app_uuid,
-                                    calls=contains(has_entries(id=call['id']))
+                                    calls=contains_exactly(has_entries(id=call['id']))
                                 )
                             )
                         ),
@@ -875,7 +875,7 @@ class TestApplication(BaseApplicationTestCase):
                                 application_uuid=self.node_app_uuid,
                                 node=has_entries(
                                     uuid=self.node_app_uuid,
-                                    calls=contains(has_entries(id=call['id']))
+                                    calls=contains_exactly(has_entries(id=call['id']))
                                 )
                             )
                         ),
@@ -975,7 +975,7 @@ class TestApplication(BaseApplicationTestCase):
                                 application_uuid=self.node_app_uuid,
                                 node=has_entries(
                                     uuid=self.node_app_uuid,
-                                    calls=contains(has_entries(id=call['id']))
+                                    calls=contains_exactly(has_entries(id=call['id']))
                                 )
                             )
                         ),
@@ -1036,7 +1036,7 @@ class TestApplication(BaseApplicationTestCase):
         assert_that(nodes, empty())
 
         nodes = self.calld_client.applications.list_nodes(self.node_app_uuid)['items']
-        assert_that(nodes, contains(has_entries(uuid=self.node_app_uuid, calls=empty())))
+        assert_that(nodes, contains_exactly(has_entries(uuid=self.node_app_uuid, calls=empty())))
 
         # TODO: replace precondition with POST /applications/uuid/nodes/uuid/calls
         channel = self.call_app(self.node_app_uuid)
@@ -1045,10 +1045,10 @@ class TestApplication(BaseApplicationTestCase):
             nodes = self.calld_client.applications.list_nodes(self.node_app_uuid)['items']
             assert_that(
                 nodes,
-                contains(
+                contains_exactly(
                     has_entries(
                         uuid=self.node_app_uuid,
-                        calls=contains(has_entries(id=channel.id)),
+                        calls=contains_exactly(has_entries(id=channel.id)),
                     )
                 )
             )
@@ -1085,7 +1085,7 @@ class TestApplicationMute(BaseApplicationTestCase):
             events = event_accumulator.accumulate(with_headers=True)
             assert_that(
                 events,
-                contains(
+                contains_exactly(
                     has_entries(
                         message=has_entries(
                             name='application_call_updated',
@@ -1106,7 +1106,7 @@ class TestApplicationMute(BaseApplicationTestCase):
 
         assert_that(
             self.calld_client.applications.list_calls(app_uuid)['items'],
-            contains(
+            contains_exactly(
                 has_entries(
                     id=channel.id,
                     muted=True,
@@ -1161,7 +1161,7 @@ class TestApplicationMute(BaseApplicationTestCase):
 
         assert_that(
             self.calld_client.applications.list_calls(app_uuid)['items'],
-            contains(
+            contains_exactly(
                 has_entries(
                     id=channel.id,
                     muted=False,
@@ -1221,7 +1221,7 @@ class TestApplicationHold(BaseApplicationTestCase):
 
         assert_that(
             self.calld_client.applications.list_calls(app_uuid)['items'],
-            contains(has_entries(id=channel.id, on_hold=True))
+            contains_exactly(has_entries(id=channel.id, on_hold=True))
         )
 
     def test_put_hold_stop(self):
@@ -1285,7 +1285,7 @@ class TestApplicationHold(BaseApplicationTestCase):
 
         assert_that(
             self.calld_client.applications.list_calls(app_uuid)['items'],
-            contains(has_entries(id=channel.id, on_hold=False))
+            contains_exactly(has_entries(id=channel.id, on_hold=False))
         )
 
 
@@ -1774,7 +1774,7 @@ class TestApplicationMoh(BaseApplicationTestCase):
 
         assert_that(
             self.calld_client.applications.list_calls(app_uuid)['items'],
-            contains(has_entries(id=channel.id, moh_uuid=self.moh_uuid))
+            contains_exactly(has_entries(id=channel.id, moh_uuid=self.moh_uuid))
         )
 
     def test_put_moh_stop_success(self):
@@ -1825,7 +1825,7 @@ class TestApplicationMoh(BaseApplicationTestCase):
 
         assert_that(
             self.calld_client.applications.list_calls(app_uuid)['items'],
-            contains(has_entries(id=channel.id, moh_uuid=None))
+            contains_exactly(has_entries(id=channel.id, moh_uuid=None))
         )
 
     def test_confd_moh_created_event_update_cache(self):
@@ -1843,12 +1843,12 @@ class TestApplicationMoh(BaseApplicationTestCase):
 
         def music_on_hold_started_event_received():
             events = event_accumulator.accumulate()
-            assert_that(events, contains(has_entries(name='application_call_updated')))
+            assert_that(events, contains_exactly(has_entries(name='application_call_updated')))
 
         until.assert_(music_on_hold_started_event_received, tries=5)
 
         calls = self.calld_client.applications.list_calls(app_uuid)['items']
-        assert_that(calls, contains(has_entries(id=channel.id, moh_uuid=moh_uuid)))
+        assert_that(calls, contains_exactly(has_entries(id=channel.id, moh_uuid=moh_uuid)))
 
     def test_confd_moh_deleted_event_update_cache(self):
         app_uuid = self.no_node_app_uuid
@@ -2091,7 +2091,7 @@ class TestApplicationAnswer(BaseApplicationTestCase):
 
         assert_that(
             self.calld_client.applications.list_calls(self.node_app_uuid)['items'],
-            contains(has_entries(id=channel.id, status='Up'))
+            contains_exactly(has_entries(id=channel.id, status='Up'))
         )
 
 
@@ -2149,7 +2149,7 @@ class TestApplicationProgress(BaseApplicationTestCase):
 
         assert_that(
             self.calld_client.applications.list_calls(self.node_app_uuid)['items'],
-            contains(has_entries(id=channel.id, status='Progress'))
+            contains_exactly(has_entries(id=channel.id, status='Progress'))
         )
 
     def test_progress_stop(self):
@@ -2204,7 +2204,7 @@ class TestApplicationProgress(BaseApplicationTestCase):
 
         assert_that(
             self.calld_client.applications.list_calls(self.node_app_uuid)['items'],
-            contains(has_entries(id=channel.id, status='Ring'))
+            contains_exactly(has_entries(id=channel.id, status='Ring'))
         )
 
 
@@ -2238,7 +2238,7 @@ class TestApplicationNode(BaseApplicationTestCase):
             node,
             has_entries(
                 uuid=uuid_(),
-                calls=contains(
+                calls=contains_exactly(
                     has_entries(id=channel.id),
                 )
             )
@@ -2269,7 +2269,7 @@ class TestApplicationNode(BaseApplicationTestCase):
                                 application_uuid=self.no_node_app_uuid,
                                 node=has_entries(
                                     uuid=node['uuid'],
-                                    calls=contains(has_entries(id=channel.id)),
+                                    calls=contains_exactly(has_entries(id=channel.id)),
                                 )
                             )
                         ),
@@ -2320,7 +2320,7 @@ class TestApplicationNode(BaseApplicationTestCase):
             node,
             has_entries(
                 uuid=uuid_(),
-                calls=contains(
+                calls=contains_exactly(
                     has_entries(id=channel.id),
                 )
             )
@@ -2361,7 +2361,7 @@ class TestApplicationNode(BaseApplicationTestCase):
                             data=has_entries(
                                 node=has_entries(
                                     uuid=node['uuid'],
-                                    calls=contains(has_entries(id=channel.id)),
+                                    calls=contains_exactly(has_entries(id=channel.id)),
                                 ),
                             ),
                         ),
@@ -2662,7 +2662,7 @@ class TestApplicationNodeCall(BaseApplicationTestCase):
                                 application_uuid=self.no_node_app_uuid,
                                 node=has_entries(
                                     uuid=node_1['uuid'],
-                                    calls=contains(
+                                    calls=contains_exactly(
                                         has_entries(id=channel_1.id),
                                         has_entries(id=channel_3.id),
                                     )

--- a/integration_tests/suite/test_calls.py
+++ b/integration_tests/suite/test_calls.py
@@ -7,7 +7,7 @@ import json
 from hamcrest import (
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     contains_string,
     empty,
@@ -58,7 +58,7 @@ class TestListCalls(IntegrationTest):
     def test_given_no_calls_when_list_calls_then_empty_list(self):
         calls = self.calld_client.calls.list_calls()
 
-        assert_that(calls, has_entries(items=contains()))
+        assert_that(calls, has_entries(items=contains_exactly()))
 
     def test_given_some_calls_with_user_id_when_list_calls_then_calls_are_complete(self):
         self.ari.set_channels(MockChannel(id='first-id',
@@ -217,7 +217,7 @@ class TestListCalls(IntegrationTest):
             application_instance='appX',
         )
 
-        assert_that(calls, has_entries(items=contains(
+        assert_that(calls, has_entries(items=contains_exactly(
             has_entries(call_id='first-id'),
         )))
 
@@ -252,7 +252,7 @@ class TestUserListCalls(IntegrationTest):
         calld_client = self.make_user_calld(user_uuid)
         calls = calld_client.calls.list_calls_from_user()
 
-        assert_that(calls, has_entries(items=contains()))
+        assert_that(calls, has_entries(items=contains_exactly()))
 
     def test_given_some_calls_with_user_id_when_list_my_calls_then_calls_are_filtered_by_user(self):
         user_uuid = 'user-uuid'
@@ -412,7 +412,7 @@ class TestGetCall(IntegrationTest):
             user_uuid='user1-uuid',
             status='Up',
             talking_to={'second-id': 'user2-uuid'},
-            bridges=contains('bridge-id'),
+            bridges=contains_exactly('bridge-id'),
             creation_time='first-time',
             caller_id_name='Weber',
             caller_id_number='4185559999',

--- a/integration_tests/suite/test_conferences.py
+++ b/integration_tests/suite/test_conferences.py
@@ -7,7 +7,7 @@ import os
 from hamcrest import (
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     has_entries,
@@ -582,7 +582,7 @@ class TestConferenceParticipants(TestConferences):
             participants = self.calld_client.conferences.list_participants(conference_id)
             assert_that(participants, has_entries({
                 'total': 1,
-                'items': contains(has_entry('muted', True))
+                'items': contains_exactly(has_entry('muted', True))
             }))
         until.assert_(participant_is_muted, timeout=10, message='Participant was not muted')
 
@@ -592,7 +592,7 @@ class TestConferenceParticipants(TestConferences):
             participants = self.calld_client.conferences.list_participants(conference_id)
             assert_that(participants, has_entries({
                 'total': 1,
-                'items': contains(has_entry('muted', False))
+                'items': contains_exactly(has_entry('muted', False))
             }))
         until.assert_(participant_is_not_muted, timeout=10, message='Participant is still muted')
 

--- a/integration_tests/suite/test_meetings.py
+++ b/integration_tests/suite/test_meetings.py
@@ -8,7 +8,7 @@ import uuid
 from hamcrest import (
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     has_entries,
@@ -682,7 +682,7 @@ class TestMeetingParticipants(TestMeetings):
             participants = self.calld_client.meetings.list_participants(meeting_uuid)
             assert_that(participants, has_entries({
                 'total': 1,
-                'items': contains(has_entry('muted', True))
+                'items': contains_exactly(has_entry('muted', True))
             }))
         until.assert_(participant_is_muted, timeout=10, message='Participant was not muted')
 
@@ -692,7 +692,7 @@ class TestMeetingParticipants(TestMeetings):
             participants = self.calld_client.meetings.list_participants(meeting_uuid)
             assert_that(participants, has_entries({
                 'total': 1,
-                'items': contains(has_entry('muted', False))
+                'items': contains_exactly(has_entry('muted', False))
             }))
         until.assert_(participant_is_not_muted, timeout=10, message='Participant is still muted')
 

--- a/integration_tests/suite/test_relocates.py
+++ b/integration_tests/suite/test_relocates.py
@@ -6,7 +6,7 @@ import uuid
 
 from hamcrest import assert_that
 from hamcrest import calling
-from hamcrest import contains
+from hamcrest import contains_exactly
 from hamcrest import contains_inanyorder
 from hamcrest import empty
 from hamcrest import has_entry
@@ -204,7 +204,7 @@ class TestListUserRelocate(TestRelocates):
 
         result = calld_client.relocates.list_from_user()
 
-        assert_that(result['items'], contains({
+        assert_that(result['items'], contains_exactly({
             'uuid': relocate['uuid'],
             'relocated_call': relocate['relocated_call'],
             'initiator_call': relocate['initiator_call'],
@@ -221,7 +221,7 @@ class TestListUserRelocate(TestRelocates):
 
         relocates = calld_client.relocates.list_from_user()
 
-        assert_that(relocates['items'], not_(contains(has_entry('uuid', relocate['uuid']))))
+        assert_that(relocates['items'], not_(contains_exactly(has_entry('uuid', relocate['uuid']))))
 
     def test_given_two_relocates_when_list_then_relocates_are_filtered_by_user(self):
         relocate1, user_uuid1, _, __ = self.given_ringing_user_relocate()
@@ -230,7 +230,7 @@ class TestListUserRelocate(TestRelocates):
 
         result = user2_calld_client.relocates.list_from_user()
 
-        assert_that(result['items'], contains(has_entries({
+        assert_that(result['items'], contains_exactly(has_entries({
             'uuid': relocate2['uuid'],
         })))
 
@@ -433,7 +433,7 @@ class TestCreateUserRelocate(TestRelocates):
         def relocate_events_received():
             assert_that(
                 events.accumulate(with_headers=True),
-                contains(
+                contains_exactly(
                     has_entries(
                         message=has_entries({
                             'name': 'relocate_initiated',
@@ -506,7 +506,7 @@ class TestCreateUserRelocate(TestRelocates):
         def relocate_events_received():
             assert_that(
                 events.accumulate(with_headers=True),
-                contains(
+                contains_exactly(
                     has_entries(
                         message=has_entries({
                             'name': 'relocate_initiated',

--- a/integration_tests/suite/test_switchboards.py
+++ b/integration_tests/suite/test_switchboards.py
@@ -12,7 +12,7 @@ from ari.exceptions import (
 from hamcrest import (
     any_of,
     assert_that,
-    contains,
+    contains_exactly,
     contains_string,
     contains_inanyorder,
     empty,
@@ -208,7 +208,7 @@ class TestSwitchboardCallsQueued(TestSwitchboards):
                             'name': 'switchboard_queued_calls_updated',
                             'data': has_entries({
                                 'switchboard_uuid': switchboard_uuid,
-                                'items': contains(has_entry(
+                                'items': contains_exactly(has_entry(
                                     'id', new_channel.id,
                                 )),
                             })
@@ -241,7 +241,7 @@ class TestSwitchboardCallsQueued(TestSwitchboards):
         def event_received():
             assert_that(
                 bus_events.accumulate(with_headers=True),
-                contains(
+                contains_exactly(
                     has_entries(
                         message=has_entries({
                             'name': 'switchboard_queued_calls_updated',
@@ -889,13 +889,13 @@ class TestSwitchboardHoldCall(TestSwitchboards):
         def event_received():
             assert_that(
                 held_bus_events.accumulate(with_headers=True),
-                contains(
+                contains_exactly(
                     has_entries(
                         message=has_entries({
                             'name': 'switchboard_held_calls_updated',
                             'data': has_entries({
                                 'switchboard_uuid': switchboard_uuid,
-                                'items': contains(
+                                'items': contains_exactly(
                                     has_entry('id', queued_call_id)
                                 ),
                             })
@@ -1086,7 +1086,7 @@ class TestSwitchboardCallsHeld(TestSwitchboards):
         def event_received():
             assert_that(
                 held_bus_events.accumulate(with_headers=True),
-                contains(
+                contains_exactly(
                     has_entries(
                         message=has_entries({
                             'name': 'switchboard_held_calls_updated',

--- a/integration_tests/suite/test_transfers.py
+++ b/integration_tests/suite/test_transfers.py
@@ -8,7 +8,7 @@ from hamcrest import all_of
 from hamcrest import anything
 from hamcrest import assert_that
 from hamcrest import calling
-from hamcrest import contains
+from hamcrest import contains_exactly
 from hamcrest import contains_inanyorder
 from hamcrest import contains_string
 from hamcrest import equal_to
@@ -418,7 +418,7 @@ class TestUserListTransfers(TestTransfers):
 
         result = self.calld.list_my_transfers(token)
 
-        assert_that(result['items'], contains({
+        assert_that(result['items'], contains_exactly({
             'id': transfer_id,
             'initiator_uuid': user_uuid,
             'initiator_tenant_uuid': VALID_TENANT,
@@ -438,7 +438,7 @@ class TestUserListTransfers(TestTransfers):
 
         result = self.calld.list_my_transfers(token)
 
-        assert_that(result['items'], contains(has_entries({
+        assert_that(result['items'], contains_exactly(has_entries({
             'id': transfer1_id,
             'initiator_uuid': user_uuid,
         })))
@@ -742,7 +742,7 @@ class TestCreateTransfer(TestTransfers):
         response1 = self.calld.post_transfer_result(body1, VALID_TOKEN)
         response2 = self.calld.post_transfer_result(body2, VALID_TOKEN)
 
-        assert_that((response1.status_code, response2.status_code), contains(201, 201))
+        assert_that((response1.status_code, response2.status_code), contains_exactly(201, 201))
 
 
 class TestUserCreateTransfer(TestTransfers):

--- a/integration_tests/suite/test_voicemail.py
+++ b/integration_tests/suite/test_voicemail.py
@@ -7,7 +7,7 @@ import uuid
 from hamcrest import (
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     contains_string,
     equal_to,
     has_entries,
@@ -103,7 +103,7 @@ class TestVoicemails(RealAsteriskIntegrationTest):
             raises(CalldError).matching(has_properties(
                 status_code=400,
                 message=contains_string("Sent data is invalid"),
-                details=has_entry("dest_greeting", contains(
+                details=has_entry("dest_greeting", contains_exactly(
                     has_entries(
                         constraint=has_entry("choices", equal_to(
                             ["unavailable", "busy", "name"]

--- a/integration_tests/suite/test_voicemail.py
+++ b/integration_tests/suite/test_voicemail.py
@@ -13,7 +13,7 @@ from hamcrest import (
     has_entries,
     has_entry,
     has_properties,
-    not_,
+    is_,
 )
 
 from wazo_test_helpers.hamcrest.raises import raises
@@ -62,13 +62,13 @@ class TestVoicemails(RealAsteriskIntegrationTest):
         exists = self.calld_client.voicemails.voicemail_greeting_exists(
             "not-exists", "busy"
         )
-        assert_that(not_(exists))
+        assert_that(exists, is_(False))
 
     def test_voicemail_head_greeting_invalid_greeting(self):
         exists = self.calld_client.voicemails.voicemail_greeting_exists(
             self._voicemail_id, "not-exists"
         )
-        assert_that(not_(exists))
+        assert_that(exists, is_(False))
 
     def test_voicemail_get_greeting_invalid_voicemail(self):
         assert_that(
@@ -120,7 +120,7 @@ class TestVoicemails(RealAsteriskIntegrationTest):
         exists = self.calld_client.voicemails.voicemail_greeting_from_user_exists(
             "not-exists"
         )
-        assert_that(not_(exists))
+        assert_that(exists, is_(False))
 
     def test_voicemail_get_greeting_invalid_greeting_from_user(self):
         assert_that(
@@ -162,7 +162,7 @@ class TestVoicemails(RealAsteriskIntegrationTest):
         exists = self.calld_client.voicemails.voicemail_greeting_exists(
             self._voicemail_id, "busy"
         )
-        assert_that(not_(exists))
+        assert_that(exists, is_(False))
 
     def test_voicemail_get_unset_greeting(self):
         assert_that(
@@ -180,7 +180,7 @@ class TestVoicemails(RealAsteriskIntegrationTest):
         exists = self.calld_client.voicemails.voicemail_greeting_from_user_exists(
             "busy"
         )
-        assert_that(not_(exists))
+        assert_that(exists, is_(False))
 
     def test_voicemail_get_unset_greeting_from_user(self):
         assert_that(

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
 https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip
 mock
-pyhamcrest<1.10 # Version 1.10 is broken
+pyhamcrest
 pytest

--- a/wazo_calld/plugins/conferences/tests/test_notifier.py
+++ b/wazo_calld/plugins/conferences/tests/test_notifier.py
@@ -1,9 +1,9 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     empty,
 )
 from unittest import TestCase
@@ -28,7 +28,7 @@ class TestNotifierParticipantsValidUserUUIDs(TestCase):
 
         result = participants.valid_user_uuids()
 
-        assert_that(result, contains('uuid1', 'uuid2'))
+        assert_that(result, contains_exactly('uuid1', 'uuid2'))
 
     def test_same_participant(self):
         participants = Participants(
@@ -38,7 +38,7 @@ class TestNotifierParticipantsValidUserUUIDs(TestCase):
 
         result = participants.valid_user_uuids()
 
-        assert_that(result, contains('uuid1'))
+        assert_that(result, contains_exactly('uuid1'))
 
     def test_participant_without_user_uuid(self):
         participants = Participants(
@@ -48,4 +48,4 @@ class TestNotifierParticipantsValidUserUUIDs(TestCase):
 
         result = participants.valid_user_uuids()
 
-        assert_that(result, contains('uuid1'))
+        assert_that(result, contains_exactly('uuid1'))

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -11,7 +11,7 @@ from mock import (
 )
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     empty,
     equal_to,
     has_items,
@@ -107,14 +107,14 @@ class TestGetContacts(DialerTestCase):
 
         result = self.poller._get_contacts(self.channel_id, self.aor)
 
-        assert_that(result, contains('contact1'))
+        assert_that(result, contains_exactly('contact1'))
 
     def test_multiple_values(self):
         self.ari.channels.getChannelVar.return_value = {'value': 'contact1&contact2&contact3'}
 
         result = self.poller._get_contacts(self.channel_id, self.aor)
 
-        assert_that(result, contains('contact1', 'contact2', 'contact3'))
+        assert_that(result, contains_exactly('contact1', 'contact2', 'contact3'))
 
 
 class TestRemoveUnansweredChannels(DialerTestCase):

--- a/wazo_calld/plugins/voicemails/tests/test_storage.py
+++ b/wazo_calld/plugins/voicemails/tests/test_storage.py
@@ -1,11 +1,11 @@
-# Copyright 2016-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from mock import Mock
 from io import BytesIO
 from hamcrest import assert_that
 from hamcrest import calling
-from hamcrest import contains
+from hamcrest import contains_exactly
 from hamcrest import empty
 from hamcrest import equal_to
 from hamcrest import has_key
@@ -140,7 +140,7 @@ class TestVoicemailMessagesCache(TestCase):
 
         diff = self.cache.get_diff(self.number, self.context)
 
-        assert_that(diff.created_messages, contains(self.message_info1))
+        assert_that(diff.created_messages, contains_exactly(self.message_info1))
         assert_that(diff.updated_messages, empty())
         assert_that(diff.deleted_messages, empty())
 
@@ -157,7 +157,7 @@ class TestVoicemailMessagesCache(TestCase):
         diff = self.cache.get_diff(self.number, self.context)
 
         assert_that(diff.created_messages, empty())
-        assert_that(diff.updated_messages, contains(self.message_info2))
+        assert_that(diff.updated_messages, contains_exactly(self.message_info2))
         assert_that(diff.deleted_messages, empty())
 
     def test_diff_when_message_deleted(self):
@@ -172,7 +172,7 @@ class TestVoicemailMessagesCache(TestCase):
 
         assert_that(diff.created_messages, empty())
         assert_that(diff.updated_messages, empty())
-        assert_that(diff.deleted_messages, contains(self.message_info1))
+        assert_that(diff.deleted_messages, contains_exactly(self.message_info1))
 
     def test_diff_twice_in_a_row(self):
         self.storage.get_voicemail_info.return_value = {
@@ -184,7 +184,7 @@ class TestVoicemailMessagesCache(TestCase):
         diff1 = self.cache.get_diff(self.number, self.context)
         diff2 = self.cache.get_diff(self.number, self.context)
 
-        assert_that(diff1.created_messages, contains(self.message_info1))
+        assert_that(diff1.created_messages, contains_exactly(self.message_info1))
         assert_that(diff2.created_messages, empty())
 
     def test_cache_cleanup(self):


### PR DESCRIPTION
## voicemail tests: fix wrong assertion

Why:

* pytest raised a warning about the assertion not being complete

## integration tests: remove warnings about hamcrest.contains