### PR TITLE
mock: check responses and raise on error

### DIFF
--- a/integration_tests/suite/helpers/amid.py
+++ b/integration_tests/suite/helpers/amid.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import requests
@@ -26,7 +26,8 @@ class AmidClient:
             return False
 
     def set_action_result(self, result):
-        requests.post(self.url('_set_action'), json=result)
+        response = requests.post(self.url('_set_action'), json=result)
+        response.raise_for_status()
 
     def set_no_valid_exten(self):
         result = []
@@ -34,12 +35,16 @@ class AmidClient:
 
     def set_valid_exten(self, context, exten, priority='1'):
         body = {'context': context, 'exten': exten, 'priority': priority}
-        requests.post(self.url('_set_valid_exten'), json=body)
+        response = requests.post(self.url('_set_valid_exten'), json=body)
+        response.raise_for_status()
 
     def reset(self):
         url = self.url('_reset')
-        requests.post(url)
+        response = requests.post(url)
+        response.raise_for_status()
 
     def requests(self):
         url = self.url('_requests')
-        return requests.get(url).json()
+        response = requests.get(url)
+        response.raise_for_status()
+        return response.json()

--- a/integration_tests/suite/helpers/ari_.py
+++ b/integration_tests/suite/helpers/ari_.py
@@ -27,55 +27,67 @@ class ARIClient:
         url = self.url('_set_response')
         body = {'response': 'applications',
                 'content': {application.name(): application.to_dict() for application in mock_applications}}
-        requests.post(url, json=body)
+        response = requests.post(url, json=body)
+        response.raise_for_status()
 
     def set_channels(self, *mock_channels):
         url = self.url('_set_response')
         body = {'response': 'channels',
                 'content': {channel.id_(): channel.to_dict() for channel in mock_channels}}
-        requests.post(url, json=body)
+        response = requests.post(url, json=body)
+        response.raise_for_status()
 
     def set_bridges(self, *mock_bridges):
         url = self.url('_set_response')
         body = {'response': 'bridges',
                 'content': {bridge.id_(): bridge.to_dict() for bridge in mock_bridges}}
-        requests.post(url, json=body)
+        response = requests.post(url, json=body)
+        response.raise_for_status()
 
     def set_endpoints(self, *mock_endpoints):
         url = self.url('_set_response')
         body = {'response': 'endpoints',
                 'content': [endpoint.to_dict() for endpoint in mock_endpoints]}
-        requests.post(url, json=body)
+        response = requests.post(url, json=body)
+        response.raise_for_status()
 
     def set_originates(self, *mock_channels):
         url = self.url('_set_response')
         body = {'response': 'originates',
                 'content': [channel.to_dict() for channel in mock_channels]}
-        requests.post(url, json=body)
+        response = requests.post(url, json=body)
+        response.raise_for_status()
 
     def set_channel_variable(self, variables):
         url = self.url('_set_response')
         body = {'response': 'channel_variables',
                 'content': variables}
-        requests.post(url, json=body)
+        response = requests.post(url, json=body)
+        response.raise_for_status()
 
     def set_global_variables(self, variables):
         url = self.url('_set_response')
         body = {'response': 'global_variables',
                 'content': variables}
-        requests.post(url, json=body)
+        response = requests.post(url, json=body)
+        response.raise_for_status()
 
     def reset(self):
         url = self.url('_reset')
-        requests.post(url)
+        response = requests.post(url)
+        response.raise_for_status()
 
     def requests(self):
         url = self.url('_requests')
-        return requests.get(url).json()
+        response = requests.get(url)
+        response.raise_for_status()
+        return response.json()
 
     def websockets(self):
         url = self.url('_websockets')
-        return requests.get(url).json()
+        response = requests.get(url)
+        response.raise_for_status()
+        return response.json()
 
 
 class MockApplication:

--- a/integration_tests/suite/helpers/auth.py
+++ b/integration_tests/suite/helpers/auth.py
@@ -19,11 +19,13 @@ class AuthClient:
 
     def set_token(self, token):
         url = self.url('_set_token')
-        requests.post(url, json=token.to_dict())
+        response = requests.post(url, json=token.to_dict())
+        response.raise_for_status()
 
     def set_refresh_tokens(self, refresh_tokens):
         url = self.url('_set_refresh_tokens')
-        requests.post(url, json=refresh_tokens)
+        response = requests.post(url, json=refresh_tokens)
+        response.raise_for_status()
 
 
 class MockUserToken:

--- a/integration_tests/suite/helpers/confd.py
+++ b/integration_tests/suite/helpers/confd.py
@@ -30,19 +30,22 @@ class ConfdClient:
         body = {'response': 'applications',
                 'content': {app.uuid(): app.to_dict() for app in mock_applications}}
 
