### PR TITLE
WAZO-3369 move-channels-with-ari-adhoc-conference

### DIFF
--- a/integration_tests/suite/test_adhoc_conferences.py
+++ b/integration_tests/suite/test_adhoc_conferences.py
@@ -12,6 +12,7 @@ from hamcrest import (
     has_entries,
     has_item,
     has_items,
+    has_key,
     has_length,
     has_properties,
 )
@@ -63,12 +64,11 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
             participant_uuid = user_uuids.pop(0)
         except IndexError:
             participant_uuid = None
-        (
-            host_call_id,
-            participant_call_id,
-        ) = self.real_asterisk.given_bridged_call_stasis(
-            caller_uuid=host_uuid, callee_uuid=participant_uuid
+        call_ids = self.real_asterisk.given_bridged_call_stasis(
+            caller_uuid=host_uuid,
+            callee_uuid=participant_uuid,
         )
+        host_call_id, participant_call_id = call_ids
         participant_call_ids.append(participant_call_id)
 
         for _ in range(participant_count - 1):
@@ -81,12 +81,11 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
             )
             participant_call_ids.append(participant_call_id)
 
-        host_events = self.bus.accumulator(
-            headers={
-                f'user_uuid:{host_uuid}': True,
-                'name': 'conference_adhoc_participant_joined',
-            }
-        )
+        headers = {
+            f'user_uuid:{host_uuid}': True,
+            'name': 'conference_adhoc_participant_joined',
+        }
+        host_events = self.bus.accumulator(headers=headers)
         calld_client = self.make_user_calld(host_uuid)
         adhoc_conference = calld_client.adhoc_conferences.create_from_user(
             host_call_id, *participant_call_ids
@@ -106,16 +105,14 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
 
     def test_user_create_adhoc_conference_no_auth(self):
         calld_no_auth = self.make_calld(token=INVALID_ACL_TOKEN)
+
+        url = calld_no_auth.adhoc_conferences.create_from_user
         assert_that(
-            calling(calld_no_auth.adhoc_conferences.create_from_user).with_args(
-                SOME_CALL_ID, SOME_CALL_ID
-            ),
+            calling(url).with_args(SOME_CALL_ID, SOME_CALL_ID),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 401,
-                        'error_id': 'unauthorized',
-                    }
+                    status_code=401,
+                    error_id='unauthorized',
                 )
             ),
         )
@@ -123,16 +120,13 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
     def test_user_create_adhoc_conference_no_host_call(self):
         caller_call_id, callee_call_id = self.real_asterisk.given_bridged_call_stasis()
 
+        url = self.calld_client.adhoc_conferences.create_from_user
         assert_that(
-            calling(self.calld_client.adhoc_conferences.create_from_user).with_args(
-                SOME_CALL_ID, callee_call_id
-            ),
+            calling(url).with_args(SOME_CALL_ID, callee_call_id),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 400,
-                        'error_id': 'host-call-not-found',
-                    }
+                    status_code=400,
+                    error_id='host-call-not-found',
                 )
             ),
         )
@@ -145,16 +139,13 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
             caller_uuid=host_uuid
         )
 
+        url = self.calld_client.adhoc_conferences.create_from_user
         assert_that(
-            calling(self.calld_client.adhoc_conferences.create_from_user).with_args(
-                caller_call_id, SOME_CALL_ID
-            ),
+            calling(url).with_args(caller_call_id, SOME_CALL_ID),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 400,
-                        'error_id': 'participant-call-not-found',
-                    }
+                    status_code=400,
+                    error_id='participant-call-not-found',
                 )
             ),
         )
@@ -165,37 +156,31 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         token = self.make_user_token(user_uuid)
 
         self.calld_client.set_token(token)
-        (
-            host_call_id,
-            participant_call_id,
-        ) = self.real_asterisk.given_bridged_call_stasis(caller_uuid=another_user_uuid)
+        call_ids = self.real_asterisk.given_bridged_call_stasis(
+            caller_uuid=another_user_uuid
+        )
+        host_call_id, participant_call_id = call_ids
 
         # response should not be different than a non-existing call, to avoid malicious call discovery
+        url = self.calld_client.adhoc_conferences.create_from_user
         assert_that(
-            calling(self.calld_client.adhoc_conferences.create_from_user).with_args(
-                host_call_id, participant_call_id
-            ),
+            calling(url).with_args(host_call_id, participant_call_id),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 400,
-                        'error_id': 'host-call-not-found',
-                    }
+                    status_code=400,
+                    error_id='host-call-not-found',
                 )
             ),
         )
 
     def test_user_create_adhoc_conference_invalid_request(self):
