### PR TITLE
requirements: use digium release for swagger-py

### DIFF
--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -1,4 +1,4 @@
-https://github.com/rsichny/swagger-py/archive/master.zip  # the digium release does not support python3
+https://github.com/digium/swagger-py/archive/master.zip  # Python 3 support has not been released into a version
 https://github.com/wazo-platform/ari-py/archive/0.4.0.zip
 https://github.com/wazo-platform/wazo-lib-rest-client/archive/master.zip
 https://github.com/wazo-platform/wazo-calld-client/archive/master.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-https://github.com/rsichny/swagger-py/archive/master.zip  # the digium release does not support python3
+https://github.com/digium/swagger-py/archive/master.zip  # Python 3 support has not been released into a version
 https://github.com/wazo-platform/ari-py/archive/master.zip
 https://github.com/wazo-platform/wazo-lib-rest-client/archive/master.zip
 https://github.com/wazo-platform/wazo-amid-client/archive/master.zip


### PR DESCRIPTION
why: A commit to support Python 3 has been accepted in upstream repo in
2019. But no version has been released