### PR TITLE
tests: wait for Asterisk to be fully booted

### DIFF
--- a/integration_tests/suite/helpers/real_asterisk.py
+++ b/integration_tests/suite/helpers/real_asterisk.py
@@ -15,10 +15,12 @@ from .constants import (
     VALID_TOKEN,
     VALID_TENANT,
 )
+from .wait_strategy import CalldAndAsteriskWaitStrategy
 
 
 class RealAsteriskIntegrationTest(IntegrationTest):
     asset = 'real_asterisk'
+    wait_strategy = CalldAndAsteriskWaitStrategy()
 
     @classmethod
     def setUpClass(cls):

--- a/integration_tests/suite/helpers/wait_strategy.py
+++ b/integration_tests/suite/helpers/wait_strategy.py
@@ -64,3 +64,26 @@ class CalldEverythingOkWaitStrategy(WaitStrategy):
             )
 
         until.assert_(is_ready, tries=60)
+
+
+class AsteriskReadyWaitStrategy(WaitStrategy):
+    def wait(self, integration_test):
+        def is_ready():
+            result = integration_test.docker_exec(
+                ['asterisk', '-rx', 'core waitfullybooted'], service_name='ari'
+            )
+            assert result == b'Asterisk has fully booted.\n'
+
+        until.assert_(is_ready, tries=60)
+
+
+class CalldAndAsteriskWaitStrategy(WaitStrategy):
+    def __init__(self):
+        self._strategies = [
+            AsteriskReadyWaitStrategy(),
+            CalldEverythingOkWaitStrategy(),
+        ]
+
+    def wait(self, integration_test):
+        for strategy in self._strategies:
+            strategy.wait(integration_test)


### PR DESCRIPTION
The calld /status is ready before Asterisk is fully booted. This waits for all modules to be loaded before starting the test