### PR TITLE
ari global vars: delete variable instead of unsetting

### DIFF
--- a/wazo_calld/plugin_helpers/ari_.py
+++ b/wazo_calld/plugin_helpers/ari_.py
@@ -89,7 +89,7 @@ class GlobalVariableAdapter:
         self._ari.asterisk.setGlobalVar(variable=variable, value=value)
 
     def unset(self, variable):
-        self._ari.asterisk.setGlobalVar(variable=variable, value='')
+        self._ari.asterisk.setGlobalVar(variable=f'GLOBAL_DELETE({variable})', value='')
 
 
 class GlobalVariableJsonAdapter:

--- a/wazo_calld/plugins/calls/tests/test_state_persistor.py
+++ b/wazo_calld/plugins/calls/tests/test_state_persistor.py
@@ -80,11 +80,11 @@ class TestStatePersistor(TestCase):
             value=exptected_variable,
         )
 
-    def test_when_remove_then_variable_unset(self):
+    def test_when_remove_then_variable_is_deleted(self):
         self.persistor.remove(SOME_CHANNEL_ID)
 
         self.ari.asterisk.setGlobalVar.assert_called_once_with(
-            variable=f'XIVO_CHANNELS_{SOME_CHANNEL_ID}', value=''
+            variable=f'GLOBAL_DELETE(XIVO_CHANNELS_{SOME_CHANNEL_ID})', value=''
         )
 
     def test_given_no_calls_when_get_then_raise_keyerror(self):


### PR DESCRIPTION
Why:

* Global vars accumulating will slow down the execution of dialplan in
  Asterisk
* Asterisk 21.1.0 introduces the GLOBAL_DELETE function to delete global
  vars