### PR TITLE
integration tests: use 127.0.0.1 for docker address

### DIFF
--- a/integration_tests/suite/test_push_mobile.py
+++ b/integration_tests/suite/test_push_mobile.py
@@ -22,7 +22,7 @@ class TestPushMobile(RealAsteriskIntegrationTest):
     def setUp(self):
         super().setUp()
         self.amid = AmidClient(
-            'localhost',
+            '127.0.0.1',
             port=self.service_port(9491, 'amid'),
             https=False,
             prefix=None,


### PR DESCRIPTION
Why:

* if localhost resolves to IPv6, the wrong port will be used in
integration tests