### PR TITLE
test_calls_stasis: wait for bus before starting the test

### DIFF
--- a/integration_tests/suite/test_calls_stasis.py
+++ b/integration_tests/suite/test_calls_stasis.py
@@ -24,12 +24,14 @@ from .helpers.constants import (
 from .helpers.calld import new_call_id
 from .helpers.confd import MockLine, MockUser
 from .helpers.hamcrest_ import a_timestamp
+from .helpers.wait_strategy import CalldConnectionsOkWaitStrategy
 
 STASIS_APP = 'callcontrol'
 
 
 class TestDialedFrom(IntegrationTest):
     asset = 'basic_rest'
+    wait_strategy = CalldConnectionsOkWaitStrategy()
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Why:

* Now that stasis uses the bus, we need to wait for the bus