### PR TITLE
test: wait for wazo-amid to be connected to ami

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -66,7 +66,7 @@ class IntegrationTest(AssetLaunchingTestCase):
     @classmethod
     def reset_clients(cls):
         try:
-            cls.amid = AmidClient('127.0.0.1', cls.service_port(9491, 'amid'))
+            cls.amid = cls.make_amid()
         except (NoSuchService, NoSuchPort) as e:
             logger.debug(e)
             cls.amid = WrongClient('amid')
@@ -132,6 +132,10 @@ class IntegrationTest(AssetLaunchingTestCase):
         except (NoSuchService, NoSuchPort) as e:
             logger.debug(e)
             cls.stasis = WrongClient('stasis')
+
+    @classmethod
+    def make_amid(cls):
+        return AmidClient('127.0.0.1', cls.service_port(9491, 'amid'))
 
     @classmethod
     def make_calld(cls, token=VALID_TOKEN):

--- a/integration_tests/suite/helpers/real_asterisk.py
+++ b/integration_tests/suite/helpers/real_asterisk.py
@@ -4,6 +4,7 @@
 import ari
 from ari.exceptions import ARINotFound
 from ari.exceptions import ARINotInStasis
+from wazo_amid_client import Client as AmidClient
 from wazo_test_helpers import until
 
 from .base import IntegrationTest, make_user_uuid
@@ -26,6 +27,16 @@ class RealAsteriskIntegrationTest(IntegrationTest):
     def setUpClass(cls):
         super().setUpClass()
         cls.chan_test = ChanTest(cls.ari_config())
+
+    @classmethod
+    def make_amid(cls):
+        return AmidClient(
+            '127.0.0.1',
+            cls.service_port(9491, 'amid'),
+            prefix=None,
+            https=False,
+            token=VALID_TOKEN,
+        )
 
     @classmethod
     def ari_config(cls):

--- a/integration_tests/suite/helpers/wait_strategy.py
+++ b/integration_tests/suite/helpers/wait_strategy.py
@@ -77,10 +77,30 @@ class AsteriskReadyWaitStrategy(WaitStrategy):
         until.assert_(is_ready, tries=60)
 
 
+class AmidReadyWaitStrategy(WaitStrategy):
+    def wait(self, integration_test):
+        def is_ready():
+            try:
+                status = integration_test.amid.status()
+            except requests.RequestException:
+                status = {}
+            assert_that(
+                status,
+                has_entries(
+                    {
+                        'ami_socket': has_entry('status', 'ok'),
+                    }
+                ),
+            )
+
+        until.assert_(is_ready, tries=60)
+
+
 class CalldAndAsteriskWaitStrategy(WaitStrategy):
     def __init__(self):
         self._strategies = [
             AsteriskReadyWaitStrategy(),
+            AmidReadyWaitStrategy(),
             CalldEverythingOkWaitStrategy(),
         ]
 


### PR DESCRIPTION
why: if we start tests when wazo-amid is not connected to asterisk,
messages won't be forwarded by this one