### PR TITLE
test: add sleep before restarting calld

### DIFF
--- a/integration_tests/suite/test_collectd.py
+++ b/integration_tests/suite/test_collectd.py
@@ -1,6 +1,8 @@
 # Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import time
+
 from hamcrest import assert_that
 from hamcrest import has_item
 from hamcrest import matches_regexp
@@ -204,7 +206,7 @@ class TestCollectdCalldRestart(IntegrationTest):
             stasis_app=STASIS_APP,
             stasis_app_instance=STASIS_APP_INSTANCE,
         )
-
+        time.sleep(1)  # wait for calld to write channel state on ari
         self.restart_service('calld')
         self.reset_clients()
         CalldEverythingOkWaitStrategy().wait(self)  # wait for calld to reconnect to rabbitmq


### PR DESCRIPTION
why: We need to wait until the StasisStart event is process before
shutdown calld. The process will write channel state on the channel to
be able to retrieve this state after a restart