### PR TITLE
remove an empty channel var from test setup

### DIFF
--- a/integration_tests/suite/test_calls.py
+++ b/integration_tests/suite/test_calls.py
@@ -395,7 +395,6 @@ class TestUserListCalls(IntegrationTest):
                 my_call_id: {'XIVO_USERUUID': user_uuid},
                 my_second_call_id: {'XIVO_USERUUID': user_uuid},
                 others_call_id: {'XIVO_USERUUID': 'user2-uuid'},
-                no_user_call_id: {'XIVO_USERUUID': ''},
             }
         )
         self.confd.set_users(MockUser(uuid=user_uuid), MockUser(uuid='user2-uuid'))


### PR DESCRIPTION
the behavior of a getChannelVar when the variable does not exists is a 404 not an empty var

This change detects the bug fixed by https://github.com/wazo-platform/wazo-calld/pull/273