### PR TITLE
pickup: restore channel ownership after pickup

### DIFF
--- a/integration_tests/assets/etc/asterisk/extensions.conf
+++ b/integration_tests/assets/etc/asterisk/extensions.conf
@@ -1,6 +1,7 @@
 [local]
 exten = recipient,1,NoOp()
-same = n,Dial(Test/integration-recipient)
+same = n,Set(_PICKUPMARK=recipient)
+same = n,Dial(Test/integration-recipient,,b(set-uuid^s^1(${CALLEE_XIVO_USERUUID})))
 
 exten = recipient_autoanswer,1,NoOp()
 same = n,Dial(Test/integration-recipient/autoanswer)
@@ -37,6 +38,9 @@ same = n,Hangup()
 
 exten = mobile-no-dial,1,NoOp(mobile)
 same = n,Hangup()
+
+exten = pickup,1,NoOp(pickup)
+same = n,Pickup(recipient@PICKUPMARK)
 
 [set-uuid]
 exten = s,1,Set(XIVO_USERUUID=${ARG1})

--- a/wazo_calld/plugins/calls/bus_consume.py
+++ b/wazo_calld/plugins/calls/bus_consume.py
@@ -54,6 +54,7 @@ class CallsBusEventHandler:
         bus_consumer.subscribe('BridgeLeave', self._relay_channel_left_bridge)
         bus_consumer.subscribe('MixMonitorStart', self._mix_monitor_start)
         bus_consumer.subscribe('MixMonitorStop', self._mix_monitor_stop)
+        bus_consumer.subscribe('Pickup', self._pickup_occurred)
         bus_consumer.subscribe(
             'users_services_dnd_updated', self._users_services_dnd_updated
         )
@@ -340,6 +341,21 @@ class CallsBusEventHandler:
             logger.debug('channel %s not found', channel_id)
             return
         self._relay_channel_updated(event)
+
+    def _pickup_occurred(self, event):
+        logger.debug('Received Pickup event: %s', event)
+        channel_id = event['Uniqueid']
+        try:
+            set_channel_id_var_sync(
+                self.ari,
+                channel_id,
+                'XIVO_USERUUID',
+                event['ChanVariable']['XIVO_USERUUID'],
+                bypass_stasis=True,
+            )
+        except ARINotFound:
+            logger.debug('channel %s not found', channel_id)
+            return
 
     def _users_services_dnd_updated(self, event):
         user_uuid = event['user_uuid']


### PR DESCRIPTION
Why:

* Pickup interceptor channel inherits variables from intercepted
  channel.