### PR TITLE
call: remove tracebacks when dialing a provisioning code

### DIFF
--- a/wazo_calld/plugins/calls/bus_consume.py
+++ b/wazo_calld/plugins/calls/bus_consume.py
@@ -91,6 +91,11 @@ class CallsBusEventHandler:
             return
 
         call = self.services.make_call_from_channel(self.ari, channel)
+        if call.is_autoprov:
+            logger.debug(
+                'ignoring event %s because this is a device in autoprov', event['Event']
+            )
+            return
         if self._call_direction_unknown(call):
             call.direction = self.services.conversation_direction_from_channels(
                 self.ari, [channel.id]
@@ -115,6 +120,11 @@ class CallsBusEventHandler:
             logger.debug('channel %s not found', channel_id)
             return
         call = self.services.make_call_from_channel(self.ari, channel)
+        if call.is_autoprov:
+            logger.debug(
+                'ignoring event %s because this is a device in autoprov', event['Event']
+            )
+            return
         self.notifier.call_updated(call)
 
     def _relay_channel_answered(self, event):
@@ -137,6 +147,11 @@ class CallsBusEventHandler:
             logger.debug('channel %s not found', channel_id)
             return
         call = self.services.make_call_from_channel(self.ari, channel)
+        if call.is_autoprov:
+            logger.debug(
+                'ignoring event %s because this is a device in autoprov', event['Event']
+            )
+            return
         if self._call_direction_unknown(call):
             call.direction = self.services.conversation_direction_from_channels(
                 self.ari, [channel.id]

--- a/wazo_calld/plugins/calls/call.py
+++ b/wazo_calld/plugins/calls/call.py
@@ -28,3 +28,4 @@ class Call:
         self.hangup_time = None
         self.direction = 'unknown'
         self.is_local = False
+        self.is_autoprov = False

--- a/wazo_calld/plugins/calls/services.py
+++ b/wazo_calld/plugins/calls/services.py
@@ -34,6 +34,7 @@ CALL_RECORDING_FILENAME_TEMPLATE = (
     '/var/lib/wazo/sounds/tenants/{tenant_uuid}/monitor/{recording_uuid}.wav'
 )
 LOCAL_TIMEZONE = datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
+AUTOPROV_CONTEXT = 'xivo-provisioning'
 
 
 class CallsService:
@@ -378,6 +379,7 @@ class CallsService:
         call.peer_caller_id_number = channel.json['connected']['number']
         call.user_uuid = channel_helper.user()
         call.tenant_uuid = channel_helper.tenant_uuid()
+        call.is_autoprov = channel.json['dialplan']['context'] == AUTOPROV_CONTEXT
         call.on_hold = channel_helper.on_hold()
         call.muted = channel_helper.muted()
         call.record_state = (
@@ -443,6 +445,7 @@ class CallsService:
         call.line_id = channel_variables.get('WAZO_LINE_ID') or None
         call.creation_time = channel.get('creationtime')
         call.answer_time = channel_variables.get('WAZO_ANSWER_TIME') or None
+        call.is_autoprov = event['channel']['dialplan']['context'] == AUTOPROV_CONTEXT
         call.hangup_time = datetime.datetime.now(LOCAL_TIMEZONE).isoformat()
         call.is_video = (
             channel_variables.get('CHANNEL(videonativeformat)') != '(nothing)'

--- a/wazo_calld/plugins/calls/stasis.py
+++ b/wazo_calld/plugins/calls/stasis.py
@@ -127,4 +127,9 @@ class CallsStasis:
             return
         logger.debug('Relaying to bus: channel %s ended', channel_id)
         call = self.services.channel_destroyed_event(self.ari, event)
+        if call.is_autoprov:
+            logger.debug(
+                'ignoring event %s because this is a device in autoprov', event['type']
+            )
+            return
         self.notifier.call_ended(call, event['cause'])


### PR DESCRIPTION
the autoprov PJSIP endpoint does not contain a tenant UUID. adding it at template creation would not fix the problem for all installed systems. Adding to confgend would be possible but it would add dependencies in wazo-confgend.

WAZO-3384