### PR TITLE
handle error: remove traceback

### DIFF
--- a/wazo_calld/plugins/calls/bus_consume.py
+++ b/wazo_calld/plugins/calls/bus_consume.py
@@ -11,6 +11,7 @@ from wazo_calld.plugin_helpers import ami
 from wazo_calld.plugin_helpers.ari_ import Channel, set_channel_id_var_sync
 from wazo_calld.plugin_helpers.exceptions import WazoAmidError
 from .call import Call
+from .exceptions import NoSuchCall
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +125,11 @@ class CallsBusEventHandler:
             return
 
         logger.debug('Relaying to bus: channel %s answered', channel_id)
-        self.services.set_answered_time(channel_id)
+        try:
+            self.services.set_answered_time(channel_id)
+        except NoSuchCall:
+            return
+
         try:
             channel = self.ari.channels.get(channelId=channel_id)
         except ARINotFound:

--- a/wazo_calld/plugins/calls/tests/test_bus_consume.py
+++ b/wazo_calld/plugins/calls/tests/test_bus_consume.py
@@ -1,0 +1,47 @@
+# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from unittest import TestCase
+from unittest.mock import Mock
+
+from hamcrest import assert_that, calling, not_, raises
+
+from ..bus_consume import CallsBusEventHandler
+from ..exceptions import NoSuchCall
+
+
+class TestCallsBusEventHandler(TestCase):
+    def setUp(self):
+        ami = Mock()
+        ari = Mock()
+        collectd = Mock()
+        bus_publisher = Mock()
+        self.services = Mock()
+        xivo_uuid = Mock()
+        dial_echo_manager = Mock()
+        notifier = Mock()
+        self.handler = CallsBusEventHandler(
+            ami,
+            ari,
+            collectd,
+            bus_publisher,
+            self.services,
+            xivo_uuid,
+            dial_echo_manager,
+            notifier,
+        )
+
+    def test_relay_channel_answered_channel_is_gone(self):
+        uniqueid = '123456789.1234'
+        event = {
+            'ChannelStateDesc': 'Up',
+            'Uniqueid': uniqueid,
+            'Channel': 'PJSIP/foobar',
+        }
+
+        self.services.set_answered_time.side_effect = NoSuchCall(uniqueid)
+
+        assert_that(
+            calling(self.handler._relay_channel_answered).with_args(event),
+            not_(raises(Exception)),
+        )


### PR DESCRIPTION
set_answered_time already logs in debug that the channel was not found. we can ignore this event if the channel is already gone