### PR TITLE
Pull request for endpoints-plugin-status

### DIFF
--- a/integration_tests/assets/ari_data/mock_ari.py
+++ b/integration_tests/assets/ari_data/mock_ari.py
@@ -215,7 +215,8 @@ def subscribe_application(application_name: str) -> Response:
 def get_global_variable() -> Response | tuple[str, int]:
     variable = request.args['variable']
     if variable not in _responses['global_variables']:
-        return '', 404
+        # Asterisk doesn't raise error when variable doesn't exist
+        return jsonify({'value': ''})
     return jsonify({'value': _responses['global_variables'][variable]})
 
 

--- a/integration_tests/suite/helpers/wait_strategy.py
+++ b/integration_tests/suite/helpers/wait_strategy.py
@@ -4,8 +4,10 @@
 import requests
 from hamcrest import (
     assert_that,
+    empty,
     has_entries,
     has_entry,
+    not_,
 )
 from wazo_test_helpers import until
 
@@ -59,9 +61,12 @@ class CalldEverythingOkWaitStrategy(WaitStrategy):
                         'ari': has_entry('status', 'ok'),
                         'bus_consumer': has_entry('status', 'ok'),
                         'service_token': has_entry('status', 'ok'),
+                        'plugins': not_(empty()),
                     }
                 ),
             )
+            for plugin in status['plugins'].values():
+                assert_that(plugin, has_entries({'status': 'ok'}))
 
         until.assert_(is_ready, tries=60)
 

--- a/wazo_calld/plugins/endpoints/plugin.py
+++ b/wazo_calld/plugins/endpoints/plugin.py
@@ -3,6 +3,7 @@
 
 from wazo_confd_client import Client as ConfdClient
 from xivo.pubsub import CallbackCollector
+from xivo.status import Status
 
 from .bus import EventHandler
 from .http import LineEndpoints, TrunkEndpoints
@@ -15,6 +16,7 @@ class Plugin:
         api = dependencies['api']
         ari = dependencies['ari']
         config = dependencies['config']
+        status_aggregator = dependencies['status_aggregator']
         token_changed_subscribe = dependencies['token_changed_subscribe']
         bus_consumer = dependencies['bus_consumer']
         bus_publisher = dependencies['bus_publisher']
@@ -28,12 +30,16 @@ class Plugin:
         status_cache = NotifyingStatusCache(notifier.endpoint_updated, ari.client)
         endpoints_service = EndpointsService(confd_cache, status_cache)
 
+        self._async_tasks_completed = False
         startup_callback_collector = CallbackCollector()
         ari.client_initialized_subscribe(startup_callback_collector.new_source())
         startup_callback_collector.subscribe(status_cache.initialize)
+        startup_callback_collector.subscribe(self._set_async_tasks_completed)
 
         event_handler = EventHandler(status_cache, confd_cache)
         event_handler.subscribe(bus_consumer)
+
+        status_aggregator.add_provider(self._provide_status)
 
         api.add_resource(
             TrunkEndpoints,
@@ -50,3 +56,10 @@ class Plugin:
                 endpoints_service,
             ],
         )
+
+    def _set_async_tasks_completed(self):
+        self._async_tasks_completed = True
+
+    def _provide_status(self, status):
+        value = Status.ok if self._async_tasks_completed else Status.fail
+        status['plugins']['endpoints']['status'] = value

--- a/wazo_calld/plugins/status/api.yml
+++ b/wazo_calld/plugins/status/api.yml
@@ -20,6 +20,20 @@ definitions:
         $ref: '#/definitions/ComponentWithStatus'
       service_token:
         $ref: '#/definitions/ComponentWithStatus'
+      plugins:
+        $ref: '#/definitions/PluginsStatus'
+  PluginsStatus:
+    type: object
+    properties:
+      voicemails:
+        $ref: '#/definitions/VoicemailsStatus'
+  VoicemailsStatus:
+    type: object
+    allOf:
+      - $ref: '#/definitions/ComponentWithStatus'
+      - properties:
+         cache_items:
+           type: integer
   ComponentWithStatus:
     type: object
     properties:

--- a/wazo_calld/plugins/status/api.yml
+++ b/wazo_calld/plugins/status/api.yml
@@ -25,6 +25,8 @@ definitions:
   PluginsStatus:
     type: object
     properties:
+      endpoints:
+        $ref: '#/definitions/ComponentWithStatus'
       voicemails:
         $ref: '#/definitions/VoicemailsStatus'
   VoicemailsStatus:

--- a/wazo_calld/plugins/voicemails/plugin.py
+++ b/wazo_calld/plugins/voicemails/plugin.py
@@ -4,6 +4,7 @@
 import logging
 
 from wazo_confd_client import Client as ConfdClient
+from xivo.status import Status
 
 from .bus_consume import VoicemailsBusEventHandler
 from .http import (
@@ -126,4 +127,5 @@ class Plugin:
         )
 
     def _provide_status(self, status):
+        status['plugins']['voicemails']['status'] = Status.ok
         status['plugins']['voicemails']['cache_items'] = len(self._voicemail_cache)


### PR DESCRIPTION
## status: add voicemail plugin "status" field

why: according convention, every component should have a 'status' field
also add missing openapi spec definition about voicemail component

## status: add endpoints plugin status

why: callback can be long to be executed and can cause some race
condition with tests

## test: wait to load all plugins correctly


## test: do not raise 404 with ari mock

why: because real asterisk never trigger 404 when variable doesn't exist
and this will avoid a lot of unnecessary traceback during test with
XIVO_TRANSFERS_INDEX variable