+        url = self.calld_client.adhoc_conferences.create_from_user
         assert_that(
-            calling(self.calld_client.adhoc_conferences.create_from_user).with_args(
-                None, None
-            ),
+            calling(url).with_args(None, None),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 400,
-                        'error_id': 'invalid-data',
-                    }
+                    status_code=400,
+                    error_id='invalid-data',
                 )
             ),
         )
@@ -208,21 +193,23 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         self.calld_client.set_token(token)
         host_events = self.adhoc_conference_events_for_user(host_uuid)
 
-        (
-            host_call1_id,
-            participant1_call_id,
-        ) = self.real_asterisk.given_bridged_call_stasis(
-            caller_uuid=host_uuid, callee_uuid=participant1_uuid
+        call_ids = self.real_asterisk.given_bridged_call_stasis(
+            caller_uuid=host_uuid,
+            callee_uuid=participant1_uuid,
         )
-        (
-            host_call2_id,
-            participant2_call_id,
-        ) = self.real_asterisk.given_bridged_call_stasis(
-            caller_uuid=host_uuid, callee_uuid=participant2_uuid
+        host_call1_id, participant1_call_id = call_ids
+
+        call_ids = self.real_asterisk.given_bridged_call_stasis(
+            caller_uuid=host_uuid,
+            callee_uuid=participant2_uuid,
         )
+        host_call2_id, participant2_call_id = call_ids
+
         host_caller_id_num = "6845"
         self.ari.channels.setChannelVar(
-            channelId=host_call1_id, variable='CALLERID(num)', value=host_caller_id_num
+            channelId=host_call1_id,
+            variable='CALLERID(num)',
+            value=host_caller_id_num,
         )
 
         adhoc_conference = self.calld_client.adhoc_conferences.create_from_user(
@@ -231,28 +218,19 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
             participant2_call_id,
         )
 
-        assert_that(
-            adhoc_conference,
-            has_entries(
-                {
-                    'conference_id': anything(),
-                }
-            ),
-        )
+        assert_that(adhoc_conference, has_key('conference_id'))
 
         def calls_are_bridged():
             host_call1 = self.calld_client.calls.get_call(host_call1_id)
             assert_that(
                 host_call1,
                 has_entries(
-                    {
-                        'talking_to': has_entries(
-                            {
-                                participant1_call_id: anything(),
-                                participant2_call_id: anything(),
-                            }
-                        )
-                    }
+                    talking_to=has_entries(
+                        {
+                            participant1_call_id: anything(),
+                            participant2_call_id: anything(),
+                        }
+                    )
                 ),
             )
             assert_that(host_call2_id, self.c.is_hungup())
@@ -273,12 +251,8 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
                 has_item(
                     has_entries(
                         message=has_entries(
-                            {
-                                'name': 'conference_adhoc_created',
-                                'data': {
-                                    'conference_id': adhoc_conference['conference_id'],
-                                },
-                            }
+                            name='conference_adhoc_created',
+                            data={'conference_id': adhoc_conference['conference_id']},
                         ),
                         headers=has_entries(
                             name='conference_adhoc_created',
@@ -292,17 +266,11 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
                 has_items(
                     has_entries(
                         message=has_entries(
-                            {
-                                'name': 'conference_adhoc_participant_joined',
-                                'data': has_entries(
-                                    {
-                                        'conference_id': adhoc_conference[
-                                            'conference_id'
-                                        ],
-                                        'call_id': participant1_call_id,
-                                    }
-                                ),
-                            }
+                            name='conference_adhoc_participant_joined',
+                            data=has_entries(
+                                conference_id=adhoc_conference['conference_id'],
+                                call_id=participant1_call_id,
+                            ),
                         ),
                         headers=has_entries(
                             name='conference_adhoc_participant_joined',
@@ -311,17 +279,11 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
                     ),
                     has_entries(
                         message=has_entries(
-                            {
-                                'name': 'conference_adhoc_participant_joined',
-                                'data': has_entries(
-                                    {
-                                        'conference_id': adhoc_conference[
-                                            'conference_id'
-                                        ],
-                                        'call_id': participant2_call_id,
-                                    }
-                                ),
-                            }
+                            name='conference_adhoc_participant_joined',
+                            data=has_entries(
+                                conference_id=adhoc_conference['conference_id'],
+                                call_id=participant2_call_id,
+                            ),
                         ),
                         headers=has_entries(
                             name='conference_adhoc_participant_joined',
@@ -342,16 +304,13 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         )
         host_call_id, participant_call_id, _ = call_ids
 
+        url = self.calld_client.adhoc_conferences.create_from_user
         assert_that(
-            calling(self.calld_client.adhoc_conferences.create_from_user).with_args(
-                host_call_id, participant_call_id
-            ),
+            calling(url).with_args(host_call_id, participant_call_id),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 409,
-                        'error_id': 'host-already-in-conference',
-                    }
+                    status_code=409,
+                    error_id='host-already-in-conference',
                 )
             ),
         )
@@ -363,18 +322,17 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         token = self.make_user_token(host_uuid)
         self.calld_client.set_token(token)
 
-        (
-            host_call1_id,
-            participant1_call_id,
-        ) = self.real_asterisk.given_bridged_call_not_stasis(
-            caller_uuid=host_uuid, callee_uuid=participant1_uuid
+        call_ids = self.real_asterisk.given_bridged_call_not_stasis(
+            caller_uuid=host_uuid,
+            callee_uuid=participant1_uuid,
         )
-        (
-            host_call2_id,
-            participant2_call_id,
-        ) = self.real_asterisk.given_bridged_call_not_stasis(
-            caller_uuid=host_uuid, callee_uuid=participant2_uuid
+        host_call1_id, participant1_call_id = call_ids
+
+        call_ids = self.real_asterisk.given_bridged_call_not_stasis(
+            caller_uuid=host_uuid,
+            callee_uuid=participant2_uuid,
         )
+        host_call2_id, participant2_call_id = call_ids
 
         adhoc_conference = self.calld_client.adhoc_conferences.create_from_user(
             host_call1_id,
@@ -382,28 +340,19 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
             participant2_call_id,
         )
 
-        assert_that(
-            adhoc_conference,
-            has_entries(
-                {
-                    'conference_id': anything(),
-                }
-            ),
-        )
+        assert_that(adhoc_conference, has_key('conference_id'))
 
         def calls_are_bridged():
             host_call1 = self.calld_client.calls.get_call(host_call1_id)
             assert_that(
                 host_call1,
                 has_entries(
-                    {
-                        'talking_to': has_entries(
-                            {
-                                participant1_call_id: anything(),
-                                participant2_call_id: anything(),
-                            }
-                        )
-                    }
+                    talking_to=has_entries(
+                        {
+                            participant1_call_id: anything(),
+                            participant2_call_id: anything(),
+                        }
+                    )
                 ),
             )
             assert_that(host_call2_id, self.c.is_hungup())
@@ -415,25 +364,24 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         another_uuid = make_user_uuid()
         token = self.make_user_token(host_uuid)
         self.calld_client.set_token(token)
-        (
-            host_call_id,
-            participant1_call_id,
-        ) = self.real_asterisk.given_bridged_call_stasis(caller_uuid=host_uuid)
+        call_ids = self.real_asterisk.given_bridged_call_stasis(caller_uuid=host_uuid)
+        host_call_id, participant1_call_id = call_ids
         _, participant2_call_id = self.real_asterisk.given_bridged_call_stasis(
             caller_uuid=another_uuid
         )
 
         # response should not be different than a non-existing call, to avoid malicious call discovery
+        url = self.calld_client.adhoc_conferences.create_from_user
         assert_that(
-            calling(self.calld_client.adhoc_conferences.create_from_user).with_args(
-                host_call_id, participant1_call_id, participant2_call_id
+            calling(url).with_args(
+                host_call_id,
+                participant1_call_id,
+                participant2_call_id,
             ),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 400,
-                        'error_id': 'participant-call-not-found',
-                    }
+                    status_code=400,
+                    error_id='participant-call-not-found',
                 )
             ),
         )
@@ -448,16 +396,13 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         lone_call_id = self.real_asterisk.stasis_channel().id
 
         # response should not be different than a non-existing call, to avoid malicious call discovery
+        url = self.calld_client.adhoc_conferences.create_from_user
         assert_that(
-            calling(self.calld_client.adhoc_conferences.create_from_user).with_args(
-                lone_call_id, participant1_call_id
-            ),
+            calling(url).with_args(lone_call_id, participant1_call_id),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 400,
-                        'error_id': 'host-call-not-found',
-                    }
+                    status_code=400,
+                    error_id='host-call-not-found',
                 )
             ),
         )
@@ -466,39 +411,32 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         host_uuid = make_user_uuid()
         token = self.make_user_token(host_uuid)
         self.calld_client.set_token(token)
-        (
-            host_call_id,
-            participant1_call_id,
-        ) = self.real_asterisk.given_bridged_call_stasis(caller_uuid=host_uuid)
+        call_ids = self.real_asterisk.given_bridged_call_stasis(caller_uuid=host_uuid)
+        host_call_id, participant1_call_id = call_ids
         lone_call_id = self.real_asterisk.stasis_channel().id
 
         # response should not be different than a non-existing call, to avoid malicious call discovery
+        url = self.calld_client.adhoc_conferences.create_from_user
         assert_that(
-            calling(self.calld_client.adhoc_conferences.create_from_user).with_args(
-                host_call_id, participant1_call_id, lone_call_id
-            ),
+            calling(url).with_args(host_call_id, participant1_call_id, lone_call_id),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 400,
-                        'error_id': 'participant-call-not-found',
-                    }
+                    status_code=400,
+                    error_id='participant-call-not-found',
                 )
             ),
         )
 
     def test_user_delete_adhoc_conference_no_auth(self):
         calld_no_auth = self.make_calld(token=INVALID_ACL_TOKEN)