-        requests.post(url, json=body)
+        response = requests.post(url, json=body)
+        response.raise_for_status()
 
     def set_users(self, *mock_users):
         url = self.url('_set_response')
         body = {'response': 'users',
                 'content': {user.uuid(): user.to_dict() for user in mock_users}}
-        requests.post(url, json=body)
+        response = requests.post(url, json=body)
+        response.raise_for_status()
 
     def set_lines(self, *mock_lines):
         url = self.url('_set_response')
         body = {'response': 'lines',
                 'content': {line.id_(): line.to_dict() for line in mock_lines}}
-        requests.post(url, json=body)
+        response = requests.post(url, json=body)
+        response.raise_for_status()
 
     def set_user_lines(self, set_user_lines):
         content = {}
@@ -52,7 +55,8 @@ class ConfdClient:
         url = self.url('_set_response')
         body = {'response': 'user_lines',
                 'content': content}
-        requests.post(url, json=body)
+        response = requests.post(url, json=body)
+        response.raise_for_status()
 
     def set_user_voicemails(self, set_user_voicemails):
         content = {}
@@ -62,14 +66,16 @@ class ConfdClient:
         url = self.url('_set_response')
         body = {'response': 'user_voicemails',
                 'content': content}
-        requests.post(url, json=body)
+        response = requests.post(url, json=body)
+        response.raise_for_status()
 
     def set_switchboards(self, *mock_switchboards):
         url = self.url('_set_response')
         body = {'response': 'switchboards',
                 'content': {switchboard.uuid(): switchboard.to_dict() for switchboard in mock_switchboards}}
 
-        requests.post(url, json=body)
+        response = requests.post(url, json=body)
+        response.raise_for_status()
 
     def set_switchboard_fallbacks(self, *mock_switchboard_fallbacks):
         url = self.url('_set_response')
@@ -79,28 +85,32 @@ class ConfdClient:
                     for switchboard_fallback in mock_switchboard_fallbacks
                 }}
 
-        requests.post(url, json=body)
+        response = requests.post(url, json=body)
+        response.raise_for_status()
 
     def set_conferences(self, *mock_conferences):
         url = self.url('_set_response')
         body = {'response': 'conferences',
                 'content': {conference.id(): conference.to_dict() for conference in mock_conferences}}
 
-        requests.post(url, json=body)
+        response = requests.post(url, json=body)
+        response.raise_for_status()
 
     def set_meetings(self, *mock_meetings):
         url = self.url('_set_response')
         body = {'response': 'meetings',
                 'content': {meeting.uuid(): meeting.to_dict() for meeting in mock_meetings}}
 
-        requests.post(url, json=body)
+        response = requests.post(url, json=body)
+        response.raise_for_status()
 
     def set_moh(self, *mock_mohs):
         url = self.url('_set_response')
         body = {'response': 'moh',
                 'content': {moh.uuid(): moh.to_dict() for moh in mock_mohs}}
 
-        requests.post(url, json=body)
+        response = requests.post(url, json=body)
+        response.raise_for_status()
 
     def set_trunks(self, *mock_trunks):
         url = self.url('_set_response')
@@ -109,21 +119,26 @@ class ConfdClient:
             'content': {trunk.id(): trunk.to_dict() for trunk in mock_trunks},
         }
 
-        requests.post(url, json=body)
+        response = requests.post(url, json=body)
+        response.raise_for_status()
 
     def set_voicemails(self, *mock_voicemails):
         url = self.url('_set_response')
         body = {'response': 'voicemails',
                 'content': {voicemail.id(): voicemail.to_dict() for voicemail in mock_voicemails}}
-        requests.post(url, json=body)
+        response = requests.post(url, json=body)
+        response.raise_for_status()
 
     def reset(self):
         url = self.url('_reset')
-        requests.post(url)
+        response = requests.post(url)
+        response.raise_for_status()
 
     def requests(self):
         url = self.url('_requests')
-        return requests.get(url).json()
+        response = requests.get(url)
+        response.raise_for_status()
+        return response.json()
 
 
 class MockApplication:

--- a/integration_tests/suite/helpers/phoned.py
+++ b/integration_tests/suite/helpers/phoned.py
@@ -1,4 +1,4 @@
-# Copyright 2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import requests
@@ -19,8 +19,11 @@ class PhonedClient:
 
     def reset(self):
         url = self.url('_reset')
-        requests.post(url)
+        response = requests.post(url)
+        response.raise_for_status()
 
     def requests(self):
         url = self.url('_requests')
-        return requests.get(url).json()
+        response = requests.get(url)
+        response.raise_for_status()
+        return response.json()


### PR DESCRIPTION
This change will not change anything. The goal is to make HTTP errors raise exception during tests instead of failing silently.
When trying to figure out what happened I need to look at the logs trying to find the matching timestamp to view the query result from the remote service to know the result.