### PR TITLE
transfers: fix transfer failure when processing is slower

### DIFF
--- a/wazo_calld/plugin_helpers/ari_.py
+++ b/wazo_calld/plugin_helpers/ari_.py
@@ -184,6 +184,12 @@ class Channel:
             return None
         return linkedid
 
+    def bridge(self):
+        for bridge in self._ari.bridges.list():
+            if self.id in bridge.json['channels']:
+                return BridgeSnapshot(bridge.json, self._ari)
+        raise BridgeNotFound()
+
     def only_connected_channel(self):
         connected_channels = self.connected_channels()
         if len(connected_channels) > 1:
@@ -417,3 +423,6 @@ class BridgeSnapshot(Bridge):
             Channel(channel_id, self._ari).user()
             for channel_id in self._snapshot['channels']
         }
+
+    def has_only_channel_ids(self, *channel_ids):
+        return set(self._snapshot['channels']) == set(channel_ids)

--- a/wazo_calld/plugin_helpers/ari_.py
+++ b/wazo_calld/plugin_helpers/ari_.py
@@ -5,9 +5,13 @@ import logging
 import time
 import json
 
-from ari.exceptions import ARINotFound, ARINotInStasis
+from ari.exceptions import (
+    ARINotFound,
+    ARINotInStasis,
+)
 
 from .exceptions import (
+    BridgeNotFound,
     NotEnoughChannels,
     TooManyChannels,
 )

--- a/wazo_calld/plugin_helpers/exceptions.py
+++ b/wazo_calld/plugin_helpers/exceptions.py
@@ -4,6 +4,10 @@
 from wazo_calld.exceptions import APIException
 
 
+class BridgeNotFound(Exception):
+    pass
+
+
 class CalldUninitializedError(APIException):
     def __init__(self):
         super().__init__(

--- a/wazo_calld/plugins/transfers/lock.py
+++ b/wazo_calld/plugins/transfers/lock.py
@@ -12,6 +12,12 @@ class InvalidLock(ValueError):
 
 
 class HangupLock:
+    '''
+    Purpose: prevent automatic deletion of a bridge (target) while a channel
+    (source) exists but is not yet in the bridge, such as an originated
+    transfer recipient
+    '''
+
     def __init__(self, ari, source_id, target_id):
         self._source_id = source_id
         self._target_id = target_id
@@ -50,6 +56,16 @@ class HangupLock:
         try:
             source_id = ari_helpers.get_bridge_variable(
                 ari, target_id, 'XIVO_HANGUP_LOCK_SOURCE'
+            )
+        except ARINotFound:
+            raise InvalidLock()
+        return cls(ari, source_id, target_id)
+
+    @classmethod
+    def acquire(cls, ari, source_id, target_id):
+        try:
+            ari_helpers.set_bridge_variable(
+                ari, target_id, 'XIVO_HANGUP_LOCK_SOURCE', source_id
             )
         except ARINotFound:
             raise InvalidLock()

--- a/wazo_calld/plugins/transfers/services.py
+++ b/wazo_calld/plugins/transfers/services.py
@@ -17,7 +17,6 @@ from wazo_calld.plugin_helpers.exceptions import (
     UserPermissionDenied,
 )
 
-from . import ari_helpers
 from .exceptions import (
     NoSuchTransfer,
     TooManyTransferredCandidates,

--- a/wazo_calld/plugins/transfers/services.py
+++ b/wazo_calld/plugins/transfers/services.py
@@ -18,10 +18,13 @@ from wazo_calld.plugin_helpers.exceptions import (
 )
 
 from . import ari_helpers
-from .exceptions import NoSuchTransfer
-from .exceptions import TooManyTransferredCandidates
-from .exceptions import TransferAlreadyStarted
-from .exceptions import TransferCreationError
+from .exceptions import (
+    NoSuchTransfer,
+    TooManyTransferredCandidates,
+    TransferAlreadyStarted,
+    TransferCreationError,
+)
+from .lock import HangupLock, InvalidLock
 from .state import TransferStateReadyNonStasis, TransferStateReady
 
 logger = logging.getLogger(__name__)
@@ -165,10 +168,8 @@ class TransfersService:
         recipient_call = new_channel.id
 
         try:
-            ari_helpers.set_bridge_variable(
-                self.ari, transfer_id, 'XIVO_HANGUP_LOCK_SOURCE', recipient_call
-            )
-        except ARINotFound:
+            HangupLock.acquire(self.ari, recipient_call, transfer_id)
+        except InvalidLock:
             raise TransferCreationError('bridge not found')
 
         return recipient_call

--- a/wazo_calld/plugins/transfers/state.py
+++ b/wazo_calld/plugins/transfers/state.py
@@ -7,6 +7,7 @@ import uuid
 from ari.exceptions import ARINotFound
 
 from wazo_calld.plugin_helpers.ari_ import Channel
+from wazo_calld.plugin_helpers.exceptions import BridgeNotFound
 from . import ari_helpers
 from .exceptions import TransferAnswerError
 from .exceptions import TransferCreationError


### PR DESCRIPTION
Why:

* If event processing is slower, the two stasis channels may not get
  moved to the new bridge before they are hungup by the bridge cleaner.