+
+        url = calld_no_auth.adhoc_conferences.delete_from_user
         assert_that(
-            calling(calld_no_auth.adhoc_conferences.delete_from_user).with_args(
-                SOME_ADHOC_CONFERENCE_ID
-            ),
+            calling(url).with_args(SOME_ADHOC_CONFERENCE_ID),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 401,
-                        'error_id': 'unauthorized',
-                    }
+                    status_code=401,
+                    error_id='unauthorized',
                 )
             ),
         )
@@ -508,16 +446,13 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         token = self.make_user_token(user_uuid)
         self.calld_client.set_token(token)
 
+        url = self.calld_client.adhoc_conferences.delete_from_user
         assert_that(
-            calling(self.calld_client.adhoc_conferences.delete_from_user).with_args(
-                SOME_ADHOC_CONFERENCE_ID
-            ),
+            calling(url).with_args(SOME_ADHOC_CONFERENCE_ID),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 404,
-                        'error_id': 'adhoc-conference-not-found',
-                    }
+                    status_code=404,
+                    error_id='adhoc-conference-not-found',
                 )
             ),
         )
@@ -535,16 +470,13 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
 
         # response should not be different than a non-existing adhoc conference
         # to avoid malicious adhoc conference discovery
+        url = self.calld_client.adhoc_conferences.delete_from_user
         assert_that(
-            calling(self.calld_client.adhoc_conferences.delete_from_user).with_args(
-                adhoc_conference_id
-            ),
+            calling(url).with_args(adhoc_conference_id),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 404,
-                        'error_id': 'adhoc-conference-not-found',
-                    }
+                    status_code=404,
+                    error_id='adhoc-conference-not-found',
                 )
             ),
         )
