### PR TITLE
test: use mock from unittest library

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
 https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip
-mock
 pyhamcrest
 pytest

--- a/wazo_calld/plugin_helpers/tests/test_ami_helpers.py
+++ b/wazo_calld/plugin_helpers/tests/test_ami_helpers.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import requests
@@ -7,7 +7,7 @@ from hamcrest import assert_that
 from hamcrest import calling
 from hamcrest import is_
 from hamcrest import raises
-from mock import Mock
+from unittest.mock import Mock
 from unittest import TestCase
 
 from ..ami import extension_exists

--- a/wazo_calld/plugin_helpers/tests/test_ari_helpers.py
+++ b/wazo_calld/plugin_helpers/tests/test_ari_helpers.py
@@ -1,8 +1,8 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
-from mock import (
+from unittest.mock import (
     Mock,
     sentinel as s,
 )

--- a/wazo_calld/plugin_helpers/tests/test_confd.py
+++ b/wazo_calld/plugin_helpers/tests/test_confd.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import requests
@@ -9,7 +9,7 @@ from hamcrest import (
     equal_to,
     raises,
 )
-from mock import Mock
+from unittest.mock import Mock
 from unittest import TestCase
 
 from ..confd import Line

--- a/wazo_calld/plugins/applications/tests/test_stasis.py
+++ b/wazo_calld/plugins/applications/tests/test_stasis.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
@@ -8,7 +8,7 @@ from hamcrest import (
     calling,
     not_,
 )
-from mock import (
+from unittest.mock import (
     Mock,
     patch,
     sentinel as s,

--- a/wazo_calld/plugins/calls/tests/test_event.py
+++ b/wazo_calld/plugins/calls/tests/test_event.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ari.exceptions import ARINotFound
@@ -7,8 +7,8 @@ from hamcrest import calling
 from hamcrest import equal_to
 from hamcrest import is_
 from hamcrest import raises
-from mock import Mock
-from mock import sentinel as s
+from unittest.mock import Mock
+from unittest.mock import sentinel as s
 from unittest import TestCase
 
 from ..exceptions import InvalidCallEvent

--- a/wazo_calld/plugins/calls/tests/test_services.py
+++ b/wazo_calld/plugins/calls/tests/test_services.py
@@ -1,7 +1,7 @@
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from hamcrest import assert_that, equal_to
-from mock import Mock
+from unittest.mock import Mock
 from unittest import TestCase
 
 from ..services import CallsService

--- a/wazo_calld/plugins/calls/tests/test_state.py
+++ b/wazo_calld/plugins/calls/tests/test_state.py
@@ -1,11 +1,11 @@
-# Copyright 2016 by Avencall
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that
 from hamcrest import calling
 from hamcrest import instance_of
 from hamcrest import raises
-from mock import Mock
+from unittest.mock import Mock
 from unittest import TestCase
 
 from ..state import CallState

--- a/wazo_calld/plugins/calls/tests/test_state_persistor.py
+++ b/wazo_calld/plugins/calls/tests/test_state_persistor.py
@@ -1,4 +1,4 @@
-# Copyright 2016 by Avencall
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -10,8 +10,8 @@ from hamcrest import equal_to
 from hamcrest import has_property
 from hamcrest import is_not
 from hamcrest import raises
-from mock import Mock
-from mock import sentinel as s
+from unittest.mock import Mock
+from unittest.mock import sentinel as s
 from unittest import TestCase
 
 from ..state_persistor import ChannelCacheEntry

--- a/wazo_calld/plugins/conferences/tests/test_bus_consume.py
+++ b/wazo_calld/plugins/conferences/tests/test_bus_consume.py
@@ -1,10 +1,10 @@
-# Copyright 2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
 from uuid import uuid4
 from hamcrest import assert_that, is_, none
-from mock import patch
+from unittest.mock import patch
 from ..bus_consume import ConferencesBusEventHandler
 
 

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -4,7 +4,7 @@
 from unittest import TestCase
 import requests
 
-from mock import (
+from unittest.mock import (
     Mock,
     patch,
     sentinel as s,

--- a/wazo_calld/plugins/dial_mobile/tests/test_stasis.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_stasis.py
@@ -1,9 +1,9 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
 
-from mock import (
+from unittest.mock import (
     Mock,
     sentinel as s,
 )

--- a/wazo_calld/plugins/meetings/tests/test_bus_consume.py
+++ b/wazo_calld/plugins/meetings/tests/test_bus_consume.py
@@ -1,10 +1,10 @@
-# Copyright 2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
 from uuid import uuid4
 from hamcrest import assert_that, is_, none
-from mock import patch
+from unittest.mock import patch
 from ..bus_consume import MeetingsBusEventHandler
 
 

--- a/wazo_calld/plugins/relocates/tests/test_relocate.py
+++ b/wazo_calld/plugins/relocates/tests/test_relocate.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -9,7 +9,7 @@ from hamcrest import (
     is_,
     none,
 )
-from mock import Mock
+from unittest.mock import Mock
 from unittest import TestCase
 from wazo_test_helpers.hamcrest.raises import raises
 from wazo_test_helpers.hamcrest.has_callable import has_callable

--- a/wazo_calld/plugins/relocates/tests/test_services.py
+++ b/wazo_calld/plugins/relocates/tests/test_services.py
@@ -1,8 +1,8 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
-from mock import (
+from unittest.mock import (
     Mock,
     sentinel as s,
 )

--- a/wazo_calld/plugins/switchboards/tests/test_confd_client_cache.py
+++ b/wazo_calld/plugins/switchboards/tests/test_confd_client_cache.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -7,7 +7,7 @@ from hamcrest import (
     calling,
     raises,
 )
-from mock import Mock
+from unittest.mock import Mock
 from unittest import TestCase
 
 from ..confd_client_cache import ConfdClientGetUUIDCacheDecorator

--- a/wazo_calld/plugins/transfers/tests/test_ari_helpers.py
+++ b/wazo_calld/plugins/transfers/tests/test_ari_helpers.py
@@ -1,11 +1,11 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that
 from hamcrest import is_
-from mock import Mock
-from mock import patch
-from mock import sentinel
+from unittest.mock import Mock
+from unittest.mock import patch
+from unittest.mock import sentinel
 from unittest import TestCase
 
 from wazo_calld.plugin_helpers.exceptions import WazoAmidError

--- a/wazo_calld/plugins/voicemails/tests/test_storage.py
+++ b/wazo_calld/plugins/voicemails/tests/test_storage.py
@@ -1,7 +1,7 @@
 # Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from mock import Mock
+from unittest.mock import Mock
 from io import BytesIO
 from hamcrest import assert_that
 from hamcrest import calling


### PR DESCRIPTION
why: pypi version is a backport if the python3 builtin package