### PR TITLE
tests: don't stop upon failure

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -21,6 +21,6 @@ egg-info:
 	cd .. && python setup.py egg_info
 
 test:
-	pytest -x
+	pytest
 
 .PHONY: test-setup build-calld build-ari egg-info test


### PR DESCRIPTION
Why:

* We now have logs of containers in the CI, so there is no need to keep
the container to inspect logs.
* We want to know how many tests are failing