@@ -558,11 +490,8 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
             host_uuid, participant_uuid, participant_count=1
         )
         host_call_id, participant_call_id = call_ids
-        host_events = self.bus.accumulator(
-            headers={
-                f'user_uuid:{host_uuid}': True,
-            }
-        )
+        headers = {f'user_uuid:{host_uuid}': True}
+        host_events = self.bus.accumulator(headers=headers)
 
         self.calld_client.adhoc_conferences.delete_from_user(adhoc_conference_id)
 
@@ -578,12 +507,8 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
                 has_items(
                     has_entries(
                         message=has_entries(
-                            {
-                                'name': 'conference_adhoc_deleted',
-                                'data': {
-                                    'conference_id': adhoc_conference_id,
-                                },
-                            }
+                            name='conference_adhoc_deleted',
+                            data={'conference_id': adhoc_conference_id},
                         ),
                         headers=has_entries(
                             name='conference_adhoc_deleted',
@@ -592,15 +517,11 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
                     ),
                     has_entries(
                         message=has_entries(
-                            {
-                                'name': 'conference_adhoc_participant_left',
-                                'data': has_entries(
-                                    {
-                                        'conference_id': adhoc_conference_id,
-                                        'call_id': participant_call_id,
-                                    }
-                                ),
-                            }
+                            name='conference_adhoc_participant_left',
+                            data=has_entries(
+                                conference_id=adhoc_conference_id,
+                                call_id=participant_call_id,
+                            ),
                         ),
                         headers=has_entries(
                             name='conference_adhoc_participant_left',
@@ -609,15 +530,11 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
                     ),
                     has_entries(
                         message=has_entries(
-                            {
-                                'name': 'conference_adhoc_participant_left',
-                                'data': has_entries(
-                                    {
-                                        'conference_id': adhoc_conference_id,
-                                        'call_id': host_call_id,
-                                    }
-                                ),
-                            }
+                            name='conference_adhoc_participant_left',
+                            data=has_entries(
+                                conference_id=adhoc_conference_id,
+                                call_id=host_call_id,
+                            ),
                         ),
                         headers=has_entries(
                             name='conference_adhoc_participant_left',
@@ -648,64 +565,33 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
             host_call1 = self.calld_client.calls.get_call(host_call_id)
             assert_that(
                 host_call1,
-                has_entries(
-                    {
-                        'talking_to': has_entries(
-                            {
-                                participant1_call_id: anything(),
-                            }
-                        )
-                    }
-                ),
+                has_entries(talking_to=has_key(participant1_call_id)),
             )
             assert_that(participant2_call_id, self.c.is_hungup())
 
         until.assert_(calls_are_still_bridged, timeout=10)
 
         def bus_events_are_sent():
-            assert_that(
-                host_events.accumulate(with_headers=True),
-                has_item(
-                    has_entries(
-                        message=has_entries(
-                            {
-                                'name': 'conference_adhoc_participant_left',
-                                'data': has_entries(
-                                    {
-                                        'conference_id': adhoc_conference_id,
-                                        'call_id': participant2_call_id,
-                                    }
-                                ),
-                            }
-                        ),
-                        headers=has_entries(
-                            name='conference_adhoc_participant_left',
-                            tenant_uuid=VALID_TENANT,
-                        ),
-                    )
+            expected_event_matcher = has_entries(
+                message=has_entries(
+                    name='conference_adhoc_participant_left',
+                    data=has_entries(
+                        conference_id=adhoc_conference_id,
+                        call_id=participant2_call_id,
+                    ),
+                ),
+                headers=has_entries(
+                    name='conference_adhoc_participant_left',
+                    tenant_uuid=VALID_TENANT,
                 ),
             )
             assert_that(
+                host_events.accumulate(with_headers=True),
+                has_item(expected_event_matcher),
+            )
+            assert_that(
                 participant1_events.accumulate(with_headers=True),
-                has_item(
-                    has_entries(
-                        message=has_entries(
-                            {
-                                'name': 'conference_adhoc_participant_left',
-                                'data': has_entries(
-                                    {
-                                        'conference_id': adhoc_conference_id,
-                                        'call_id': participant2_call_id,
-                                    }
-                                ),
-                            }
-                        ),
-                        headers=has_entries(
-                            name='conference_adhoc_participant_left',
-                            tenant_uuid=VALID_TENANT,
-                        ),
-                    )
-                ),
+                has_item(expected_event_matcher),
             )
 
         until.assert_(bus_events_are_sent, timeout=10)
@@ -734,12 +620,8 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
                 has_item(
                     has_entries(
                         message=has_entries(
-                            {
-                                'name': 'conference_adhoc_deleted',
-                                'data': {
-                                    'conference_id': adhoc_conference_id,
-                                },
-                            }
+                            name='conference_adhoc_deleted',
+                            data={'conference_id': adhoc_conference_id},
                         ),
                         headers=has_entries(
                             name='conference_adhoc_deleted',
@@ -776,12 +658,8 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
                 has_item(
                     has_entries(
                         message=has_entries(
-                            {
-                                'name': 'conference_adhoc_deleted',
-                                'data': {
-                                    'conference_id': adhoc_conference_id,
-                                },
-                            }
+                            name='conference_adhoc_deleted',
+                            data={'conference_id': adhoc_conference_id},
                         ),
                         headers=has_entries(
                             name='conference_adhoc_deleted',
@@ -795,16 +673,13 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
 
     def test_user_add_participant_no_auth(self):
         calld_no_auth = self.make_calld(token=INVALID_ACL_TOKEN)
+        url = calld_no_auth.adhoc_conferences.add_participant_from_user
         assert_that(
-            calling(
-                calld_no_auth.adhoc_conferences.add_participant_from_user
-            ).with_args(SOME_CALL_ID, SOME_CALL_ID),
+            calling(url).with_args(SOME_CALL_ID, SOME_CALL_ID),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 401,
-                        'error_id': 'unauthorized',
-                    }
+                    status_code=401,
+                    error_id='unauthorized',
                 )
             ),
         )
@@ -813,21 +688,16 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         user_uuid = make_user_uuid()
         token = self.make_user_token(user_uuid)
         self.calld_client.set_token(token)
-        (
-            host_call_id,
-            participant_call_id,
-        ) = self.real_asterisk.given_bridged_call_stasis(caller_uuid=user_uuid)
+        call_ids = self.real_asterisk.given_bridged_call_stasis(caller_uuid=user_uuid)
+        host_call_id, participant_call_id = call_ids
 
+        url = self.calld_client.adhoc_conferences.add_participant_from_user
         assert_that(
-            calling(
-                self.calld_client.adhoc_conferences.add_participant_from_user
-            ).with_args(SOME_ADHOC_CONFERENCE_ID, participant_call_id),
+            calling(url).with_args(SOME_ADHOC_CONFERENCE_ID, participant_call_id),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 404,
-                        'error_id': 'adhoc-conference-not-found',
-                    }
+                    status_code=404,
+                    error_id='adhoc-conference-not-found',
                 )
             ),
         )
@@ -840,16 +710,13 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
             user_uuid, participant_count=1
         )
 
+        url = self.calld_client.adhoc_conferences.add_participant_from_user
         assert_that(
-            calling(
-                self.calld_client.adhoc_conferences.add_participant_from_user
-            ).with_args(adhoc_conference_id, SOME_CALL_ID),
+            calling(url).with_args(adhoc_conference_id, SOME_CALL_ID),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 400,
-                        'error_id': 'participant-call-not-found',
-                    }
+                    status_code=400,
+                    error_id='participant-call-not-found',
                 )
             ),
         )
@@ -870,16 +737,13 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
 
         # response should not be different than a non-existing adhoc conference
         # to avoid malicious adhoc conference discovery
+        url = self.calld_client.adhoc_conferences.add_participant_from_user
         assert_that(
-            calling(
-                self.calld_client.adhoc_conferences.add_participant_from_user
-            ).with_args(adhoc_conference_id, participant_call_id),
+            calling(url).with_args(adhoc_conference_id, participant_call_id),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 404,
-                        'error_id': 'adhoc-conference-not-found',
-                    }
+                    status_code=404,
+                    error_id='adhoc-conference-not-found',
                 )
             ),
         )
