### PR TITLE
jenkins: build docker image without cache

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
     }
     stage('Docker build') {
       steps {
-        sh "docker build -t wazoplatform/${JOB_NAME}:latest ."
+        sh "docker build --no-cache -t wazoplatform/${JOB_NAME}:latest ."
       }
     }
     stage('Docker publish') {


### PR DESCRIPTION
Why:

* When updating a Wazo lib (xivo-bus, lib-python, etc.), the docker cache will
  skip installing the new version of the lib because the requirements.txt file
  does not change
* This results in a broken Docker image that does not start or with broken
  plugins