@@ -892,13 +756,14 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
             host_uuid, participant_count=1
         )
         host_call1_id, participant1_call_id = call_ids
+
         participant2_uuid = make_user_uuid()
-        (
-            host_call2_id,
-            participant2_call_id,
-        ) = self.real_asterisk.given_bridged_call_stasis(
-            caller_uuid=host_uuid, callee_uuid=participant2_uuid
+        call_ids = self.real_asterisk.given_bridged_call_stasis(
+            caller_uuid=host_uuid,
+            callee_uuid=participant2_uuid,
         )
+        host_call2_id, participant2_call_id = call_ids
+
         host_events = self.adhoc_conference_events_for_user(host_uuid)
         host_connected_line_before = self.ari.channels.getChannelVar(
             channelId=host_call1_id, variable='CONNECTEDLINE(all)'
@@ -913,14 +778,12 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
             assert_that(
                 host_call1,
                 has_entries(
-                    {
-                        'talking_to': has_entries(
-                            {
-                                participant1_call_id: anything(),
-                                participant2_call_id: anything(),
-                            }
-                        )
-                    }
+                    talking_to=has_entries(
+                        {
+                            participant1_call_id: anything(),
+                            participant2_call_id: anything(),
+                        }
+                    )
                 ),
             )
             assert_that(host_call2_id, self.c.is_hungup())
@@ -929,7 +792,8 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
 
         def callerid_are_correct():
             host_connected_line = self.ari.channels.getChannelVar(
-                channelId=host_call1_id, variable='CONNECTEDLINE(all)'
+                channelId=host_call1_id,
+                variable='CONNECTEDLINE(all)',
             )['value']
             assert_that(host_connected_line, equal_to(host_connected_line_before))
 
@@ -941,15 +805,11 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
                 has_items(
                     has_entries(
                         message=has_entries(
-                            {
-                                'name': 'conference_adhoc_participant_joined',
-                                'data': has_entries(
-                                    {
-                                        'conference_id': adhoc_conference_id,
-                                        'call_id': participant2_call_id,
-                                    }
-                                ),
-                            }
+                            name='conference_adhoc_participant_joined',
+                            data=has_entries(
+                                conference_id=adhoc_conference_id,
+                                call_id=participant2_call_id,
+                            ),
                         ),
                         headers=has_entries(
                             name='conference_adhoc_participant_joined',
@@ -969,10 +829,8 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
             host_uuid, participant_count=1
         )
         host_call1_id, participant1_call_id = call_ids
-        (
-            host_call2_id,
-            participant2_call_id,
-        ) = self.real_asterisk.given_bridged_call_not_stasis(caller_uuid=host_uuid)
+        ids = self.real_asterisk.given_bridged_call_not_stasis(caller_uuid=host_uuid)
+        host_call2_id, participant2_call_id = ids
 
         self.calld_client.adhoc_conferences.add_participant_from_user(
             adhoc_conference_id, participant2_call_id
@@ -983,14 +841,12 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
             assert_that(
                 host_call1,
                 has_entries(
-                    {
-                        'talking_to': has_entries(
-                            {
-                                participant1_call_id: anything(),
-                                participant2_call_id: anything(),
-                            }
-                        )
-                    }
+                    talking_to=has_entries(
+                        {
+                            participant1_call_id: anything(),
+                            participant2_call_id: anything(),
+                        }
+                    )
                 ),
             )
             assert_that(host_call2_id, self.c.is_hungup())
@@ -1008,16 +864,13 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         lone_call_id = self.real_asterisk.stasis_channel().id
 
         # response should not be different than a non-existing call, to avoid malicious call discovery
+        url = self.calld_client.adhoc_conferences.add_participant_from_user
         assert_that(
-            calling(
-                self.calld_client.adhoc_conferences.add_participant_from_user
-            ).with_args(adhoc_conference_id, lone_call_id),
+            calling(url).with_args(adhoc_conference_id, lone_call_id),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 400,
-                        'error_id': 'participant-call-not-found',
-                    }
+                    status_code=400,
+                    error_id='participant-call-not-found',
                 )
             ),
         )
@@ -1035,16 +888,13 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         )
 
         # response should not be different than a non-existing call, to avoid malicious call discovery
+        url = self.calld_client.adhoc_conferences.add_participant_from_user
         assert_that(
-            calling(
-                self.calld_client.adhoc_conferences.add_participant_from_user
-            ).with_args(adhoc_conference_id, participant2_call_id),
+            calling(url).with_args(adhoc_conference_id, participant2_call_id),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 400,
-                        'error_id': 'participant-call-not-found',
-                    }
+                    status_code=400,
+                    error_id='participant-call-not-found',
                 )
             ),
         )
@@ -1058,16 +908,13 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         )
         host_call_id, participant1_call_id, _ = call_ids
 
+        url = self.calld_client.adhoc_conferences.add_participant_from_user
         assert_that(
-            calling(
-                self.calld_client.adhoc_conferences.add_participant_from_user
-            ).with_args(adhoc_conference_id, participant1_call_id),
+            calling(url).with_args(adhoc_conference_id, participant1_call_id),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 409,
-                        'error_id': 'participant-already-in-conference',
-                    }
+                    status_code=409,
+                    error_id='participant-already-in-conference',
                 )
             ),
         )
@@ -1086,32 +933,26 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         _, participant1_call_id, __ = call_ids
 
         # response should not be different than a non-existing call, to avoid malicious call discovery
+        url = self.calld_client.adhoc_conferences.add_participant_from_user
         assert_that(
-            calling(
-                self.calld_client.adhoc_conferences.add_participant_from_user
-            ).with_args(adhoc_conference_id, participant1_call_id),
+            calling(url).with_args(adhoc_conference_id, participant1_call_id),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 400,
-                        'error_id': 'participant-call-not-found',
-                    }
+                    status_code=400,
+                    error_id='participant-call-not-found',
                 )
             ),
         )
 
     def test_user_remove_participant_no_auth(self):
         calld_no_auth = self.make_calld(token=INVALID_ACL_TOKEN)
+        url = calld_no_auth.adhoc_conferences.remove_participant_from_user
         assert_that(
-            calling(
-                calld_no_auth.adhoc_conferences.remove_participant_from_user
-            ).with_args(SOME_CALL_ID, SOME_CALL_ID),
+            calling(url).with_args(SOME_CALL_ID, SOME_CALL_ID),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 401,
-                        'error_id': 'unauthorized',
-                    }
+                    status_code=401,
+                    error_id='unauthorized',
                 )
             ),
         )
@@ -1125,16 +966,13 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
             participant_call_id,
         ) = self.real_asterisk.given_bridged_call_stasis(caller_uuid=user_uuid)
 
+        url = self.calld_client.adhoc_conferences.remove_participant_from_user
         assert_that(
-            calling(
-                self.calld_client.adhoc_conferences.remove_participant_from_user
-            ).with_args(SOME_ADHOC_CONFERENCE_ID, participant_call_id),
+            calling(url).with_args(SOME_ADHOC_CONFERENCE_ID, participant_call_id),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 404,
-                        'error_id': 'adhoc-conference-not-found',
-                    }
+                    status_code=404,
+                    error_id='adhoc-conference-not-found',
                 )
             ),
         )
@@ -1147,16 +985,13 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
             user_uuid, participant_count=1
         )
 
+        url = self.calld_client.adhoc_conferences.remove_participant_from_user
         assert_that(
-            calling(
-                self.calld_client.adhoc_conferences.remove_participant_from_user
-            ).with_args(adhoc_conference_id, SOME_CALL_ID),
+            calling(url).with_args(adhoc_conference_id, SOME_CALL_ID),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 400,
-                        'error_id': 'participant-call-not-found',
-                    }
+                    status_code=400,
+                    error_id='participant-call-not-found',
                 )
             ),
         )
@@ -1168,22 +1003,17 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
         adhoc_conference_id, call_ids = self.given_adhoc_conference(
             user_uuid, participant_count=1
         )
-        (
-            host_call_id,
-            participant_call_id,
-        ) = self.real_asterisk.given_bridged_call_stasis(caller_uuid=user_uuid)
+        call_ids = self.real_asterisk.given_bridged_call_stasis(caller_uuid=user_uuid)
+        host_call_id, participant_call_id = call_ids
 
         # response should not be different than a non-existing call, to avoid malicious call discovery
+        url = self.calld_client.adhoc_conferences.remove_participant_from_user
         assert_that(
-            calling(
-                self.calld_client.adhoc_conferences.remove_participant_from_user
-            ).with_args(adhoc_conference_id, participant_call_id),
+            calling(url).with_args(adhoc_conference_id, participant_call_id),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 400,
-                        'error_id': 'participant-call-not-found',
-                    }
+                    status_code=400,
+                    error_id='participant-call-not-found',
                 )
             ),
         )
@@ -1204,16 +1034,13 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
 
         # response should not be different than a non-existing adhoc conference
         # to avoid malicious adhoc conference discovery
+        url = self.calld_client.adhoc_conferences.remove_participant_from_user
         assert_that(
-            calling(
-                self.calld_client.adhoc_conferences.remove_participant_from_user
-            ).with_args(adhoc_conference_id, participant_call_id),
+            calling(url).with_args(adhoc_conference_id, participant_call_id),
             raises(CalldError).matching(
                 has_properties(
-                    {
-                        'status_code': 404,
-                        'error_id': 'adhoc-conference-not-found',
-                    }
+                    status_code=404,
+                    error_id='adhoc-conference-not-found',
                 )
             ),
         )
@@ -1239,64 +1066,33 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
             host_call1 = self.calld_client.calls.get_call(host_call_id)
             assert_that(
                 host_call1,
-                has_entries(
-                    {
-                        'talking_to': has_entries(
-                            {
-                                participant1_call_id: anything(),
-                            }
-                        )
-                    }
-                ),
+                has_entries(talking_to=has_key(participant1_call_id)),
             )
             assert_that(participant2_call_id, self.c.is_hungup())
 
         until.assert_(calls_are_still_bridged, timeout=10)
 
         def bus_events_are_sent():
-            assert_that(
-                host_events.accumulate(with_headers=True),
-                has_item(
-                    has_entries(
-                        message=has_entries(
-                            {
-                                'name': 'conference_adhoc_participant_left',
-                                'data': has_entries(
-                                    {
-                                        'conference_id': adhoc_conference_id,
-                                        'call_id': participant2_call_id,
-                                    }
-                                ),
-                            }
-                        ),
-                        headers=has_entries(
-                            name='conference_adhoc_participant_left',
-                            tenant_uuid=VALID_TENANT,
-                        ),
-                    )
+            expected_event_matcher = has_entries(
+                message=has_entries(
+                    name='conference_adhoc_participant_left',
+                    data=has_entries(
+                        conference_id=adhoc_conference_id,
+                        call_id=participant2_call_id,
+                    ),
+                ),
+                headers=has_entries(
+                    name='conference_adhoc_participant_left',
+                    tenant_uuid=VALID_TENANT,
                 ),
             )
             assert_that(
+                host_events.accumulate(with_headers=True),
+                has_item(expected_event_matcher),
+            )
+            assert_that(
                 participant1_events.accumulate(with_headers=True),
-                has_item(
-                    has_entries(
-                        message=has_entries(
-                            {
-                                'name': 'conference_adhoc_participant_left',
-                                'data': has_entries(
-                                    {
-                                        'conference_id': adhoc_conference_id,
-                                        'call_id': participant2_call_id,
-                                    }
-                                ),
-                            }
-                        ),
-                        headers=has_entries(
-                            name='conference_adhoc_participant_left',
-                            tenant_uuid=VALID_TENANT,
-                        ),
-                    )
-                ),
+                has_item(expected_event_matcher),
             )
 
         until.assert_(bus_events_are_sent, timeout=10)

--- a/wazo_calld/plugin_helpers/ari_.py
+++ b/wazo_calld/plugin_helpers/ari_.py
@@ -430,3 +430,6 @@ class BridgeSnapshot(Bridge):
 
     def has_only_channel_ids(self, *channel_ids):
         return set(self._snapshot['channels']) == set(channel_ids)
+
+    def channel_ids(self):
+        return self._snapshot['channels']

--- a/wazo_calld/plugins/adhoc_conferences/services.py
+++ b/wazo_calld/plugins/adhoc_conferences/services.py
@@ -284,7 +284,8 @@ class AdhocConferencesService:
         #       to avoid to trigger cleanup from callcontrol
         try:
             bridge = Channel(channel_id, self._ari).bridge()
-            self._ari.bridges.get(bridgeId=bridge.id).destroy()
+            if len(bridge.channel_ids()) <= 2:
+                self._ari.bridges.destroy(bridgeId=bridge.id)
         except (ARINotFound, BridgeNotFound):
             pass
 


### PR DESCRIPTION
## test adhoc conference fix styling issues

why: remove 200 lines from files, easier to read

## adhoc conference: use ari to move channels to app

why: using ari allow us to have more control over bridge/channel.
By using ari, we could delete bridge without issue and avoid a race
condition that occur when cleanup from callcontrol remove bridge with
only one channel

Moreover, using ari is the future to go and using dual logic (ari when
stasis and ami when non stasis channel) make logic cleaner and standard
with other usage of redirect in the code (relocate, transfers)

Note: integration already test stasis AND non stasis channels