### PR TITLE
WP-1275: call park api

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,19 @@ repos:
     hooks:
       - id: isort
         args: [--filter-files]
+# Automatically check typing via MyPy
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.991
+    hooks:
+      - id: mypy
+        language_version: '3.10'
+        exclude: 'integration_tests/setup.py'
+        additional_dependencies:
+          - 'types-flask'
+          - 'types-pyyaml'
+          - 'types-requests'
+          - 'types-setuptools'
+          - 'types-werkzeug'
 # See https://pre-commit.com for more information
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 24.03
+
+* New API to manage a call parking
+
+  * GET `/parking_lots/<parking-id>`
+  * PUT `/calls/<call-id>/park`
+  * PUT `/users/me/calls/<call-id>/park_peer`
+
 ## 24.02
 
 * The `timeout` field has been added to the following resources:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
-## 24.03
+## 24.05
 
 * New API to manage a call parking
 
   * GET `/parking_lots/<parking-id>`
   * PUT `/calls/<call-id>/park`
-  * PUT `/users/me/calls/<call-id>/park_peer`
+  * PUT `/users/me/calls/<call-id>/collocutor/park`
+
+* New attribute for `calls` objects (API and events):
+
+  * `parked`
 
 ## 24.02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
   * GET `/parking_lots/<parking-id>`
   * PUT `/calls/<call-id>/park`
-  * PUT `/users/me/calls/<call-id>/collocutor/park`
+  * PUT `/users/me/calls/<call-id>/park`
 
 * New attribute for `calls` objects (API and events):
 

--- a/integration_tests/assets/amid_data/mock-wazo-amid.py
+++ b/integration_tests/assets/amid_data/mock-wazo-amid.py
@@ -15,8 +15,8 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 action_response = ''
-valid_extens = []
-_requests = []
+valid_extens: list = []
+_requests: list = []
 
 
 def _reset() -> None:

--- a/integration_tests/assets/ari_data/mock_ari.py
+++ b/integration_tests/assets/ari_data/mock_ari.py
@@ -6,11 +6,16 @@ from __future__ import annotations
 import json
 import logging
 import sys
+from typing import TYPE_CHECKING
 
 from flask import Flask, Response, jsonify, make_response, request
 from flask_sockets import Sockets
 
-_EMPTY_RESPONSES = {
+if TYPE_CHECKING:
+    from geventwebsocket.websocket import WebSocket
+
+
+_EMPTY_RESPONSES: dict[str, dict | list] = {
     'amqp': {},
     'applications': {},
     'bridges': {},
@@ -23,10 +28,10 @@ _EMPTY_RESPONSES = {
 
 app = Flask(__name__)
 sockets = Sockets(app)
-websocket = None
+websocket: WebSocket = None  # type: ignore[assignment]
 
-_requests = []
-_responses = {}
+_requests: list = []
+_responses: dict = {}
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger('wazo-ari-mock')

--- a/integration_tests/assets/docker-compose.real_asterisk.override.yml
+++ b/integration_tests/assets/docker-compose.real_asterisk.override.yml
@@ -36,6 +36,7 @@ services:
       - "./etc/asterisk/manager.conf:/etc/asterisk/manager.conf"
       - "./etc/asterisk/modules.conf:/etc/asterisk/modules.conf"
       - "./etc/asterisk/musiconhold.conf:/etc/asterisk/musiconhold.conf"
+      - "./etc/asterisk/res_parking.conf:/etc/asterisk/res_parking.conf"
       - "./etc/asterisk/stasis_amqp.conf:/etc/asterisk/stasis_amqp.conf"
       - "./ssl:/usr/local/share/ssl"
     command: "asterisk -fTn"

--- a/integration_tests/assets/etc/asterisk/res_parking.conf
+++ b/integration_tests/assets/etc/asterisk/res_parking.conf
@@ -12,6 +12,6 @@ parkext = 600
 context = parkings
 parkedmusicclass = default
 parkpos = 601-602
-parkingtime = 5
+parkingtime = 0
 findslot = next
 parkext_exclusive = yes

--- a/integration_tests/assets/etc/asterisk/res_parking.conf
+++ b/integration_tests/assets/etc/asterisk/res_parking.conf
@@ -3,7 +3,7 @@ parkext = 500
 context = parkings
 parkedmusicclass = default
 parkpos = 501-510
-parkingtime = 5
+parkingtime = 45
 findslot = next
 parkext_exclusive = yes
 

--- a/integration_tests/assets/etc/asterisk/res_parking.conf
+++ b/integration_tests/assets/etc/asterisk/res_parking.conf
@@ -1,0 +1,17 @@
+[parkinglot-1]
+parkext = 500
+context = parkings
+parkedmusicclass = default
+parkpos = 501-510
+parkingtime = 5
+findslot = next
+parkext_exclusive = yes
+
+[parkinglot-2]
+parkext = 600
+context = parkings
+parkedmusicclass = default
+parkpos = 601-602
+parkingtime = 5
+findslot = next
+parkext_exclusive = yes

--- a/integration_tests/assets/phoned_data/mock-wazo-phoned.py
+++ b/integration_tests/assets/phoned_data/mock-wazo-phoned.py
@@ -14,8 +14,8 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 action_response = ''
-valid_extens = []
-_requests = []
+valid_extens: list = []
+_requests: list = []
 
 
 def _reset() -> None:

--- a/integration_tests/suite/helpers/amid.py
+++ b/integration_tests/suite/helpers/amid.py
@@ -37,7 +37,7 @@ class MockAmidClient:
         response.raise_for_status()
 
     def set_no_valid_exten(self):
-        result = []
+        result: list = []
         self.set_action_result(result)
 
     def set_valid_exten(self, context, exten, priority='1'):

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -7,7 +7,7 @@ import tempfile
 import uuid
 from contextlib import contextmanager
 
-from requests.packages import urllib3
+import urllib3
 from wazo_test_helpers import until
 from wazo_test_helpers.asset_launching_test_case import (
     AssetLaunchingTestCase,

--- a/integration_tests/suite/helpers/bus.py
+++ b/integration_tests/suite/helpers/bus.py
@@ -313,3 +313,17 @@ class BusClient(bus_helper.BusClient):
 
     def send_stasis_non_json_event(self):
         self.send_event('', headers={'category': 'stasis', 'name': 'StasisStart'})
+
+    def send_confd_parking_created(self, id: int):
+        payload = {
+            'name': 'parking_lot_created',
+            'data': {'id': id},
+        }
+        self.send_event(payload, headers={'name': 'parking_lot_created'})
+
+    def send_confd_parking_deleted(self, id: int):
+        payload = {
+            'name': 'parking_lot_deleted',
+            'data': {'id': id},
+        }
+        self.send_event(payload, headers={'name': 'parking_lot_deleted'})

--- a/integration_tests/suite/helpers/bus.py
+++ b/integration_tests/suite/helpers/bus.py
@@ -192,7 +192,7 @@ class BusClient(bus_helper.BusClient):
         )
 
     def send_application_created_event(self, application_uuid, destination=None):
-        payload = {
+        payload: dict = {
             'data': {
                 'uuid': application_uuid,
                 'tenant_uuid': VALID_TENANT,
@@ -214,7 +214,7 @@ class BusClient(bus_helper.BusClient):
         )
 
     def send_application_edited_event(self, application_uuid, destination=None):
-        payload = {
+        payload: dict = {
             'data': {
                 'uuid': application_uuid,
                 'tenant_uuid': VALID_TENANT,

--- a/integration_tests/suite/helpers/confd.py
+++ b/integration_tests/suite/helpers/confd.py
@@ -3,11 +3,11 @@
 
 from __future__ import annotations
 
-import requests
-
 from random import choice
 from string import ascii_uppercase, digits
 from typing import TYPE_CHECKING
+
+import requests
 
 if TYPE_CHECKING:
     from .schemas import ParkingLotSchema

--- a/integration_tests/suite/helpers/confd.py
+++ b/integration_tests/suite/helpers/confd.py
@@ -1,7 +1,16 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 import requests
+
+from random import choice
+from string import ascii_uppercase, digits
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .schemas import ParkingLotSchema
 
 
 class ConfdClient:
@@ -121,6 +130,16 @@ class ConfdClient:
         body = {
             'response': 'moh',
             'content': {moh.uuid(): moh.to_dict() for moh in mock_mohs},
+        }
+
+        response = requests.post(url, json=body)
+        response.raise_for_status()
+
+    def set_parkinglots(self, *mock_parkings: MockParkinglot):
+        url = self.url('_set_response')
+        body = {
+            'response': 'parkinglots',
+            'content': {parking.id(): parking.to_dict() for parking in mock_parkings},
         }
 
         response = requests.post(url, json=body)
@@ -334,6 +353,53 @@ class MockMeeting:
             'name': self._name,
             'owner_uuids': self._owner_uuids,
             'tenant_uuid': self._tenant_uuid,
+        }
+
+
+class MockParkinglot:
+    def __init__(
+        self,
+        id: int,
+        name: str | None = None,
+        slots_start: int | None = None,
+        slots_end: int | None = None,
+        timeout: int | None = None,
+        tenant_uuid: str | None = None,
+        extension: int = 500,
+    ):
+        self._id = id
+        self._name = name or ''.join(
+            choice(ascii_uppercase + digits) for _ in range(10)
+        )
+        self._slots_start = slots_start or extension + 1
+        self._slots_end = slots_end or extension + 2
+        self._timeout = timeout
+        self._tenant_uuid = tenant_uuid or ''
+        self._extension = extension
+
+    def id(self):
+        return self._id
+
+    def to_dict(self) -> ParkingLotSchema:
+        extensions = []
+        if self._extension:
+            extensions = [
+                {
+                    'id': 1000,
+                    'context': 'some-ctx',
+                    'exten': self._extension,
+                }
+            ]
+
+        return {
+            'id': self._id,
+            'tenant_uuid': self._tenant_uuid,
+            'name': self._name,
+            'slots_start': self._slots_start,
+            'slots_end': self._slots_end,
+            'timeout': self._timeout,
+            'music_on_hold': 'default',
+            'extensions': extensions,
         }
 
 

--- a/integration_tests/suite/helpers/confd.py
+++ b/integration_tests/suite/helpers/confd.py
@@ -365,14 +365,14 @@ class MockParkinglot:
         slots_end: str | None = None,
         timeout: int | None = None,
         tenant_uuid: str | None = None,
-        extension: int = 500,
+        extension: str = '500',
     ):
         self._id = id
         self._name = name or ''.join(
             choice(ascii_uppercase + digits) for _ in range(10)
         )
-        self._slots_start = slots_start or str(extension + 1)
-        self._slots_end = slots_end or str(extension + 2)
+        self._slots_start = slots_start or str(int(extension) + 1)
+        self._slots_end = slots_end or str(int(extension) + 2)
         self._timeout = timeout or 45
         self._tenant_uuid = tenant_uuid or ''
         self._extension = extension
@@ -387,7 +387,7 @@ class MockParkinglot:
                 {
                     'id': 1000,
                     'context': 'some-ctx',
-                    'exten': str(self._extension),
+                    'exten': self._extension,
                 }
             ]
 

--- a/integration_tests/suite/helpers/confd.py
+++ b/integration_tests/suite/helpers/confd.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 import requests
 
 if TYPE_CHECKING:
-    from .schemas import ParkingLotSchema
+    from .schemas import ExtensionSchema, ParkingLotSchema
 
 
 class ConfdClient:
@@ -361,8 +361,8 @@ class MockParkinglot:
         self,
         id: int,
         name: str | None = None,
-        slots_start: int | None = None,
-        slots_end: int | None = None,
+        slots_start: str | None = None,
+        slots_end: str | None = None,
         timeout: int | None = None,
         tenant_uuid: str | None = None,
         extension: int = 500,
@@ -371,9 +371,9 @@ class MockParkinglot:
         self._name = name or ''.join(
             choice(ascii_uppercase + digits) for _ in range(10)
         )
-        self._slots_start = slots_start or extension + 1
-        self._slots_end = slots_end or extension + 2
-        self._timeout = timeout
+        self._slots_start = slots_start or str(extension + 1)
+        self._slots_end = slots_end or str(extension + 2)
+        self._timeout = timeout or 45
         self._tenant_uuid = tenant_uuid or ''
         self._extension = extension
 
@@ -381,13 +381,13 @@ class MockParkinglot:
         return self._id
 
     def to_dict(self) -> ParkingLotSchema:
-        extensions = []
+        extensions: list[ExtensionSchema] = []
         if self._extension:
             extensions = [
                 {
                     'id': 1000,
                     'context': 'some-ctx',
-                    'exten': self._extension,
+                    'exten': str(self._extension),
                 }
             ]
 

--- a/integration_tests/suite/helpers/schemas.py
+++ b/integration_tests/suite/helpers/schemas.py
@@ -1,0 +1,23 @@
+# Copyright 2024 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class ExtensionSchema(TypedDict):
+    id: int
+    context: str
+    exten: str
+
+
+class ParkingLotSchema(TypedDict):
+    id: int
+    name: str
+    tenant_uuid: str
+    slots_start: str
+    slots_end: str
+    timeout: int
+    music_on_hold: str
+    extensions: list[ExtensionSchema]

--- a/integration_tests/suite/helpers/wait_strategy.py
+++ b/integration_tests/suite/helpers/wait_strategy.py
@@ -100,7 +100,7 @@ class AmidReadyWaitStrategy(WaitStrategy):
 
 
 class _ServicesWaitStrategy(WaitStrategy):
-    _strategies = {
+    _strategies: dict[str, WaitStrategy] = {
         'amid': AmidReadyWaitStrategy(),
         'asterisk': AsteriskReadyWaitStrategy(),
         'calld': CalldEverythingOkWaitStrategy(),

--- a/integration_tests/suite/test_adhoc_conferences.py
+++ b/integration_tests/suite/test_adhoc_conferences.py
@@ -57,11 +57,11 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
 
     def given_adhoc_conference(self, *user_uuids, participant_count):
         participant_call_ids = []
-        user_uuids = list(user_uuids)
+        uuids = list(user_uuids)
 
-        host_uuid = user_uuids.pop(0)
+        host_uuid = uuids.pop(0)
         try:
-            participant_uuid = user_uuids.pop(0)
+            participant_uuid = uuids.pop(0)
         except IndexError:
             participant_uuid = None
         call_ids = self.real_asterisk.given_bridged_call_stasis(
@@ -73,7 +73,7 @@ class TestAdhocConference(RealAsteriskIntegrationTest):
 
         for _ in range(participant_count - 1):
             try:
-                participant_uuid = user_uuids.pop(0)
+                participant_uuid = uuids.pop(0)
             except IndexError:
                 participant_uuid = None
             _, participant_call_id = self.real_asterisk.given_bridged_call_stasis(

--- a/integration_tests/suite/test_applications.py
+++ b/integration_tests/suite/test_applications.py
@@ -84,7 +84,7 @@ class BaseApplicationTestCase(RealAsteriskIntegrationTest):
         )
 
     def call_app(self, app_uuid, variables=None):
-        kwargs = {
+        kwargs: dict = {
             'endpoint': ENDPOINT_AUTOANSWER,
             'app': f'wazo-app-{app_uuid}',
             'appArgs': 'incoming',
@@ -337,7 +337,7 @@ class TestStasisTriggers(BaseApplicationTestCase):
 
         self.bus.send_application_created_event(app_uuid, destination='node')
 
-        def event_received():
+        def event_received():  # type: ignore
             events = event_accumulator.accumulate(with_headers=True)
             assert_that(
                 events,
@@ -362,7 +362,7 @@ class TestStasisTriggers(BaseApplicationTestCase):
 
         self.call_app(self.no_node_app_uuid)
 
-        def event_received():
+        def event_received():  # type: ignore
             events = event_accumulator.accumulate()
             assert_that(events, has_length(1))
 
@@ -2587,7 +2587,7 @@ class TestApplicationNode(BaseApplicationTestCase):
 
         self.calld_client.applications.delete_node(self.no_node_app_uuid, node['uuid'])
 
-        def event_received():
+        def event_received():  # type: ignore
             events = event_accumulator.accumulate(with_headers=True)
             assert_that(
                 events,

--- a/integration_tests/suite/test_calls.py
+++ b/integration_tests/suite/test_calls.py
@@ -3,6 +3,7 @@
 
 import json
 import uuid
+from typing import Any
 
 import pytest
 from hamcrest import (
@@ -1692,7 +1693,7 @@ class TestUserCreateCall(IntegrationTest):
         valid_call_request = {'extension': '1234', 'variables': {'key': 'value'}}
 
         for key in ('extension', 'variables'):
-            body = dict(valid_call_request)
+            body: dict[str, Any] = dict(valid_call_request)
             body[key] = None
             yield body
             body[key] = 1234

--- a/integration_tests/suite/test_endpoints_bus_consume.py
+++ b/integration_tests/suite/test_endpoints_bus_consume.py
@@ -150,7 +150,7 @@ class TestTrunkBusConsume(IntegrationTest):
         self.wait_strategy.wait(self)
         self.bus.send_ami_peerstatus_event('PJSIP', 'PJSIP/abcdef', 'Reachable')
 
-        def assert_function():
+        def assert_registered():
             assert_that(
                 events.accumulate(),
                 has_item(
@@ -167,11 +167,11 @@ class TestTrunkBusConsume(IntegrationTest):
                 ),
             )
 
-        until.assert_(assert_function, tries=5)
+        until.assert_(assert_registered, tries=5)
 
         self.bus.send_ami_peerstatus_event('PJSIP', 'PJSIP/abcdef', 'Unreachable')
 
-        def assert_function():
+        def assert_not_registered():
             assert_that(
                 events.accumulate(),
                 has_item(
@@ -188,7 +188,7 @@ class TestTrunkBusConsume(IntegrationTest):
                 ),
             )
 
-        until.assert_(assert_function, tries=5)
+        until.assert_(assert_not_registered, tries=5)
 
     def test_when_ami_registry_then_bus_event(self):
         trunk_id = 42
@@ -222,7 +222,7 @@ class TestTrunkBusConsume(IntegrationTest):
             client_uri,
         )
 
-        def assert_function():
+        def assert_registered():
             assert_that(
                 events.accumulate(),
                 has_item(
@@ -239,7 +239,7 @@ class TestTrunkBusConsume(IntegrationTest):
                 ),
             )
 
-        until.assert_(assert_function, tries=5)
+        until.assert_(assert_registered, tries=5)
 
         self.bus.send_ami_registry_event(
             'PJSIP',
@@ -248,7 +248,7 @@ class TestTrunkBusConsume(IntegrationTest):
             client_uri,
         )
 
-        def assert_function():
+        def assert_not_registered():
             assert_that(
                 events.accumulate(),
                 has_item(
@@ -265,7 +265,7 @@ class TestTrunkBusConsume(IntegrationTest):
                 ),
             )
 
-        until.assert_(assert_function, tries=5)
+        until.assert_(assert_not_registered, tries=5)
 
     def test_when_trunk_associated_events_can_be_published(self):
         trunk_id = 42
@@ -461,7 +461,7 @@ class TestLineBusConsume(IntegrationTest):
         self.wait_strategy.wait(self)
         self.bus.send_ami_peerstatus_event('PJSIP', 'PJSIP/abcdef', 'Reachable')
 
-        def assert_function():
+        def assert_registered():
             assert_that(
                 events.accumulate(),
                 has_item(
@@ -478,11 +478,11 @@ class TestLineBusConsume(IntegrationTest):
                 ),
             )
 
-        until.assert_(assert_function, tries=5)
+        until.assert_(assert_registered, tries=5)
 
         self.bus.send_ami_peerstatus_event('PJSIP', 'PJSIP/abcdef', 'Unreachable')
 
-        def assert_function():
+        def assert_not_registered():
             assert_that(
                 events.accumulate(),
                 has_item(
@@ -499,4 +499,4 @@ class TestLineBusConsume(IntegrationTest):
                 ),
             )
 
-        until.assert_(assert_function, tries=5)
+        until.assert_(assert_not_registered, tries=5)

--- a/integration_tests/suite/test_meetings.py
+++ b/integration_tests/suite/test_meetings.py
@@ -884,7 +884,7 @@ class TestMeetingParticipants(TestMeetings):
             no_more_participants, timeout=10, message='Participant was not kicked'
         )
 
-    @unittest.skip
+    @unittest.skip('')
     def test_mute_participant_with_no_confd(self):
         meeting_uuid = 14
         participant_id = '12345.67'
@@ -917,7 +917,7 @@ class TestMeetingParticipants(TestMeetings):
                 ),
             )
 
-    @unittest.skip
+    @unittest.skip('')
     def test_mute_participant_with_no_amid(self):
         meeting_uuid = MEETING1_UUID
         self.confd.set_meetings(
@@ -955,7 +955,7 @@ class TestMeetingParticipants(TestMeetings):
                 ),
             )
 
-    @unittest.skip
+    @unittest.skip('')
     def test_mute_participant_with_no_meetings(self):
         meeting_uuid = 14
         participant_id = '12345.67'
@@ -987,7 +987,7 @@ class TestMeetingParticipants(TestMeetings):
             ),
         )
 
-    @unittest.skip
+    @unittest.skip('')
     def test_mute_participant_with_no_participants(self):
         meeting_uuid = MEETING1_UUID
         participant_id = '12345.67'
@@ -1022,7 +1022,7 @@ class TestMeetingParticipants(TestMeetings):
             ),
         )
 
-    @unittest.skip
+    @unittest.skip('')
     def test_mute_unmute_participant(self):
         meeting_uuid = MEETING1_UUID
         self.confd.set_meetings(
@@ -1062,7 +1062,7 @@ class TestMeetingParticipants(TestMeetings):
             participant_is_not_muted, timeout=10, message='Participant is still muted'
         )
 
-    @unittest.skip
+    @unittest.skip('')
     def test_mute_unmute_participant_twice(self):
         meeting_uuid = MEETING1_UUID
         self.confd.set_meetings(
@@ -1082,7 +1082,7 @@ class TestMeetingParticipants(TestMeetings):
 
         # no error
 
-    @unittest.skip
+    @unittest.skip('')
     def test_mute_unmute_participant_send_events(self):
         meeting_uuid = MEETING1_UUID
         tenant_uuid = MEETING1_TENANT_UUID
@@ -1146,7 +1146,7 @@ class TestMeetingParticipants(TestMeetings):
             message='Unmute event was not received',
         )
 
-    @unittest.skip
+    @unittest.skip('')
     def test_record_with_no_confd(self):
         meeting_uuid = 14
 
@@ -1174,7 +1174,7 @@ class TestMeetingParticipants(TestMeetings):
                 ),
             )
 
-    @unittest.skip
+    @unittest.skip('')
     def test_record_with_no_amid(self):
         meeting_uuid = MEETING1_UUID
         self.confd.set_meetings(
@@ -1206,7 +1206,7 @@ class TestMeetingParticipants(TestMeetings):
                 ),
             )
 
-    @unittest.skip
+    @unittest.skip('')
     def test_record_with_no_meetings(self):
         meeting_uuid = 14
 
@@ -1233,7 +1233,7 @@ class TestMeetingParticipants(TestMeetings):
             ),
         )
 
-    @unittest.skip
+    @unittest.skip('')
     def test_record_participant_with_no_participants(self):
         meeting_uuid = MEETING1_UUID
         self.confd.set_meetings(
@@ -1252,7 +1252,7 @@ class TestMeetingParticipants(TestMeetings):
             ),
         )
 
-    @unittest.skip
+    @unittest.skip('')
     def test_record(self):
         meeting_uuid = MEETING1_UUID
         self.confd.set_meetings(
@@ -1288,7 +1288,7 @@ class TestMeetingParticipants(TestMeetings):
         self.calld_client.meetings.stop_record(meeting_uuid)
         assert_that(record_file_is_closed(), is_(True))
 
-    @unittest.skip
+    @unittest.skip('')
     def test_record_twice(self):
         meeting_uuid = MEETING1_UUID
         self.confd.set_meetings(
@@ -1324,7 +1324,7 @@ class TestMeetingParticipants(TestMeetings):
             ),
         )
 
-    @unittest.skip
+    @unittest.skip('')
     def test_record_send_events(self):
         meeting_uuid = MEETING1_UUID
         tenant_uuid = MEETING1_TENANT_UUID
@@ -1383,7 +1383,7 @@ class TestMeetingParticipants(TestMeetings):
             message='Record stop event was not received',
         )
 
-    @unittest.skip
+    @unittest.skip('')
     def test_participant_talking_sends_event(self):
         meeting_uuid = MEETING1_UUID
         self.confd.set_meetings(

--- a/integration_tests/suite/test_parkings.py
+++ b/integration_tests/suite/test_parkings.py
@@ -40,8 +40,8 @@ class ParkingLotArgs(TypedDict, total=False):
     tenant_uuid: NotRequired[str]
     name: NotRequired[str]
     extension: NotRequired[int]
-    slots_start: NotRequired[int]
-    slots_end: NotRequired[int]
+    slots_start: NotRequired[str]
+    slots_end: NotRequired[str]
     timeout: NotRequired[int]
 
 
@@ -51,8 +51,8 @@ PARKINGLOT_1: ParkingLotArgs = {
     'tenant_uuid': VALID_TENANT,
     'name': 'First Parking',
     'extension': 500,
-    'slots_start': 501,
-    'slots_end': 510,
+    'slots_start': '501',
+    'slots_end': '510',
     'timeout': 5,
 }
 PARKINGLOT_2: ParkingLotArgs = {
@@ -60,8 +60,8 @@ PARKINGLOT_2: ParkingLotArgs = {
     'tenant_uuid': 'b93892f0-5300-4682-aede-3104b449ba69',
     'name': 'Second Parking',
     'extension': 600,
-    'slots_start': 601,
-    'slots_end': 602,
+    'slots_start': '601',
+    'slots_end': '602',
     'timeout': 5,
 }
 

--- a/integration_tests/suite/test_parkings.py
+++ b/integration_tests/suite/test_parkings.py
@@ -3,9 +3,14 @@
 
 from __future__ import annotations
 
-from ari.exceptions import ARINotFound
+from collections.abc import Generator
 from datetime import datetime, timezone
 from functools import wraps
+from math import floor
+from typing import TYPE_CHECKING, Callable, TypedDict, cast
+from uuid import uuid4
+
+from ari.exceptions import ARINotFound
 from hamcrest import (
     assert_that,
     calling,
@@ -16,16 +21,13 @@ from hamcrest import (
     has_properties,
     not_,
 )
-from math import floor
-from typing import Callable, cast, Generator, TYPE_CHECKING, TypedDict
-from typing_extensions import Unpack, NotRequired, Required
+from typing_extensions import NotRequired, Required, Unpack
 from wazo_calld_client.exceptions import CalldError
 from wazo_test_helpers import until
 from wazo_test_helpers.hamcrest.raises import raises
-from uuid import uuid4
 
-from .helpers.constants import ENDPOINT_AUTOANSWER, VALID_TENANT
 from .helpers.confd import MockParkinglot
+from .helpers.constants import ENDPOINT_AUTOANSWER, VALID_TENANT
 from .helpers.hamcrest_ import HamcrestARIBridge, HamcrestARIChannel
 from .helpers.real_asterisk import RealAsterisk, RealAsteriskIntegrationTest
 

--- a/integration_tests/suite/test_parkings.py
+++ b/integration_tests/suite/test_parkings.py
@@ -202,7 +202,7 @@ class TestParkings(BaseParkingTest):
 
     @Fixture.parking_lot(**PARKINGLOT_1)
     def test_call_park_updates_call_object(self, parking: ParkingLotSchema) -> None:
-        caller, callee = self.real_asterisk.given_bridged_call_not_stasis()
+        caller, _ = self.real_asterisk.given_bridged_call_not_stasis()
         parked_event = self.bus.accumulator(headers={'name': 'call_parked'})
 
         response = self.calld_client.calls.get_call(caller)

--- a/integration_tests/suite/test_parkings.py
+++ b/integration_tests/suite/test_parkings.py
@@ -1,0 +1,561 @@
+# Copyright 2024 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from functools import wraps
+from hamcrest import (
+    assert_that,
+    calling,
+    empty,
+    equal_to,
+    has_entries,
+    has_item,
+    has_properties,
+    not_,
+)
+from math import floor
+from typing import Callable, cast, Generator, TYPE_CHECKING, TypedDict
+from typing_extensions import Unpack, NotRequired, Required
+from wazo_calld_client.exceptions import CalldError
+from wazo_test_helpers import until
+from wazo_test_helpers.hamcrest.raises import raises
+from uuid import uuid4
+
+from .helpers.constants import ENDPOINT_AUTOANSWER, VALID_TENANT
+from .helpers.confd import MockParkinglot
+from .helpers.hamcrest_ import HamcrestARIBridge, HamcrestARIChannel
+from .helpers.real_asterisk import RealAsterisk, RealAsteriskIntegrationTest
+
+if TYPE_CHECKING:
+    from .helpers.schemas import ParkingLotSchema
+
+
+class ParkingLotArgs(TypedDict, total=False):
+    id: Required[int]
+    tenant_uuid: NotRequired[str]
+    name: NotRequired[str]
+    extension: NotRequired[int]
+    slots_start: NotRequired[int]
+    slots_end: NotRequired[int]
+    timeout: NotRequired[int]
+
+
+# NOTE: Parkings must be defined in `/etc/asterisk/res_parking.conf`
+PARKINGLOT_1: ParkingLotArgs = {
+    'id': 1,
+    'tenant_uuid': VALID_TENANT,
+    'name': 'First Parking',
+    'extension': 500,
+    'slots_start': 501,
+    'slots_end': 510,
+    'timeout': 5,
+}
+PARKINGLOT_2: ParkingLotArgs = {
+    'id': 2,
+    'tenant_uuid': 'b93892f0-5300-4682-aede-3104b449ba69',
+    'name': 'Second Parking',
+    'extension': 600,
+    'slots_start': 601,
+    'slots_end': 602,
+    'timeout': 5,
+}
+
+
+class Fixture:
+    @staticmethod
+    def parkinglot(**parking_lot: Unpack[ParkingLotArgs]) -> Callable[..., None]:
+        def decorator(decorated: Callable):
+            @wraps(decorated)
+            def wrapper(test: RealAsteriskIntegrationTest, *args, **kwargs):
+                parkinglot = MockParkinglot(**cast(ParkingLotArgs, parking_lot))
+
+                test.confd.set_parkinglots(parkinglot)
+                test.bus.send_confd_parking_created(parking_lot['id'])
+
+                args = args + (parkinglot.to_dict(),)
+                try:
+                    return decorated(test, *args, **kwargs)
+                finally:
+                    # must send bus message to clear parking cache
+                    test.bus.send_confd_parking_deleted(parking_lot['id'])
+
+            return wrapper
+
+        return decorator
+
+
+def random_uuid() -> str:
+    return str(uuid4())
+
+
+class BaseParkingTest(RealAsteriskIntegrationTest):
+    asset = 'real_asterisk'
+
+    def setUp(self):
+        super().setUp()
+        self.confd.reset()
+        self.b = HamcrestARIBridge(self.ari)
+        self.c = HamcrestARIChannel(self.ari)
+        self.real_asterisk = RealAsterisk(self.ari, self.calld_client)
+
+    def tearDown(self):
+        super().tearDown()
+        for bridge in self.ari.bridges.list():
+            for channel_id in bridge.json['channels']:
+                self.ari.channels.get(channelId=channel_id).hangup()
+
+    def given_parked_call(
+        self,
+        parking_extension: str,
+        *,
+        tenant_uuid: str | None = VALID_TENANT,
+        user_uuid: str | None = None,
+    ) -> Generator[str, None, None]:
+        variables = {}
+        if tenant_uuid:
+            variables['WAZO_TENANT_UUID'] = tenant_uuid
+        if user_uuid:
+            variables['WAZO_USERUUID'] = user_uuid
+
+        channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            context='parkings',
+            extension=parking_extension,
+            variables={'variables': variables},
+        )
+
+        def is_parked(channel) -> None:
+            assert_that(channel.id, self.c.is_in_bridge(), 'Channel is not parked')
+
+        until.assert_(is_parked, channel, timeout=3)
+        return channel.id
+
+
+class TestParkings(BaseParkingTest):
+    @Fixture.parkinglot(**PARKINGLOT_1)
+    def test_get_parking(self, parking: ParkingLotSchema):
+        parking_extension = parking['extensions'][0]['exten']
+
+        result = self.calld_client.parking_lots.get(parking['id'])
+        assert_that(result['calls'], empty())
+
+        call_id = self.given_parked_call(parking_extension)
+        response = self.calld_client.parking_lots.get(parking['id'])
+
+        assert_that(
+            response,
+            has_entries(
+                calls=has_item(
+                    has_entries(call_id=call_id),
+                )
+            ),
+        )
+
+    @Fixture.parkinglot(**PARKINGLOT_1)
+    def test_get_parking_no_confd(self, parking: ParkingLotSchema):
+        with self.confd_stopped():
+            assert_that(
+                calling(self.calld_client.parking_lots.get).with_args(parking['id']),
+                raises(CalldError).matching(
+                    has_properties(status_code=503, error_id='wazo-confd-unreachable')
+                ),
+            )
+
+    @Fixture.parkinglot(**PARKINGLOT_1)
+    def test_get_parking_no_amid(self, parking: ParkingLotSchema):
+        with self.amid_stopped():
+            assert_that(
+                calling(self.calld_client.parking_lots.get).with_args(parking['id']),
+                raises(CalldError).matching(
+                    has_properties(status_code=503, error_id='wazo-amid-error')
+                ),
+            )
+
+    @Fixture.parkinglot(**PARKINGLOT_1)
+    def test_get_parking_wrong_parking_id(self, _: ParkingLotSchema):
+        assert_that(
+            calling(self.calld_client.parking_lots.get).with_args(0),
+            raises(CalldError).matching(
+                has_properties(status_code=404, error_id='no-such-parking')
+            ),
+        )
+
+    @Fixture.parkinglot(**PARKINGLOT_1)
+    def test_get_wrong_tenant_uuid(self, parking: ParkingLotSchema):
+        calld = self.make_user_calld(
+            user_uuid=random_uuid(), tenant_uuid='eeeeeeee-eeee-eeee-eeee-eeeeeeeeeee1'
+        )
+
+        assert_that(
+            calling(calld.parking_lots.get).with_args(parking['id']),
+            raises(CalldError).matching(
+                has_properties(status_code=404, error_id='no-such-parking')
+            ),
+        )
+
+    @Fixture.parkinglot(**PARKINGLOT_1)
+    def test_call_park_updates_call_object(self, parking: ParkingLotSchema) -> None:
+        caller, callee = self.real_asterisk.given_bridged_call_not_stasis()
+        parked_event = self.bus.accumulator(headers={'name': 'call_parked'})
+
+        response = self.calld_client.calls.get_call(caller)
+        assert_that(response, has_entries(call_id=caller, parked=False))
+
+        def get_parked_event():
+            try:
+                return parked_event.pop(with_headers=False)
+            except IndexError:
+                return False
+
+        self.calld_client.calls.park(caller, parking['id'])
+        assert_that(
+            until.true(get_parked_event, timeout=3),
+            has_entries(data=has_entries(call_id=caller)),
+        )
+
+        response = self.calld_client.calls.get_call(caller)
+        assert_that(response, has_entries(call_id=caller, parked=True))
+
+    @Fixture.parkinglot(**PARKINGLOT_1)
+    def test_park_call(self, parking: ParkingLotSchema) -> None:
+        parked_events = self.bus.accumulator(headers={'name': 'call_parked'})
+
+        def get_parked_call_event():
+            try:
+                return parked_events.pop(with_headers=False)
+            except IndexError:
+                return False
+
+        caller, _ = self.real_asterisk.given_bridged_call_not_stasis()
+        response = self.calld_client.calls.park(caller, parking['id'], timeout=0)
+
+        parked_event = until.true(get_parked_call_event, timeout=3)
+        assert_that(
+            parked_event,
+            has_entries(
+                name='call_parked',
+                data=has_entries(
+                    call_id=caller, slot=response['slot'], parking_id=str(parking['id'])
+                ),
+            ),
+        )
+
+    @Fixture.parkinglot(**PARKINGLOT_1)
+    def test_503_when_parking_is_full(self, parking: ParkingLotSchema) -> None:
+        for _ in range(10):
+            self.given_parked_call(parking['extensions'][0]['exten'])
+
+        response = self.calld_client.parking_lots.get(parking['id'])
+        assert_that(response, has_entries('slots_remaining', equal_to(0)))
+
+        caller, _ = self.real_asterisk.given_bridged_call_not_stasis()
+
+        assert_that(
+            calling(self.calld_client.calls.park).with_args(caller, parking['id']),
+            raises(CalldError).matching(
+                has_properties(status_code=503, error_id='parking-full')
+            ),
+        )
+
+    @Fixture.parkinglot(**PARKINGLOT_1)
+    def test_park_call_with_preferred_slot(self, parking: ParkingLotSchema) -> None:
+        parked_events = self.bus.accumulator(headers={'name': 'call_parked'})
+
+        def get_parked_call_event():
+            try:
+                return parked_events.pop(with_headers=False)
+            except IndexError:
+                return False
+
+        caller, _ = self.real_asterisk.given_bridged_call_not_stasis()
+        response = self.calld_client.calls.park(
+            caller, parking['id'], preferred_slot='505'
+        )
+
+        assert_that(response, has_entries(slot='505'))
+
+        parked_event = until.true(get_parked_call_event, timeout=3)
+        assert_that(
+            parked_event,
+            has_entries(
+                name='call_parked',
+                data=has_entries(
+                    call_id=caller, parking_id=str(parking['id']), slot='505'
+                ),
+            ),
+        )
+
+    @Fixture.parkinglot(**PARKINGLOT_1)
+    def test_park_call_with_preferred_slot_already_taken_takes_next_slot(
+        self, parking: ParkingLotSchema
+    ) -> None:
+        self.given_parked_call(parking['extensions'][0]['exten'])
+        response = self.calld_client.parking_lots.get(parking['id'])
+        parking_slot = response['calls'][0]['slot']
+        caller, _ = self.real_asterisk.given_bridged_call_not_stasis()
+
+        response = self.calld_client.calls.park(
+            caller, parking['id'], preferred_slot=parking_slot
+        )
+
+        assert_that(response, not_(has_entries(slot=parking_slot)))
+
+    @Fixture.parkinglot(**PARKINGLOT_1)
+    def test_call_park_while_already_parked_with_same_preferred_slot_keeps_same_slot(
+        self, parking: ParkingLotSchema
+    ) -> None:
+        caller = self.given_parked_call(parking['extensions'][0]['exten'])
+        parking_slot = self.calld_client.parking_lots.get(parking['id'])['calls'][0][
+            'slot'
+        ]
+
+        response = self.calld_client.calls.park(
+            caller, parking['id'], preferred_slot=parking_slot
+        )
+        assert_that(response, has_entries(slot=parking_slot))
+
+    @Fixture.parkinglot(**PARKINGLOT_1)
+    def test_call_park_while_already_parked_reparks_in_another_slot(
+        self, parking: ParkingLotSchema
+    ) -> None:
+        caller = self.given_parked_call(parking['extensions'][0]['exten'])
+        parking_slot = self.calld_client.parking_lots.get(parking['id'])['calls'][0][
+            'slot'
+        ]
+
+        response = self.calld_client.calls.park(caller, parking['id'])
+        assert_that(response, not_(has_entries(slot=parking_slot)))
+
+    @Fixture.parkinglot(**PARKINGLOT_1)
+    def test_call_park_timeout_callback(self, parking: ParkingLotSchema) -> None:
+        parked_events = self.bus.accumulator(headers={'name': 'call_parked'})
+        timeout_events = self.bus.accumulator(headers={'name': 'parked_call_timed_out'})
+
+        def call_is_parked(call_id):
+            assert_that(
+                parked_events.accumulate(with_headers=False),
+                has_item(
+                    has_entries(
+                        name='call_parked',
+                        tenant_uuid=VALID_TENANT,
+                        data=has_entries(
+                            call_id=call_id, parking_id=str(parking['id'])
+                        ),
+                    )
+                ),
+            )
+
+        def parked_call_timed_out():
+            assert_that(
+                timeout_events.accumulate(),
+                has_item(
+                    has_entries(
+                        name='parked_call_timed_out',
+                        data=has_entries(call_id=caller, parking_id=str(parking['id'])),
+                    )
+                ),
+            )
+
+        def call_ended(call_id):
+            assert_that(
+                call_ended_events.accumulate(with_headers=False),
+                has_item(
+                    has_entries(
+                        name='call_ended',
+                        data=has_entries(call_id=call_id),
+                    )
+                ),
+            )
+
+        def call_created():
+            assert_that(
+                call_created_events.accumulate(with_headers=False),
+                has_item(
+                    has_entries(
+                        name='call_created',
+                        data=has_entries(status='Ringing'),
+                    )
+                ),
+            )
+
+        caller, callee = self.real_asterisk.given_bridged_call_not_stasis()
+        self.calld_client.calls.park(caller, parking['id'], timeout=1)
+
+        call_ended_events = self.bus.accumulator(headers={'name': 'call_ended'})
+        call_created_events = self.bus.accumulator(headers={'name': 'call_created'})
+
+        until.assert_(call_is_parked, caller, timeout=3)
+        until.assert_(call_ended, callee, timeout=3)
+        until.assert_(parked_call_timed_out, timeout=3)
+        until.assert_(call_created, timeout=3)
+
+    @Fixture.parkinglot(**PARKINGLOT_1)
+    def test_call_parked_hangup_event(self, parking: ParkingLotSchema) -> None:
+        caller, callee = self.real_asterisk.given_bridged_call_not_stasis()
+        parked_events = self.bus.accumulator(headers={'name': 'call_parked'})
+        ended_events = self.bus.accumulator(headers={'name': 'call_ended'})
+        hangup_events = self.bus.accumulator(headers={'name': 'parked_call_hungup'})
+
+        def call_is_parked():
+            assert_that(
+                parked_events.accumulate(with_headers=False),
+                has_item(has_entries(data=has_entries(call_id=caller))),
+            )
+
+        def callee_call_ended():
+            assert_that(
+                ended_events.accumulate(with_headers=False),
+                has_item(has_entries(data=has_entries(call_id=callee))),
+            )
+
+        def parked_call_is_hungup():
+            assert_that(
+                hangup_events.accumulate(with_headers=False),
+                has_item(has_entries(data=has_entries(call_id=caller))),
+            )
+
+        self.calld_client.calls.park(caller, parking['id'], timeout=10)
+
+        until.assert_(call_is_parked, timeout=3)
+        until.assert_(callee_call_ended, timeout=3)
+
+        self.ari.channels.get(channelId=caller).hangup()
+
+        until.assert_(parked_call_is_hungup, timeout=10)
+
+    @Fixture.parkinglot(**PARKINGLOT_1)
+    def test_call_park_timeout_values(self, parking: ParkingLotSchema) -> None:
+        caller, _ = self.real_asterisk.given_bridged_call_not_stasis()
+        parked_events = self.bus.accumulator(headers={'name': 'call_parked'})
+
+        def get_parked_event():
+            try:
+                return parked_events.pop(with_headers=False)
+            except IndexError:
+                return False
+
+        now = datetime.now(timezone.utc)
+        response = self.calld_client.calls.park(caller, parking['id'], timeout=7)
+
+        timeout_at = datetime.fromisoformat(response['timeout_at'])
+        assert floor((timeout_at - now).total_seconds()) == 7
+
+        event = until.true(get_parked_event, timeout=3)
+        timeout_at = datetime.fromisoformat(event['data']['timeout_at'])
+
+        assert floor((timeout_at - now).total_seconds()) == 7
+
+    @Fixture.parkinglot(**PARKINGLOT_1)
+    def test_reparking_call_updates_timeout(self, parking: ParkingLotSchema) -> None:
+        caller, _ = self.real_asterisk.given_bridged_call_not_stasis()
+
+        def get_parked_event():
+            try:
+                return parked_events.pop(with_headers=False)
+            except IndexError:
+                return False
+
+        self.calld_client.calls.park(caller, parking['id'], timeout=5)
+
+        now = datetime.now(timezone.utc)
+        parked_events = self.bus.accumulator(headers={'name': 'call_parked'})
+        response = self.calld_client.calls.park(caller, parking['id'], timeout=12345)
+
+        timeout_at = datetime.fromisoformat(response['timeout_at'])
+        assert floor((timeout_at - now).total_seconds()) == 12345
+
+        event = until.true(get_parked_event, timeout=3)
+        timeout_at = datetime.fromisoformat(event['data']['timeout_at'])
+        assert floor((timeout_at - now).total_seconds()) == 12345
+
+    @Fixture.parkinglot(**PARKINGLOT_1)
+    def test_park_stasis(self, parking: ParkingLotSchema) -> None:
+        caller, _ = self.real_asterisk.given_bridged_call_stasis()
+        parked_events = self.bus.accumulator(headers={'name': 'call_parked'})
+
+        def get_parked_event():
+            try:
+                return parked_events.pop(with_headers=False)
+            except IndexError:
+                return False
+
+        self.calld_client.calls.park(caller, parking['id'], preferred_slot='510')
+
+        event = until.true(get_parked_event, timeout=3)
+        assert_that(
+            event,
+            has_entries(
+                data=has_entries(
+                    call_id=caller, parking_id=str(parking['id']), slot='510'
+                )
+            ),
+        )
+
+    @Fixture.parkinglot(**PARKINGLOT_1)
+    def test_user_call_park(self, parking: ParkingLotSchema) -> None:
+        user_uuid = random_uuid()
+        calld = self.make_user_calld(user_uuid)
+
+        caller, callee = self.real_asterisk.given_bridged_call_not_stasis(
+            caller_uuid=user_uuid
+        )
+        parked_events = self.bus.accumulator(headers={'name': 'call_parked'})
+
+        def get_call_parked_event():
+            try:
+                return parked_events.pop(with_headers=False)
+            except IndexError:
+                return False
+
+        calld.calls.park_collocutor_from_user(caller, parking['id'])
+
+        event = until.true(get_call_parked_event, timeout=3)
+
+        assert_that(event, has_entries(data=has_entries(call_id=callee)))
+
+    @Fixture.parkinglot(**PARKINGLOT_1)
+    def test_user_call_park_invalid_call(self, parking: ParkingLotSchema):
+        user_uuid = random_uuid()
+        calld = self.make_user_calld(user_uuid)
+
+        caller = self.given_parked_call(
+            parking['extensions'][0]['exten'], user_uuid=user_uuid
+        )
+
+        assert_that(
+            calling(calld.calls.park_collocutor_from_user).with_args(
+                caller, parking['id']
+            ),
+            raises(CalldError).matching(
+                has_properties(status_code=400, error_id='cannot-park-call')
+            ),
+        )
+
+    @Fixture.parkinglot(**PARKINGLOT_1)
+    def test_user_call_park_permissions(self, parking: ParkingLotSchema) -> None:
+        user_uuid = random_uuid()
+        some_other_user_uuid = random_uuid()
+        calld = self.make_user_calld(user_uuid)
+
+        not_user_call, user_call = self.real_asterisk.given_bridged_call_not_stasis(
+            caller_uuid=some_other_user_uuid,
+            callee_uuid=user_uuid,
+        )
+
+        assert_that(
+            calling(calld.calls.park_collocutor_from_user).with_args(
+                not_user_call, parking['id']
+            ),
+            raises(CalldError).matching(
+                has_properties(status_code=403, error_id='user-permission-denied')
+            ),
+        )
+
+        assert_that(
+            calling(calld.calls.park_collocutor_from_user).with_args(
+                user_call, parking['id']
+            ),
+            not_(raises(CalldError)),
+        )

--- a/integration_tests/suite/test_parkings.py
+++ b/integration_tests/suite/test_parkings.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from datetime import datetime, timezone
 from functools import wraps
 from typing import TYPE_CHECKING, Callable, TypedDict, cast
@@ -31,6 +30,8 @@ from .helpers.hamcrest_ import HamcrestARIBridge, HamcrestARIChannel
 from .helpers.real_asterisk import RealAsterisk, RealAsteriskIntegrationTest
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from .helpers.schemas import ParkingLotSchema
 
 
@@ -589,7 +590,7 @@ class TestParkings(BaseParkingTest):
             except IndexError:
                 return False
 
-        calld.calls.park_collocutor_from_user(caller, parking['id'])
+        calld.calls.park_from_user(caller, parking['id'])
 
         event = until.true(get_call_parked_event, timeout=3)
 
@@ -605,9 +606,7 @@ class TestParkings(BaseParkingTest):
         )
 
         assert_that(
-            calling(calld.calls.park_collocutor_from_user).with_args(
-                caller, parking['id']
-            ),
+            calling(calld.calls.park_from_user).with_args(caller, parking['id']),
             raises(CalldError).matching(
                 has_properties(status_code=400, error_id='cannot-park-call')
             ),
@@ -625,17 +624,13 @@ class TestParkings(BaseParkingTest):
         )
 
         assert_that(
-            calling(calld.calls.park_collocutor_from_user).with_args(
-                not_user_call, parking['id']
-            ),
+            calling(calld.calls.park_from_user).with_args(not_user_call, parking['id']),
             raises(CalldError).matching(
                 has_properties(status_code=403, error_id='user-permission-denied')
             ),
         )
 
         assert_that(
-            calling(calld.calls.park_collocutor_from_user).with_args(
-                user_call, parking['id']
-            ),
+            calling(calld.calls.park_from_user).with_args(user_call, parking['id']),
             not_(raises(CalldError)),
         )

--- a/integration_tests/suite/test_parkings.py
+++ b/integration_tests/suite/test_parkings.py
@@ -39,7 +39,7 @@ class ParkingLotArgs(TypedDict, total=False):
     id: Required[int]
     tenant_uuid: NotRequired[str]
     name: NotRequired[str]
-    extension: NotRequired[int]
+    extension: NotRequired[str]
     slots_start: NotRequired[str]
     slots_end: NotRequired[str]
     timeout: NotRequired[int]
@@ -50,16 +50,16 @@ PARKINGLOT_1: ParkingLotArgs = {
     'id': 1,
     'tenant_uuid': VALID_TENANT,
     'name': 'First Parking',
-    'extension': 500,
+    'extension': '500',
     'slots_start': '501',
     'slots_end': '510',
-    'timeout': 5,
+    'timeout': 45,
 }
 PARKINGLOT_2: ParkingLotArgs = {
     'id': 2,
     'tenant_uuid': 'b93892f0-5300-4682-aede-3104b449ba69',
     'name': 'Second Parking',
-    'extension': 600,
+    'extension': '600',
     'slots_start': '601',
     'slots_end': '602',
     'timeout': 0,
@@ -116,14 +116,13 @@ class BaseParkingTest(RealAsteriskIntegrationTest):
         self,
         parking_extension: str,
         *,
-        tenant_uuid: str | None = VALID_TENANT,
+        tenant_uuid: str | None = None,
         user_uuid: str | None = None,
     ) -> Generator[str, None, None]:
-        variables = {}
-        if tenant_uuid:
-            variables['WAZO_TENANT_UUID'] = tenant_uuid
-        if user_uuid:
-            variables['WAZO_USERUUID'] = user_uuid
+        variables = {
+            'WAZO_TENANT_UUID': tenant_uuid or VALID_TENANT,
+            'WAZO_USERUUID': user_uuid or random_uuid(),
+        }
 
         channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,

--- a/integration_tests/suite/test_parkings.py
+++ b/integration_tests/suite/test_parkings.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from collections.abc import Generator
 from datetime import datetime, timezone
 from functools import wraps
-from math import floor
 from typing import TYPE_CHECKING, Callable, TypedDict, cast
 from uuid import uuid4
 
@@ -489,16 +488,16 @@ class TestParkings(BaseParkingTest):
             except IndexError:
                 return False
 
-        now = datetime.now(timezone.utc)
+        now = datetime.now(timezone.utc).replace(microsecond=0)
         response = self.calld_client.calls.park(caller, parking['id'], timeout=7)
 
         timeout_at = datetime.fromisoformat(response['timeout_at'])
-        assert floor((timeout_at - now).total_seconds()) == 7
+        assert (timeout_at - now).total_seconds() == 7
 
         event = until.true(get_parked_event, timeout=3)
         timeout_at = datetime.fromisoformat(event['data']['timeout_at'])
 
-        assert floor((timeout_at - now).total_seconds()) == 7
+        assert (timeout_at - now).total_seconds() == 7
 
     @Fixture.parking_lot(**PARKINGLOT_1)
     def test_reparking_call_updates_timeout(self, parking: ParkingLotSchema) -> None:
@@ -512,16 +511,16 @@ class TestParkings(BaseParkingTest):
 
         self.calld_client.calls.park(caller, parking['id'], timeout=5)
 
-        now = datetime.now(timezone.utc)
+        now = datetime.now(timezone.utc).replace(microsecond=0)
         parked_events = self.bus.accumulator(headers={'name': 'call_parked'})
         response = self.calld_client.calls.park(caller, parking['id'], timeout=12345)
 
         timeout_at = datetime.fromisoformat(response['timeout_at'])
-        assert floor((timeout_at - now).total_seconds()) == 12345
+        assert (timeout_at - now).total_seconds() == 12345
 
         event = until.true(get_parked_event, timeout=3)
         timeout_at = datetime.fromisoformat(event['data']['timeout_at'])
-        assert floor((timeout_at - now).total_seconds()) == 12345
+        assert (timeout_at - now).total_seconds() == 12345
 
     @Fixture.parking_lot(**PARKINGLOT_1)
     def test_park_stasis(self, parking: ParkingLotSchema) -> None:

--- a/integration_tests/suite/test_push_mobile.py
+++ b/integration_tests/suite/test_push_mobile.py
@@ -149,7 +149,7 @@ class TestPushMobile(RealAsteriskIntegrationTest):
             },
         )
 
-        def user_hint_updated():
+        def user_hint_updated():  # type: ignore
             result = self.amid.action(
                 'Getvar', {'Variable': f'DEVICE_STATE(Custom:{user_uuid}-mobile)'}
             )
@@ -184,7 +184,7 @@ class TestPushMobile(RealAsteriskIntegrationTest):
             },
         )
 
-        def user_hint_updated():
+        def user_hint_updated():  # type: ignore
             result = self.amid.action(
                 'Getvar', {'Variable': f'DEVICE_STATE(Custom:{user_uuid}-mobile)'}
             )

--- a/integration_tests/suite/test_switchboards.py
+++ b/integration_tests/suite/test_switchboards.py
@@ -443,7 +443,7 @@ class TestSwitchboardCallsQueued(TestSwitchboards):
 
         until.assert_(call_was_forwarded, timeout=4)
 
-    @unittest.skip
+    @unittest.skip(reason='')
     def test_given_one_call_queued_answered_held_when_unhold_then_no_queued_calls_updated_bus_event(
         self,
     ):

--- a/integration_tests/suite/test_transfers.py
+++ b/integration_tests/suite/test_transfers.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
+from typing import Any
 
 from ari.exceptions import ARINotFound
 from hamcrest import (
@@ -816,8 +817,10 @@ class TestCreateTransfer(TestTransfers):
         }
 
         for key in ('transferred_call', 'initiator_call', 'context', 'exten'):
-            body = dict(valid_transfer_request)
+            body: dict[str, Any] = dict(valid_transfer_request)
             body.pop(key)
+
+            invalid: Any
             for invalid in (None, 1234, True, '', [], {}):
                 body[key] = invalid
                 yield body
@@ -1221,6 +1224,8 @@ class TestUserCreateTransfer(TestTransfers):
             body = dict(valid_transfer_request)
             body.pop(key)
             yield body
+
+            value: Any
             for value in (None, 1234, True, '', [], {}):
                 body[key] = value
                 yield body

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,4 +36,3 @@ module = [
 disable_error_code = [
   "assignment",
 ]
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,22 @@ exclude = [
 [tool.isort]
 profile = "black"
 py_version = 39
+
+[tool.mypy]
+python_version = "3.10"
+show_error_codes = true
+check_untyped_defs = true
+warn_unused_configs = true
+follow_imports = "skip"
+ignore_missing_imports = true
+enable_incomplete_feature = "Unpack"
+
+[[tool.mypy.overrides]]
+module = [
+  "*.tests.*",
+  "integration_tests.suite.*",
+]
+disable_error_code = [
+  "assignment",
+]
+

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
             'endpoints = wazo_calld.plugins.endpoints.plugin:Plugin',
             'faxes = wazo_calld.plugins.faxes.plugin:Plugin',
             'meetings = wazo_calld.plugins.meetings.plugin:Plugin',
+            'parking_lots = wazo_calld.plugins.parking_lots.plugin:Plugin',
             'relocates = wazo_calld.plugins.relocates.plugin:Plugin',
             'status = wazo_calld.plugins.status.plugin:Plugin',
             'switchboards = wazo_calld.plugins.switchboards.plugin:Plugin',

--- a/wazo_calld/auth.py
+++ b/wazo_calld/auth.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
+from typing import TYPE_CHECKING
 
-from flask import request
 from requests import HTTPError
 from werkzeug.local import LocalProxy as Proxy
 from xivo import auth_verifier
@@ -14,6 +14,15 @@ from wazo_calld.exceptions import (
     TokenWithUserUUIDRequiredError,
 )
 from wazo_calld.http_server import app
+
+if TYPE_CHECKING:
+    from flask import request as _request
+    from xivo.auth_verifier import Request
+
+    request: Request = _request  # type: ignore[assignment]
+else:
+    from flask import request
+
 
 logger = logging.getLogger(__name__)
 required_acl = auth_verifier.required_acl

--- a/wazo_calld/config.py
+++ b/wazo_calld/config.py
@@ -99,6 +99,7 @@ _DEFAULT_CONFIG = {
         'endpoints': True,
         'faxes': True,
         'meetings': True,
+        'parking_lots': True,
         'relocates': True,
         'status': True,
         'switchboards': True,

--- a/wazo_calld/exceptions.py
+++ b/wazo_calld/exceptions.py
@@ -1,14 +1,11 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
 
-from xivo import rest_api_helpers
+from xivo.rest_api_helpers import APIException
 
 logger = logging.getLogger(__name__)
-
-
-APIException = rest_api_helpers.APIException
 
 
 class ARIUnreachable(Exception):

--- a/wazo_calld/plugin_helpers/ami.py
+++ b/wazo_calld/plugin_helpers/ami.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -47,7 +47,7 @@ def moh_class_exists(amid, moh_class):
 
     raw_body = response['response']
     classes = [
-        MOH_CLASS_RE.match(line).group(1)
+        MOH_CLASS_RE.match(line).group(1)  # type: ignore[union-attr]
         for line in raw_body
         if line.startswith('Class:')
     ]

--- a/wazo_calld/plugin_helpers/ari_.py
+++ b/wazo_calld/plugin_helpers/ari_.py
@@ -289,6 +289,13 @@ class Channel:
         except ARINotFound:
             return False
 
+    def parked(self):
+        try:
+            parked = self._get_var('WAZO_CALL_PARKED')
+            return parked == '1'
+        except ARINotFound:
+            return False
+
     def is_progress(self):
         try:
             progress = self._get_var('WAZO_CALL_PROGRESS')

--- a/wazo_calld/plugins/applications/caches.py
+++ b/wazo_calld/plugins/applications/caches.py
@@ -1,8 +1,11 @@
 # Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 import logging
 import threading
+from typing import Callable
 
 import requests
 
@@ -22,7 +25,7 @@ class ConfdIsReadyThread:
         self._started = False
         self._should_stop = threading.Event()
         self._retry_time = 1
-        self.callback = None
+        self.callback: Callable | None = None
 
     def start(self):
         if self._started:
@@ -44,7 +47,8 @@ class ConfdIsReadyThread:
     def _run(self):
         while not self._should_stop.is_set():
             if self._is_ready():
-                self.callback()
+                if self.callback:
+                    self.callback()
                 return
             logger.info(
                 'wazo-confd is not ready yet, retrying in %s seconds...',
@@ -67,7 +71,7 @@ class ConfdApplicationsCache:
         self._confd = confd
         self._cache = None
         self._cache_lock = threading.Lock()
-        self._triggers = {'created': [], 'updated': [], 'deleted': []}
+        self._triggers: dict[str, list] = {'created': [], 'updated': [], 'deleted': []}
 
     @property
     def _applications(self):

--- a/wazo_calld/plugins/applications/models.py
+++ b/wazo_calld/plugins/applications/models.py
@@ -1,6 +1,8 @@
 # Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 import logging
 from uuid import uuid4
 
@@ -21,6 +23,17 @@ class InvalidSnoopBridge(Exception):
 
 
 class ApplicationCall:
+    creation_time: str
+    status: str
+    caller_id_name: str
+    caller_id_number: str
+    snoops: dict
+    node_uuid: str | None
+    on_hold: bool
+    is_caller: bool
+    dialed_extension: str
+    variables: dict | None
+
     def __init__(self, id_):
         self.id_ = id_
         self.moh_uuid = None
@@ -188,7 +201,7 @@ class _Snoop:
         old_snoop_channel = self._snoop_channel
         self._snoop_channel = snoop_channel
         logger.debug('adding the new snoop channel %s', self._snoop_channel)
-        self._bridge.addChannel(channel=self._snoop_channel.id)
+        self._bridge.addChannel(channel=self._snoop_channel.id)  # type: ignore[union-attr]
         if old_snoop_channel:
             old_snoop_channel.hangup()
 

--- a/wazo_calld/plugins/calls/api.yml
+++ b/wazo_calld/plugins/calls/api.yml
@@ -619,6 +619,9 @@ definitions:
       is_caller:
         type: boolean
         description: This value is only correct when the destination of the call is a user or outgoing call. In other cases, it is always False.
+      parked:
+        type: boolean
+        description: If this call is currently parked
       is_video:
         type: boolean
         description: If this call has a video track

--- a/wazo_calld/plugins/calls/call.py
+++ b/wazo_calld/plugins/calls/call.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -29,3 +29,4 @@ class Call:
         self.direction = 'unknown'
         self.is_local = False
         self.is_autoprov = False
+        self.parked = False

--- a/wazo_calld/plugins/calls/schemas.py
+++ b/wazo_calld/plugins/calls/schemas.py
@@ -86,6 +86,7 @@ class CallSchema(CallBaseSchema):
     answer_time = fields.String()
     hangup_time = fields.String()
     direction = fields.String()
+    parked = fields.Boolean()
 
     @post_dump()
     def default_peer_caller_id_number(self, call, **kwargs):

--- a/wazo_calld/plugins/calls/services.py
+++ b/wazo_calld/plugins/calls/services.py
@@ -380,6 +380,7 @@ class CallsService:
         call.is_autoprov = channel.json['dialplan']['context'] == AUTOPROV_CONTEXT
         call.on_hold = channel_helper.on_hold()
         call.muted = channel_helper.muted()
+        call.parked = channel_helper.parked()
         call.record_state = (
             'active'
             if channel_variables.get('WAZO_CALL_RECORD_ACTIVE') == '1'

--- a/wazo_calld/plugins/calls/state.py
+++ b/wazo_calld/plugins/calls/state.py
@@ -1,7 +1,10 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 import logging
+from typing import ClassVar
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +33,7 @@ state_factory = StateFactory()
 
 
 class CallState:
-    name = None
+    name: ClassVar[str] = None  # type: ignore[assignment]
 
     def __init__(self, ari, stat_sender):
         self._ari = ari

--- a/wazo_calld/plugins/calls/tests/test_services.py
+++ b/wazo_calld/plugins/calls/tests/test_services.py
@@ -16,7 +16,7 @@ class TestServices(TestCase):
             Mock(), Mock(), self.ari, Mock(), Mock(), Mock(), Mock()
         )
 
-        self.example_to_fit = {
+        self.example_to_fit: dict = {
             'type': 'ChannelDestroyed',
             'timestamp': '2021-06-15T11:06:46.331-0400',
             'cause': 3,

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -134,7 +134,7 @@ class TestRemoveUnansweredChannels(DialerTestCase):
         channel_2.id = s.channel_2_id
         channel_2.get.return_value = Mock(json={'state': 'Ringing'})
 
-        self.poller._dialed_channels = {channel_1, channel_2}
+        self.poller._dialed_channels = [channel_1, channel_2]
 
         self.poller._remove_unanswered_channels()
 
@@ -149,7 +149,7 @@ class TestRemoveUnansweredChannels(DialerTestCase):
         channel_2.id = s.channel_2_id
         channel_2.get.return_value = Mock(json={'state': 'Ringing'})
 
-        self.poller._dialed_channels = {channel_1, channel_2}
+        self.poller._dialed_channels = [channel_1, channel_2]
 
         def hangup_mock(channelId):
             if channelId == s.channel_1_id:
@@ -166,7 +166,7 @@ class TestRemoveUnansweredChannels(DialerTestCase):
         channel_1.id = s.channel_1_id
         channel_1.get.return_value = Mock(json={'state': 'Down'})
 
-        self.poller._dialed_channels = {channel_1}
+        self.poller._dialed_channels = [channel_1]
 
         self.poller._remove_unanswered_channels()
 
@@ -177,13 +177,13 @@ class TestChannelGone(DialerTestCase):
     def test_unknown_channel_gone(self):
         dialed_channel = Mock()
         dialed_channel.id = s.dialed_channel_id
-        self.poller._dialed_channels = {dialed_channel}
+        self.poller._dialed_channels = [dialed_channel]
 
         with pytest.raises(_NoSuchChannel):
             self.poller._on_channel_gone('unknown')
 
     def test_caller_gone_before_dialed_any_channel(self):
-        self.poller._dialed_channels = set()
+        self.poller._dialed_channels = []
         self.poller.stop = Mock()
 
         self.poller._on_channel_gone(self.poller._caller_channel_id)
@@ -193,7 +193,7 @@ class TestChannelGone(DialerTestCase):
     def test_dialed_channel_gone(self):
         dialed_channel = Mock()
         dialed_channel.id = s.dialed_channel_id
-        self.poller._dialed_channels = {dialed_channel}
+        self.poller._dialed_channels = [dialed_channel]
         self.poller.stop = Mock()
 
         self.poller._on_channel_gone(s.dialed_channel_id)

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -134,7 +134,7 @@ class TestRemoveUnansweredChannels(DialerTestCase):
         channel_2.id = s.channel_2_id
         channel_2.get.return_value = Mock(json={'state': 'Ringing'})
 
-        self.poller._dialed_channels = [channel_1, channel_2]
+        self.poller._dialed_channels = {channel_1, channel_2}
 
         self.poller._remove_unanswered_channels()
 
@@ -149,7 +149,7 @@ class TestRemoveUnansweredChannels(DialerTestCase):
         channel_2.id = s.channel_2_id
         channel_2.get.return_value = Mock(json={'state': 'Ringing'})
 
-        self.poller._dialed_channels = [channel_1, channel_2]
+        self.poller._dialed_channels = {channel_1, channel_2}
 
         def hangup_mock(channelId):
             if channelId == s.channel_1_id:
@@ -166,7 +166,7 @@ class TestRemoveUnansweredChannels(DialerTestCase):
         channel_1.id = s.channel_1_id
         channel_1.get.return_value = Mock(json={'state': 'Down'})
 
-        self.poller._dialed_channels = [channel_1]
+        self.poller._dialed_channels = {channel_1}
 
         self.poller._remove_unanswered_channels()
 
@@ -177,13 +177,13 @@ class TestChannelGone(DialerTestCase):
     def test_unknown_channel_gone(self):
         dialed_channel = Mock()
         dialed_channel.id = s.dialed_channel_id
-        self.poller._dialed_channels = [dialed_channel]
+        self.poller._dialed_channels = {dialed_channel}
 
         with pytest.raises(_NoSuchChannel):
             self.poller._on_channel_gone('unknown')
 
     def test_caller_gone_before_dialed_any_channel(self):
-        self.poller._dialed_channels = []
+        self.poller._dialed_channels = set()
         self.poller.stop = Mock()
 
         self.poller._on_channel_gone(self.poller._caller_channel_id)
@@ -193,7 +193,7 @@ class TestChannelGone(DialerTestCase):
     def test_dialed_channel_gone(self):
         dialed_channel = Mock()
         dialed_channel.id = s.dialed_channel_id
-        self.poller._dialed_channels = [dialed_channel]
+        self.poller._dialed_channels = {dialed_channel}
         self.poller.stop = Mock()
 
         self.poller._on_channel_gone(s.dialed_channel_id)

--- a/wazo_calld/plugins/parking_lots/api.yml
+++ b/wazo_calld/plugins/parking_lots/api.yml
@@ -143,7 +143,7 @@ paths:
   /users/me/calls/{call_id}/collocutor/park:
     put:
       summary: Park the user's collocutor (talking to) call
-      description: '**Required ACL:** `calld.users.me.calls.{call_id}.park.update`'
+      description: '**Required ACL:** `calld.users.me.calls.{call_id}.collocutor.park.update`'
       parameters:
       - $ref: '#/parameters/TenantUUID'
       - $ref: '#/parameters/CallID'

--- a/wazo_calld/plugins/parking_lots/api.yml
+++ b/wazo_calld/plugins/parking_lots/api.yml
@@ -74,6 +74,7 @@ definitions:
           parker.  If unspecified, it will defaults to the parking's timeout value.
           (A value of 0 disables the timeout feature)
         type: integer
+        minimum: 0
         example: 30
   ParkedCallInfo:
     description: Information returned when a call has been parked

--- a/wazo_calld/plugins/parking_lots/api.yml
+++ b/wazo_calld/plugins/parking_lots/api.yml
@@ -1,0 +1,171 @@
+responses:
+  FullOrServiceUnavailable:
+    description: Parking is full or another service is unavailable (e.g. wazo-auth, wazo-confd, Asterisk, ...)
+    schema:
+      $ref: '#/definitions/Error'
+definitions:
+  ParkingLot:
+    title: Parking lot
+    type: object
+    properties:
+      name:
+        description: Parking lot's name
+        type: string
+        example: Some Parking Lot
+      exten:
+        description: Parking lot's extension
+        type: string
+        example: '500'
+      slots_start:
+        type: string
+        example: '501'
+      slots_end:
+        type: string
+        example: '510'
+      slots_total:
+        description: Total number of slots available for parking
+        type: integer
+        example: 10
+      slots_remaining:
+        description: Remaining slots to park a call in this lot
+        type: integer
+        example: 9
+      default_timeout:
+        description: Default timeout to assign if a timeout value was
+         unspecified when a call was parked
+        type: integer
+        example: 45
+      calls:
+        type: array
+        items:
+          $ref: '#/definitions/ParkedCallItem'
+  ParkedCallItem:
+    title: Parked Call
+    type: object
+    properties:
+      call_id:
+        type: string
+        example: 123456789.1
+      slot:
+        description: Slots where this call has been parked
+        type: string
+        example: 508
+      parked_at:
+        description: Timestamp when the call was parked
+        type: string
+        format: date-time
+      timeout_at:
+        description: Timestamp when the call will timeout
+        type: string
+        format: date-time
+  ParkCallBody:
+    title: Information needed to park the call
+    required:
+    - parking_id
+    type: object
+    properties:
+      parking_id:
+        description: Parking lot ID in which to park the call
+        type: integer
+        minimum: 1
+        example: 2
+      preferred_slot:
+        description: |
+         Preferred slot in which to park the call.  If slots is already
+         occupied, another slot will be automatically chosen
+        type: string
+        example: '501'
+      timeout:
+        description: |
+          A timeout specified in seconds after which the call will redial the
+          parker.  If unspecified, it will defaults to the parking's timeout value.
+          (A value of 0 disables the timeout feature)
+        type: integer
+        example: 30
+  ParkedCallInfo:
+    description: Information returned when a call has been parked
+    properties:
+      slot:
+        description: Parking slot where this call has been parked
+        type: string
+        example: 501
+      timeout_at:
+        description: Timestamp when the call will timeout
+        type: string
+        format: date-time
+parameters:
+  CallID:
+    name: call_id
+    in: path
+    description: Call ID
+    required: true
+    type: string
+  ParkingLotID:
+    name: parking_id
+    in: path
+    description: Parking lot's ID
+    required: true
+    type: string
+  ParkCall:
+    name: park_call
+    in: body
+    description: Payload required to park a call
+    required: true
+    schema:
+      $ref: '#/definitions/ParkCallBody'
+paths:
+  /parking_lots/{parking_id}:
+    get:
+      summary: Retrieve parked calls for parking
+      description: '**Required ACL:** `calld.parkings.{parking_id}.read`'
+      parameters:
+      - $ref: '#/parameters/TenantUUID'
+      - $ref: '#/parameters/ParkingLotID'
+      tags:
+      - parking_lots
+      responses:
+        '200':
+          description: List of parked calls in parking lot
+          schema:
+            $ref: '#/definitions/ParkingLot'
+  /calls/{call_id}/park:
+    put:
+      summary: Park a call
+      description: '**Required ACL:** calld.parkings.{parking_id}.update`'
+      parameters:
+      - $ref: '#/parameters/TenantUUID'
+      - $ref: '#/parameters/CallID'
+      - $ref: '#/parameters/ParkCall'
+      tags:
+      - calls
+      - parking_lots
+      responses:
+        '200':
+          description: Parked call
+          schema:
+            $ref: '#/definitions/ParkedCallInfo'
+        '404':
+          $ref: '#/responses/NotFoundError'
+        '503':
+          $ref: '#/responses/FullOrServiceUnavailable'
+  /users/me/calls/{call_id}/collocutor/park:
+    put:
+      summary: Park the user's collocutor (talking to) call
+      description: '**Required ACL:** `calld.users.me.calls.{call_id}.update`'
+      parameters:
+      - $ref: '#/parameters/TenantUUID'
+      - $ref: '#/parameters/CallID'
+      - $ref: '#/parameters/ParkCall'
+      tags:
+      - calls
+      - parking_lots
+      - users
+      responses:
+        '200':
+          description: Parked call
+          schema:
+            $ref: '#/definitions/ParkedCallInfo'
+        '404':
+          $ref: '#/responses/NotFoundError'
+        '503':
+          $ref: '#/responses/FullOrServiceUnavailable'

--- a/wazo_calld/plugins/parking_lots/api.yml
+++ b/wazo_calld/plugins/parking_lots/api.yml
@@ -131,7 +131,7 @@ paths:
   /calls/{call_id}/park:
     put:
       summary: Park a call
-      description: '**Required ACL:** calld.parkings.{parking_id}.update`'
+      description: '**Required ACL:** calld.calls.{call_id}.park.update`'
       parameters:
       - $ref: '#/parameters/TenantUUID'
       - $ref: '#/parameters/CallID'
@@ -151,7 +151,7 @@ paths:
   /users/me/calls/{call_id}/collocutor/park:
     put:
       summary: Park the user's collocutor (talking to) call
-      description: '**Required ACL:** `calld.users.me.calls.{call_id}.update`'
+      description: '**Required ACL:** `calld.users.me.calls.{call_id}.park.update`'
       parameters:
       - $ref: '#/parameters/TenantUUID'
       - $ref: '#/parameters/CallID'

--- a/wazo_calld/plugins/parking_lots/api.yml
+++ b/wazo_calld/plugins/parking_lots/api.yml
@@ -8,14 +8,6 @@ definitions:
     title: Parking lot
     type: object
     properties:
-      name:
-        description: Parking lot's name
-        type: string
-        example: Some Parking Lot
-      exten:
-        description: Parking lot's extension
-        type: string
-        example: '500'
       slots_start:
         type: string
         example: '501'

--- a/wazo_calld/plugins/parking_lots/api.yml
+++ b/wazo_calld/plugins/parking_lots/api.yml
@@ -47,7 +47,8 @@ definitions:
         type: string
         format: date-time
       timeout_at:
-        description: Timestamp when the call will timeout
+        description: |
+          Timestamp when the call will timeout (null if timeout is disabled)
         type: string
         format: date-time
   ParkCallBody:

--- a/wazo_calld/plugins/parking_lots/api.yml
+++ b/wazo_calld/plugins/parking_lots/api.yml
@@ -108,7 +108,7 @@ parameters:
     schema:
       $ref: '#/definitions/ParkCallBody'
 paths:
-  /parking_lots/{parking_id}:
+  /parkinglots/{parking_id}:
     get:
       summary: Retrieve parked calls for parking
       description: '**Required ACL:** `calld.parkings.{parking_id}.read`'
@@ -142,10 +142,10 @@ paths:
           $ref: '#/responses/NotFoundError'
         '503':
           $ref: '#/responses/FullOrServiceUnavailable'
-  /users/me/calls/{call_id}/collocutor/park:
+  /users/me/calls/{call_id}/park:
     put:
       summary: Park the user's collocutor (talking to) call
-      description: '**Required ACL:** `calld.users.me.calls.{call_id}.collocutor.park.update`'
+      description: '**Required ACL:** `calld.users.me.calls.{call_id}.park.update`'
       parameters:
       - $ref: '#/parameters/TenantUUID'
       - $ref: '#/parameters/CallID'

--- a/wazo_calld/plugins/parking_lots/api.yml
+++ b/wazo_calld/plugins/parking_lots/api.yml
@@ -144,7 +144,7 @@ paths:
           $ref: '#/responses/FullOrServiceUnavailable'
   /users/me/calls/{call_id}/park:
     put:
-      summary: Park the user's collocutor (talking to) call
+      summary: Park the user's connected (talking to) call
       description: '**Required ACL:** `calld.users.me.calls.{call_id}.park.update`'
       parameters:
       - $ref: '#/parameters/TenantUUID'

--- a/wazo_calld/plugins/parking_lots/bus_consume.py
+++ b/wazo_calld/plugins/parking_lots/bus_consume.py
@@ -12,7 +12,7 @@ from typing import Callable, TYPE_CHECKING
 from wazo_calld.plugin_helpers.ari_ import set_channel_id_var_sync, Channel
 from .dataclasses_ import AsteriskParkedCall
 from .exceptions import NoSuchParking
-from .helpers import split_parking_id_from_name
+from .helpers import split_parking_id_from_name, DONT_CHECK_TENANT
 
 if TYPE_CHECKING:
     from wazo_calld.bus import CoreBusConsumer
@@ -113,7 +113,7 @@ class ParkingLotEventsHandler:
         tenant_uuid = None
         try:
             id_ = split_parking_id_from_name(parked_call.parkinglot)
-            parking = self._service.get_parking(None, id_)
+            parking = self._service.get_parking(DONT_CHECK_TENANT, id_)
         except (ValueError, NoSuchParking):
             logger.debug(
                 'parked call hangup handler failed: couldn\'t determine tenant_uuid'

--- a/wazo_calld/plugins/parking_lots/bus_consume.py
+++ b/wazo_calld/plugins/parking_lots/bus_consume.py
@@ -1,0 +1,131 @@
+# Copyright 2024 The Wazo Authors (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import logging
+
+from ari.exceptions import ARINotFound
+from functools import wraps
+from typing import Callable, TYPE_CHECKING
+
+from wazo_calld.plugin_helpers.ari_ import set_channel_id_var_sync, Channel
+from .dataclasses_ import AsteriskParkedCall
+
+if TYPE_CHECKING:
+    from wazo_calld.bus import CoreBusConsumer
+    from wazo_calld.ari_ import CoreARI
+    from .notifier import ParkingNotifier
+
+
+logger = logging.getLogger(__name__)
+PARKED_CHANNEL_VAR = 'WAZO_CALL_PARKED'
+
+
+def convert_ami_event(
+    fn: Callable[[ParkingLotEventsHandler, AsteriskParkedCall, Channel], None],
+) -> Callable[[ParkingLotEventsHandler, dict], None]:
+    '''Helper decorator to convert AMI event dict to call and channel objects'''
+
+    @wraps(fn)
+    def wrapper(handler: ParkingLotEventsHandler, event: dict) -> None:
+        if not isinstance(event, dict):
+            raise ValueError('received invalid data')
+        call = AsteriskParkedCall.from_dict(event)
+        channel = handler._get_channel(call)
+        return fn(handler, call, channel)
+
+    return wrapper
+
+
+class ParkingLotEventsHandler:
+    def __init__(
+        self,
+        ari: CoreARI,
+        consumer: CoreBusConsumer,
+        notifier: ParkingNotifier,
+    ):
+        self._ari = ari
+        self._notifier = notifier
+        consumer.subscribe('ParkedCall', self.on_ami_call_parked)
+        consumer.subscribe('ParkedCallGiveUp', self.on_ami_parked_call_hangup)
+        consumer.subscribe('ParkedCallSwap', self.on_ami_parked_call_swap)
+        consumer.subscribe('ParkedCallTimeOut', self.on_ami_parked_call_timed_out)
+
+    def _get_channel(self, call: AsteriskParkedCall) -> Channel:
+        return Channel(call.parkee_uniqueid, self._ari.client)
+
+    def _set_parked_status(self, channel: Channel, parked: bool) -> None:
+        status = '1' if parked else ''
+        try:
+            set_channel_id_var_sync(
+                self._ari.client,
+                channel.id,
+                PARKED_CHANNEL_VAR,
+                status,
+                bypass_stasis=True,
+            )
+        except ARINotFound:
+            logger.error('channel not found: %s', channel.id)
+            return
+        else:
+            logger.debug(
+                'call has been marked as %s: %s',
+                'parked' if parked else 'unparked',
+                channel.id,
+            )
+
+    @convert_ami_event
+    def on_ami_call_parked(
+        self, parked_call: AsteriskParkedCall, parked_channel: Channel
+    ) -> None:
+        '''A call has been parked'''
+
+        self._set_parked_status(parked_channel, True)
+
+        if tenant_uuid := parked_channel.tenant_uuid():
+            self._notifier.call_parked(parked_call, tenant_uuid)
+
+    @convert_ami_event
+    def on_ami_call_unparked(
+        self, parked_call: AsteriskParkedCall, parked_channel: Channel
+    ) -> None:
+        '''A call has been unparked'''
+
+        self._set_parked_status(parked_channel, False)
+        retriever_channel = parked_channel.only_connected_channel()
+
+        if tenant_uuid := parked_channel.tenant_uuid():
+            self._notifier.call_unparked(parked_call, retriever_channel.id, tenant_uuid)
+
+    @convert_ami_event
+    def on_ami_parked_call_hangup(
+        self, parked_call: AsteriskParkedCall, _: Channel
+    ) -> None:
+        '''A parked call has been hungup before being answered'''
+
+        vars = parked_call.parkee_chan_variable.split('=')
+        if vars[0] == 'WAZO_TENANT_UUID':
+            tenant_uuid = vars.pop()
+
+        if tenant_uuid:
+            self._notifier.parked_call_hangup(parked_call, tenant_uuid)
+
+    @convert_ami_event
+    def on_ami_parked_call_swap(
+        self, parked_call: AsteriskParkedCall, parked_channel: Channel
+    ) -> None:
+        '''A parked call has been swaped'''
+
+        self._set_parked_status(parked_channel, False)
+
+    @convert_ami_event
+    def on_ami_parked_call_timed_out(
+        self, parked_call: AsteriskParkedCall, parked_channel: Channel
+    ) -> None:
+        '''A parked call has timed out'''
+
+        self._set_parked_status(parked_channel, False)
+
+        if tenant_uuid := parked_channel.tenant_uuid():
+            self._notifier.parked_call_timed_out(parked_call, tenant_uuid)

--- a/wazo_calld/plugins/parking_lots/bus_consume.py
+++ b/wazo_calld/plugins/parking_lots/bus_consume.py
@@ -4,19 +4,21 @@
 from __future__ import annotations
 
 import logging
+from functools import wraps
+from typing import TYPE_CHECKING, Callable
 
 from ari.exceptions import ARINotFound
-from functools import wraps
-from typing import Callable, TYPE_CHECKING
 
-from wazo_calld.plugin_helpers.ari_ import set_channel_id_var_sync, Channel
+from wazo_calld.plugin_helpers.ari_ import Channel, set_channel_id_var_sync
+
 from .dataclasses_ import AsteriskParkedCall
 from .exceptions import NoSuchParking
-from .helpers import split_parking_id_from_name, DONT_CHECK_TENANT
+from .helpers import DONT_CHECK_TENANT, split_parking_id_from_name
 
 if TYPE_CHECKING:
-    from wazo_calld.bus import CoreBusConsumer
     from wazo_calld.ari_ import CoreARI
+    from wazo_calld.bus import CoreBusConsumer
+
     from .notifier import ParkingNotifier
     from .services import ParkingService
 

--- a/wazo_calld/plugins/parking_lots/cache.py
+++ b/wazo_calld/plugins/parking_lots/cache.py
@@ -4,11 +4,11 @@
 from __future__ import annotations
 
 import logging
+from threading import Lock
+from time import monotonic_ns
+from typing import TYPE_CHECKING, TypedDict
 
 from requests import HTTPError, RequestException
-from time import monotonic_ns
-from threading import Lock
-from typing import TypedDict, TYPE_CHECKING
 
 from wazo_calld.plugin_helpers.exceptions import WazoConfdUnreachable
 
@@ -16,8 +16,9 @@ from .dataclasses_ import ConfdParkingLot
 from .exceptions import NoSuchParking
 
 if TYPE_CHECKING:
-    from wazo_calld.bus import CoreBusConsumer as BusConsumer
     from wazo_confd_client import Client as ConfdClient
+
+    from wazo_calld.bus import CoreBusConsumer as BusConsumer
 
 
 logger = logging.getLogger(__name__)

--- a/wazo_calld/plugins/parking_lots/cache.py
+++ b/wazo_calld/plugins/parking_lots/cache.py
@@ -115,4 +115,4 @@ class ParkingLotCache:
     def _subscribe(self, bus: BusConsumer) -> None:
         bus.subscribe('parking_lot_created', self._on_parking_created)
         bus.subscribe('parking_lot_deleted', self._on_parking_deleted)
-        bus.subscribe('parking_lot_updated', self._on_parking_updated)
+        bus.subscribe('parking_lot_edited', self._on_parking_updated)

--- a/wazo_calld/plugins/parking_lots/cache.py
+++ b/wazo_calld/plugins/parking_lots/cache.py
@@ -13,7 +13,7 @@ from typing import TypedDict, TYPE_CHECKING
 from wazo_calld.plugin_helpers.exceptions import WazoConfdUnreachable
 
 from .dataclasses_ import ConfdParkingLot
-from .exceptions import NoSuchParkingException
+from .exceptions import NoSuchParking
 
 if TYPE_CHECKING:
     from wazo_calld.bus import CoreBusConsumer as BusConsumer
@@ -59,7 +59,7 @@ class ParkingLotCache:
         if parking_id in self._invalid_ids:
             with self._lock:
                 self._invalid_ids[parking_id].refresh()
-            raise NoSuchParkingException(parking_id)
+            raise NoSuchParking(parking_id)
 
         if parking_id not in self._cache:
             try:
@@ -91,7 +91,7 @@ class ParkingLotCache:
             result = self._confd.parking_lots.get(parking_id)
         except HTTPError as e:
             if e.response.status_code == 404:
-                raise NoSuchParkingException(parking_id)
+                raise NoSuchParking(parking_id)
             raise
         except RequestException as e:
             raise WazoConfdUnreachable(self._confd, e)

--- a/wazo_calld/plugins/parking_lots/cache.py
+++ b/wazo_calld/plugins/parking_lots/cache.py
@@ -1,0 +1,117 @@
+# Copyright 2024 The Wazo Authors (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import logging
+
+from requests import HTTPError, RequestException
+from time import monotonic_ns
+from threading import Lock
+from typing import TypedDict, TYPE_CHECKING
+
+from wazo_calld.plugin_helpers.exceptions import WazoConfdUnreachable
+
+from .dataclasses_ import ConfdParkingLot
+from .exceptions import NoSuchParkingException
+
+if TYPE_CHECKING:
+    from wazo_calld.bus import CoreBusConsumer as BusConsumer
+    from wazo_confd_client import Client as ConfdClient
+
+
+logger = logging.getLogger(__name__)
+
+
+def to_nsec(seconds: int) -> int:
+    return seconds * 1_000_000_000
+
+
+class _ParkinglotEventPayload(TypedDict, total=False):
+    id: int
+
+
+class _TTLEntry:
+    hits: int
+    expiration: int
+
+    def __init__(self, ttl: int = 10):
+        self.hits = 0
+        self.expiration = monotonic_ns() + to_nsec(ttl)
+
+    def refresh(self, ttl: int = 10):
+        self.hits += 1
+        self.expiration = monotonic_ns() + to_nsec(ttl)
+        return self
+
+
+class ParkingLotCache:
+    def __init__(self, bus: BusConsumer, confd: ConfdClient):
+        self._cache: dict[int, ConfdParkingLot] = {}
+        self._invalid_ids: dict[int, _TTLEntry] = {}
+        self._confd = confd
+        self._lock = Lock()
+        self._subscribe(bus)
+
+    def __getitem__(self, parking_id: int) -> ConfdParkingLot:
+        self.evict_expired()
+
+        if parking_id in self._invalid_ids:
+            with self._lock:
+                self._invalid_ids[parking_id].refresh()
+            raise NoSuchParkingException(parking_id)
+
+        if parking_id not in self._cache:
+            try:
+                return self._fetch_parking_lot(parking_id)
+            except Exception:
+                with self._lock:
+                    self._invalid_ids[parking_id] = _TTLEntry(10)
+                raise
+
+        return self._cache[parking_id]
+
+    def evict_expired(self):
+        now = monotonic_ns()
+        for index in list(self._invalid_ids.keys()):
+            if now >= self._invalid_ids[index].expiration:
+                logger.debug('evicted expired id from cache: %d', index)
+                with self._lock:
+                    del self._invalid_ids[index]
+
+    def invalidate(self, key: int) -> None:
+        logger.debug('invalidating parking: %s', key)
+        with self._lock:
+            self._invalid_ids.pop(key, None)
+            self._cache.pop(key, None)
+
+    def _fetch_parking_lot(self, parking_id: int) -> ConfdParkingLot:
+        logger.debug('fetching parking_lot from confd: %d', parking_id)
+        try:
+            result = self._confd.parking_lots.get(parking_id)
+        except HTTPError as e:
+            if e.response.status_code == 404:
+                raise NoSuchParkingException(parking_id)
+            raise
+        except RequestException as e:
+            raise WazoConfdUnreachable(self._confd, e)
+        else:
+            parking = ConfdParkingLot.from_dict(result)
+            with self._lock:
+                self._cache[parking.id] = parking
+
+            return parking
+
+    def _on_parking_created(self, payload: _ParkinglotEventPayload) -> None:
+        self.invalidate(payload['id'])
+
+    def _on_parking_updated(self, payload: _ParkinglotEventPayload) -> None:
+        self.invalidate(payload['id'])
+
+    def _on_parking_deleted(self, payload: _ParkinglotEventPayload) -> None:
+        self.invalidate(payload['id'])
+
+    def _subscribe(self, bus: BusConsumer) -> None:
+        bus.subscribe('parking_lot_created', self._on_parking_created)
+        bus.subscribe('parking_lot_deleted', self._on_parking_deleted)
+        bus.subscribe('parking_lot_updated', self._on_parking_updated)

--- a/wazo_calld/plugins/parking_lots/dataclasses_.py
+++ b/wazo_calld/plugins/parking_lots/dataclasses_.py
@@ -1,0 +1,72 @@
+# Copyright 2024 The Wazo Authors (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from .helpers import dataclass_from_dict
+
+ChannelStateDesc = Literal[
+    'Down',
+    'Rsrvd',
+    'OffHook',
+    'Dialing',
+    'Ring',
+    'Ringing',
+    'Up',
+    'Busy',
+    'Dialing OffHook',
+    'Pre-ring',
+    'Unknown',
+]
+
+
+class _FromDictMixin:
+    @classmethod
+    def from_dict(cls, mapping: dict):
+        return dataclass_from_dict(cls, mapping)
+
+
+@dataclass
+class ConfdParkingExtension(_FromDictMixin):
+    id: int
+    exten: str
+    context: str
+
+
+@dataclass
+class ConfdParkingLot(_FromDictMixin):
+    id: int
+    tenant_uuid: str
+    name: str
+    slots_start: str
+    slots_end: str
+    timeout: str
+    music_on_hold: str
+    extensions: list[ConfdParkingExtension]
+
+
+@dataclass(frozen=True)
+class AsteriskParkedCall(_FromDictMixin):
+    parkee_channel: str
+    parkee_channel_state: str
+    parkee_channel_state_desc: ChannelStateDesc
+    parkee_caller_id_num: str
+    parkee_caller_id_name: str
+    parkee_connected_line_num: str
+    parkee_connected_line_name: str
+    parkee_language: str
+    parkee_account_code: str
+    parkee_context: str
+    parkee_exten: str
+    parkee_priority: str
+    parkee_uniqueid: str
+    parkee_linkedid: str
+    parkee_chan_variable: str
+    parker_dial_string: str
+    parkinglot: str
+    parking_space: str
+    parking_timeout: str
+    parking_duration: str

--- a/wazo_calld/plugins/parking_lots/exceptions.py
+++ b/wazo_calld/plugins/parking_lots/exceptions.py
@@ -16,7 +16,7 @@ class InvalidCall(APIException):
         )
 
 
-class NoSuchParkingException(APIException):
+class NoSuchParking(APIException):
     def __init__(self, parking_id: int):
         super().__init__(
             status_code=404,

--- a/wazo_calld/plugins/parking_lots/exceptions.py
+++ b/wazo_calld/plugins/parking_lots/exceptions.py
@@ -1,0 +1,69 @@
+# Copyright 2024 The Wazo Authors (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from wazo_calld.exceptions import APIException
+
+
+class InvalidCall(APIException):
+    def __init__(self, call_id: str, reason: str):
+        super().__init__(
+            status_code=400,
+            message=f'unable to park call: {call_id}, reason={reason}',
+            error_id='cannot-park-call',
+            details={'call_id': call_id, 'reason': reason},
+        )
+
+
+class NoSuchParkingException(APIException):
+    def __init__(self, parking_id: int):
+        super().__init__(
+            status_code=404,
+            message=f'No such parking: id={parking_id}',
+            error_id='no-such-parking',
+            resource='parking_lots',
+            details={
+                'parking_id': parking_id,
+            },
+        )
+
+
+class NoSuchParkedCall(APIException):
+    def __init__(self, tenant_uuid: str, parking_id: int, call_id: str):
+        super().__init__(
+            status_code=404,
+            message=f'No such parked call: parking={parking_id}, call={call_id}',
+            error_id='no-such-parked-call',
+            resource='parking_lots',
+            details={
+                'tenant_uuid': tenant_uuid,
+                'parking_id': parking_id,
+                'call_id': call_id,
+            },
+        )
+
+
+class NoSuchCall(APIException):
+    def __init__(self, call_id: str):
+        super().__init__(
+            status_code=404,
+            message=f'No such call: {call_id}',
+            error_id='no-such-call',
+            details={'call_id': call_id},
+        )
+
+
+class ParkingFull(APIException):
+    def __init__(self, tenant_uuid: str, parking_id: int, call_id: str):
+        super().__init__(
+            status_code=503,
+            message=f'Unable to park call {call_id}: parking is full',
+            error_id='parking-full',
+            resource='parking_lots',
+            details={
+                'tenant_uuid': tenant_uuid,
+                'parking_id': parking_id,
+                'call_id': call_id,
+            },
+        )

--- a/wazo_calld/plugins/parking_lots/helpers.py
+++ b/wazo_calld/plugins/parking_lots/helpers.py
@@ -56,3 +56,10 @@ def dataclass_from_dict(dataclass: type[T], dict_: dict) -> T:
             args[key] = value
 
     return dataclass(**args)
+
+
+def split_parking_id_from_name(parking_name: str) -> int:
+    prefix, *id_ = parking_name.split('-', 1)
+    if not id_ or prefix != 'parkinglot':
+        raise ValueError('invalid parking lot name')
+    return int(id_.pop(0))

--- a/wazo_calld/plugins/parking_lots/helpers.py
+++ b/wazo_calld/plugins/parking_lots/helpers.py
@@ -73,10 +73,9 @@ def split_parking_id_from_name(parking_name: str) -> int:
     return int(id_.pop(0))
 
 
-def timestamp(seconds: str) -> str | None:
-    '''Helper to convert seconds to a timestamp in the future'''
-    value = int(seconds)
-    if not value:
+def timestamp(seconds: int | str) -> str | None:
+    '''Helper to convert seconds to a timestamp'''
+    if not (value := int(seconds or 0)):
         return None
 
     now = datetime.now(timezone.utc)
@@ -88,9 +87,9 @@ def timestamp(seconds: str) -> str | None:
     return timestamp.replace(microsecond=0).isoformat()
 
 
-def timestamp_since(seconds_ago: str) -> str:
+def timestamp_since(seconds_ago: int | str) -> str:
     '''Helper to convert seconds to a timestamp in the past'''
-    value = int(seconds_ago)
-    now = datetime.now(timezone.utc)
+    value = abs(int(seconds_ago or 0))
+    now = datetime.now(timezone.utc).replace(microsecond=0)
     timestamp = now - timedelta(seconds=value)
-    return timestamp.replace(microsecond=0).isoformat()
+    return timestamp.isoformat()

--- a/wazo_calld/plugins/parking_lots/helpers.py
+++ b/wazo_calld/plugins/parking_lots/helpers.py
@@ -6,8 +6,16 @@ from __future__ import annotations
 import re
 
 from dataclasses import is_dataclass
+from enum import auto, Enum
 from inspect import signature
 from typing import Any, get_args, get_origin, get_type_hints, TypeVar
+
+
+class DontCheckTenant(Enum):
+    DONT_CHECK_TENANT = auto()
+
+
+DONT_CHECK_TENANT = DontCheckTenant.DONT_CHECK_TENANT
 
 T = TypeVar('T')
 

--- a/wazo_calld/plugins/parking_lots/helpers.py
+++ b/wazo_calld/plugins/parking_lots/helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import is_dataclass
+from datetime import datetime, timedelta, timezone
 from enum import Enum, auto
 from inspect import signature
 from typing import Any, TypeVar, get_args, get_origin, get_type_hints
@@ -70,3 +71,26 @@ def split_parking_id_from_name(parking_name: str) -> int:
     if not id_ or prefix != 'parkinglot':
         raise ValueError('invalid parking lot name')
     return int(id_.pop(0))
+
+
+def timestamp(seconds: str) -> str | None:
+    '''Helper to convert seconds to a timestamp in the future'''
+    value = int(seconds)
+    if not value:
+        return None
+
+    now = datetime.now(timezone.utc)
+
+    try:
+        timestamp = now + timedelta(seconds=value)
+    except OverflowError:
+        return None
+    return timestamp.replace(microsecond=0).isoformat()
+
+
+def timestamp_since(seconds_ago: str) -> str:
+    '''Helper to convert seconds to a timestamp in the past'''
+    value = int(seconds_ago)
+    now = datetime.now(timezone.utc)
+    timestamp = now - timedelta(seconds=value)
+    return timestamp.replace(microsecond=0).isoformat()

--- a/wazo_calld/plugins/parking_lots/helpers.py
+++ b/wazo_calld/plugins/parking_lots/helpers.py
@@ -4,11 +4,10 @@
 from __future__ import annotations
 
 import re
-
 from dataclasses import is_dataclass
-from enum import auto, Enum
+from enum import Enum, auto
 from inspect import signature
-from typing import Any, get_args, get_origin, get_type_hints, TypeVar
+from typing import Any, TypeVar, get_args, get_origin, get_type_hints
 
 
 class DontCheckTenant(Enum):

--- a/wazo_calld/plugins/parking_lots/helpers.py
+++ b/wazo_calld/plugins/parking_lots/helpers.py
@@ -1,0 +1,58 @@
+# Copyright 2024 The Wazo Authors (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import re
+
+from dataclasses import is_dataclass
+from inspect import signature
+from typing import Any, get_args, get_origin, get_type_hints, TypeVar
+
+T = TypeVar('T')
+
+_CAMEL_TO_SNAKE = (
+    re.compile(r'(.)([A-Z][a-z]+)'),
+    re.compile(r'__([A-Z])'),
+    re.compile(r'([a-z0-9])([A-Z])'),
+)
+
+
+def camel_to_snake(name: str) -> str:
+    '''Helper function to convert CamelCase to snake_case'''
+    name = _CAMEL_TO_SNAKE[0].sub(r'\1_\2', name)
+    name = _CAMEL_TO_SNAKE[1].sub(r'_\1', name)
+    name = _CAMEL_TO_SNAKE[2].sub(r'\1_\2', name)
+    return name.lower()
+
+
+def snakify_keys(dict_: dict[str, Any]) -> dict[str, Any]:
+    '''Helper to convert CamelCase to snake_case'''
+    return {camel_to_snake(k) if k[0].isupper() else k: v for k, v in dict_.items()}
+
+
+def dataclass_from_dict(dataclass: type[T], dict_: dict) -> T:
+    '''Helper to recursively instanciate a dataclass while ignoring unknown parameters'''
+    dict_ = snakify_keys(dict_)
+    valid_props = signature(dataclass).parameters
+    hints: dict[str, type] = get_type_hints(dataclass)
+    args = {}
+
+    for key, value in dict_.items():
+        if key not in valid_props:
+            continue
+
+        type_ = hints[key]
+        if get_origin(type_) in (list, set, tuple):
+            if is_dataclass(nested_type := get_args(type_)[0]):
+                args[key] = type_(
+                    [dataclass_from_dict(nested_type, item) for item in value]
+                )
+                continue
+            args[key] = type_(value)
+        elif is_dataclass(type_):
+            args[key] = dataclass_from_dict(type_, value)
+        else:
+            args[key] = value
+
+    return dataclass(**args)

--- a/wazo_calld/plugins/parking_lots/http.py
+++ b/wazo_calld/plugins/parking_lots/http.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from flask import request
 from xivo.tenant_flask_helpers import Tenant
 
-from wazo_calld.auth import required_acl
+from wazo_calld.auth import get_token_user_uuid_from_request, required_acl
 from wazo_calld.http import AuthResource
 
 from .schemas import (
@@ -48,9 +48,10 @@ class ParkCallResource(_Base):
 class UserCallParkResource(_Base):
     @required_acl('calld.users.me.calls.{call_id}.park.update')
     def put(self, call_id: str):
+        user_uuid: str = get_token_user_uuid_from_request()
         request_data = park_call_request_schema.load(request.get_json(force=True))
 
         parked_call = self._service.park_collocutor_call(
-            request.user_uuid, request_data.pop('parking_id'), call_id, **request_data
+            user_uuid, request_data.pop('parking_id'), call_id, **request_data
         )
         return parked_call_put_response_schema.dump(parked_call), 200

--- a/wazo_calld/plugins/parking_lots/http.py
+++ b/wazo_calld/plugins/parking_lots/http.py
@@ -1,0 +1,62 @@
+# Copyright 2024 The Wazo Authors (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from flask import request
+from xivo.tenant_flask_helpers import Tenant
+
+from wazo_calld.auth import required_acl
+from wazo_calld.http import AuthResource
+
+from .schemas import (
+    ParkingLotSchema,
+    park_call_request_schema,
+    parked_call_put_response_schema,
+)
+from .services import ParkingService
+
+
+class _Base(AuthResource):
+    def __init__(self, parking_service: ParkingService):
+        self._service = parking_service
+
+
+class ParkingLotResource(_Base):
+    @required_acl('calld.parkings.{parking_id}.read')
+    def get(self, parking_id: int) -> tuple[dict, int]:
+        tenant = Tenant.autodetect()
+        parking_lot = self._service.get_parking(tenant.uuid, parking_id)
+        calls = self._service.list_parked_calls(tenant.uuid, parking_id)
+
+        return ParkingLotSchema(context={'calls': calls}).dump(parking_lot), 200
+
+
+class ParkCallResource(_Base):
+    @required_acl('calld.calls.{call_id}.park.update')
+    def put(self, call_id: str):
+        tenant = Tenant.autodetect()
+        request_data = park_call_request_schema.load(request.get_json(force=True))
+
+        parked_call = self._service.park_call(
+            request_data.pop('parking_id'),
+            call_id,
+            tenant_uuid=tenant.uuid,
+            **request_data,
+        )
+
+        return parked_call_put_response_schema.dump(parked_call), 200
+
+
+class UserCallParkResource(_Base):
+    @required_acl('calld.users.me.calls.{call_id}.park.update')
+    def put(self, call_id: str):
+        request_data = park_call_request_schema.load(request.get_json(force=True))
+
+        parked_call = self._service.park_peer_call(
+            request.user_uuid,
+            request_data.pop('parking_id'),
+            call_id,
+            **request_data,
+        )
+        return parked_call_put_response_schema.dump(parked_call), 200

--- a/wazo_calld/plugins/parking_lots/http.py
+++ b/wazo_calld/plugins/parking_lots/http.py
@@ -39,10 +39,7 @@ class ParkCallResource(_Base):
         request_data = park_call_request_schema.load(request.get_json(force=True))
 
         parked_call = self._service.park_call(
-            request_data.pop('parking_id'),
-            call_id,
-            tenant_uuid=tenant.uuid,
-            **request_data,
+            request_data.pop('parking_id'), call_id, tenant.uuid, **request_data
         )
 
         return parked_call_put_response_schema.dump(parked_call), 200
@@ -53,10 +50,7 @@ class UserCallParkResource(_Base):
     def put(self, call_id: str):
         request_data = park_call_request_schema.load(request.get_json(force=True))
 
-        parked_call = self._service.park_peer_call(
-            request.user_uuid,
-            request_data.pop('parking_id'),
-            call_id,
-            **request_data,
+        parked_call = self._service.park_collocutor_call(
+            request.user_uuid, request_data.pop('parking_id'), call_id, **request_data
         )
         return parked_call_put_response_schema.dump(parked_call), 200

--- a/wazo_calld/plugins/parking_lots/http.py
+++ b/wazo_calld/plugins/parking_lots/http.py
@@ -46,7 +46,7 @@ class ParkCallResource(_Base):
 
 
 class UserCallParkResource(_Base):
-    @required_acl('calld.users.me.calls.{call_id}.collocutor.park.update')
+    @required_acl('calld.users.me.calls.{call_id}.park.update')
     def put(self, call_id: str):
         user_uuid: str = get_token_user_uuid_from_request()
         request_data = park_call_request_schema.load(request.get_json(force=True))

--- a/wazo_calld/plugins/parking_lots/http.py
+++ b/wazo_calld/plugins/parking_lots/http.py
@@ -46,7 +46,7 @@ class ParkCallResource(_Base):
 
 
 class UserCallParkResource(_Base):
-    @required_acl('calld.users.me.calls.{call_id}.park.update')
+    @required_acl('calld.users.me.calls.{call_id}.collocutor.park.update')
     def put(self, call_id: str):
         user_uuid: str = get_token_user_uuid_from_request()
         request_data = park_call_request_schema.load(request.get_json(force=True))

--- a/wazo_calld/plugins/parking_lots/http.py
+++ b/wazo_calld/plugins/parking_lots/http.py
@@ -51,7 +51,7 @@ class UserCallParkResource(_Base):
         user_uuid: str = get_token_user_uuid_from_request()
         request_data = park_call_request_schema.load(request.get_json(force=True))
 
-        parked_call = self._service.park_collocutor_call(
+        parked_call = self._service.user_park_call(
             user_uuid, request_data.pop('parking_id'), call_id, **request_data
         )
         return parked_call_put_response_schema.dump(parked_call), 200

--- a/wazo_calld/plugins/parking_lots/notifier.py
+++ b/wazo_calld/plugins/parking_lots/notifier.py
@@ -13,7 +13,7 @@ from wazo_bus.resources.calls.parking import (
     ParkedCallTimedOutEvent,
 )
 
-from .helpers import split_parking_id_from_name
+from .helpers import split_parking_id_from_name, timestamp, timestamp_since
 
 if TYPE_CHECKING:
     from wazo_calld.bus import CoreBusPublisher
@@ -40,7 +40,7 @@ class ParkingNotifier:
             parked_call.parkee_uniqueid,
             split_parking_id_from_name(parked_call.parkinglot),
             parked_call.parking_space,
-            self._to_timestamp(parked_call.parking_timeout),
+            timestamp(parked_call.parking_timeout),
             tenant_uuid,
         )
         self._publisher.publish(event)
@@ -64,7 +64,7 @@ class ParkingNotifier:
             parked_call.parkee_uniqueid,
             split_parking_id_from_name(parked_call.parkinglot),
             parked_call.parker_dial_string,
-            self._since_timestamp(parked_call.parking_duration),
+            timestamp_since(parked_call.parking_duration),
             tenant_uuid,
         )
         self._publisher.publish(event)
@@ -76,7 +76,7 @@ class ParkingNotifier:
             parked_call.parkee_uniqueid,
             split_parking_id_from_name(parked_call.parkinglot),
             parked_call.parking_space,
-            self._since_timestamp(parked_call.parking_duration),
+            timestamp_since(parked_call.parking_duration),
             tenant_uuid,
         )
         self._publisher.publish(event)

--- a/wazo_calld/plugins/parking_lots/notifier.py
+++ b/wazo_calld/plugins/parking_lots/notifier.py
@@ -12,6 +12,7 @@ from wazo_bus.resources.calls.parking import (
     ParkedCallTimedOutEvent,
 )
 
+from .helpers import split_parking_id_from_name
 
 if TYPE_CHECKING:
     from wazo_calld.bus import CoreBusPublisher
@@ -21,12 +22,6 @@ if TYPE_CHECKING:
 class ParkingNotifier:
     def __init__(self, bus_publisher: CoreBusPublisher):
         self._publisher = bus_publisher
-
-    def _get_parking_id(self, parkinglot_name: str) -> str | None:
-        _, *id_ = parkinglot_name.split('-', 1)
-        if not id_:
-            return None
-        return str(*id_)
 
     def _to_timestamp(self, value: str) -> str:
         now = datetime.now(timezone.utc)
@@ -41,7 +36,7 @@ class ParkingNotifier:
     def call_parked(self, parked_call: AsteriskParkedCall, tenant_uuid: str) -> None:
         event = CallParkedEvent(
             parked_call.parkee_uniqueid,
-            self._get_parking_id(parked_call.parkinglot),
+            split_parking_id_from_name(parked_call.parkinglot),
             parked_call.parking_space,
             self._to_timestamp(parked_call.parking_timeout),
             tenant_uuid,
@@ -53,7 +48,7 @@ class ParkingNotifier:
     ) -> None:
         event = CallUnparkedEvent(
             parked_call.parkee_uniqueid,
-            self._get_parking_id(parked_call.parkinglot),
+            split_parking_id_from_name(parked_call.parkinglot),
             parked_call.parking_space,
             retriever_call,
             tenant_uuid,
@@ -65,7 +60,7 @@ class ParkingNotifier:
     ) -> None:
         event = ParkedCallTimedOutEvent(
             parked_call.parkee_uniqueid,
-            self._get_parking_id(parked_call.parkinglot),
+            split_parking_id_from_name(parked_call.parkinglot),
             parked_call.parker_dial_string,
             self._since_timestamp(parked_call.parking_duration),
             tenant_uuid,
@@ -77,7 +72,7 @@ class ParkingNotifier:
     ) -> None:
         event = ParkedCallHungupEvent(
             parked_call.parkee_uniqueid,
-            self._get_parking_id(parked_call.parkinglot),
+            split_parking_id_from_name(parked_call.parkinglot),
             parked_call.parking_space,
             self._since_timestamp(parked_call.parking_duration),
             tenant_uuid,

--- a/wazo_calld/plugins/parking_lots/notifier.py
+++ b/wazo_calld/plugins/parking_lots/notifier.py
@@ -1,0 +1,85 @@
+# Copyright 2024 The Wazo Authors (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+from wazo_bus.resources.calls.parking import (
+    CallParkedEvent,
+    CallUnparkedEvent,
+    ParkedCallHungupEvent,
+    ParkedCallTimedOutEvent,
+)
+
+
+if TYPE_CHECKING:
+    from wazo_calld.bus import CoreBusPublisher
+    from .dataclasses_ import AsteriskParkedCall
+
+
+class ParkingNotifier:
+    def __init__(self, bus_publisher: CoreBusPublisher):
+        self._publisher = bus_publisher
+
+    def _get_parking_id(self, parkinglot_name: str) -> str | None:
+        _, *id_ = parkinglot_name.split('-', 1)
+        if not id_:
+            return None
+        return str(*id_)
+
+    def _to_timestamp(self, value: str) -> str:
+        now = datetime.now(timezone.utc)
+        timestamp = now + timedelta(seconds=int(value))
+        return timestamp.isoformat()
+
+    def _since_timestamp(self, value: str) -> str:
+        now = datetime.now(timezone.utc)
+        timestamp = now - timedelta(seconds=int(value))
+        return timestamp.isoformat()
+
+    def call_parked(self, parked_call: AsteriskParkedCall, tenant_uuid: str) -> None:
+        event = CallParkedEvent(
+            parked_call.parkee_uniqueid,
+            self._get_parking_id(parked_call.parkinglot),
+            parked_call.parking_space,
+            self._to_timestamp(parked_call.parking_timeout),
+            tenant_uuid,
+        )
+        self._publisher.publish(event)
+
+    def call_unparked(
+        self, parked_call: AsteriskParkedCall, retriever_call: str, tenant_uuid: str
+    ) -> None:
+        event = CallUnparkedEvent(
+            parked_call.parkee_uniqueid,
+            self._get_parking_id(parked_call.parkinglot),
+            parked_call.parking_space,
+            retriever_call,
+            tenant_uuid,
+        )
+        self._publisher.publish(event)
+
+    def parked_call_timed_out(
+        self, parked_call: AsteriskParkedCall, tenant_uuid: str
+    ) -> None:
+        event = ParkedCallTimedOutEvent(
+            parked_call.parkee_uniqueid,
+            self._get_parking_id(parked_call.parkinglot),
+            parked_call.parker_dial_string,
+            self._since_timestamp(parked_call.parking_duration),
+            tenant_uuid,
+        )
+        self._publisher.publish(event)
+
+    def parked_call_hangup(
+        self, parked_call: AsteriskParkedCall, tenant_uuid: str
+    ) -> None:
+        event = ParkedCallHungupEvent(
+            parked_call.parkee_uniqueid,
+            self._get_parking_id(parked_call.parkinglot),
+            parked_call.parking_space,
+            self._since_timestamp(parked_call.parking_duration),
+            tenant_uuid,
+        )
+        self._publisher.publish(event)

--- a/wazo_calld/plugins/parking_lots/notifier.py
+++ b/wazo_calld/plugins/parking_lots/notifier.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 from wazo_bus.resources.calls.parking import (
@@ -24,16 +23,6 @@ if TYPE_CHECKING:
 class ParkingNotifier:
     def __init__(self, bus_publisher: CoreBusPublisher):
         self._publisher = bus_publisher
-
-    def _to_timestamp(self, value: str) -> str:
-        now = datetime.now(timezone.utc)
-        timestamp = now + timedelta(seconds=int(value))
-        return timestamp.isoformat()
-
-    def _since_timestamp(self, value: str) -> str:
-        now = datetime.now(timezone.utc)
-        timestamp = now - timedelta(seconds=int(value))
-        return timestamp.isoformat()
 
     def call_parked(self, parked_call: AsteriskParkedCall, tenant_uuid: str) -> None:
         event = CallParkedEvent(

--- a/wazo_calld/plugins/parking_lots/notifier.py
+++ b/wazo_calld/plugins/parking_lots/notifier.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
+
 from wazo_bus.resources.calls.parking import (
     CallParkedEvent,
     CallUnparkedEvent,
@@ -16,6 +17,7 @@ from .helpers import split_parking_id_from_name
 
 if TYPE_CHECKING:
     from wazo_calld.bus import CoreBusPublisher
+
     from .dataclasses_ import AsteriskParkedCall
 
 

--- a/wazo_calld/plugins/parking_lots/plugin.py
+++ b/wazo_calld/plugins/parking_lots/plugin.py
@@ -44,7 +44,7 @@ class Plugin:
 
         notifier = ParkingNotifier(bus_publisher)
         service = ParkingService(amid_client, ari, bus_consumer, confd_client, notifier)
-        ParkingLotEventsHandler(ari, bus_consumer, notifier)
+        ParkingLotEventsHandler(ari, bus_consumer, notifier, service)
 
         self.set_resources(api, service)
 

--- a/wazo_calld/plugins/parking_lots/plugin.py
+++ b/wazo_calld/plugins/parking_lots/plugin.py
@@ -3,24 +3,22 @@
 
 from __future__ import annotations
 
-from typing import Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 from wazo_amid_client import Client as AmidClient
 from wazo_confd_client import Client as ConfdClient
 
-from .http import (
-    ParkingLotResource,
-    ParkCallResource,
-    UserCallParkResource,
-)
 from .bus_consume import ParkingLotEventsHandler
+from .http import ParkCallResource, ParkingLotResource, UserCallParkResource
 from .notifier import ParkingNotifier
 from .services import ParkingService
 
 if TYPE_CHECKING:
-    from collections import Mapping
+    from collections.abc import Mapping
+
     from flask_restful import Api
     from xivo.token_renewer import Callback
+
     from wazo_calld.ari_ import CoreARI as AriClient
     from wazo_calld.bus import CoreBusConsumer, CoreBusPublisher
 

--- a/wazo_calld/plugins/parking_lots/plugin.py
+++ b/wazo_calld/plugins/parking_lots/plugin.py
@@ -49,7 +49,7 @@ class Plugin:
     def set_resources(self, api: Api, service: ParkingService) -> None:
         api.add_resource(
             ParkingLotResource,
-            '/parking_lots/<int:parking_id>',
+            '/parkinglots/<int:parking_id>',
             resource_class_args=[service],
         )
 
@@ -61,6 +61,6 @@ class Plugin:
 
         api.add_resource(
             UserCallParkResource,
-            '/users/me/calls/<call_id>/collocutor/park',
+            '/users/me/calls/<call_id>/park',
             resource_class_args=[service],
         )

--- a/wazo_calld/plugins/parking_lots/plugin.py
+++ b/wazo_calld/plugins/parking_lots/plugin.py
@@ -1,0 +1,68 @@
+# Copyright 2024 The Wazo Authors (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from typing import Callable, TYPE_CHECKING
+
+from wazo_amid_client import Client as AmidClient
+from wazo_confd_client import Client as ConfdClient
+
+from .http import (
+    ParkingLotResource,
+    ParkCallResource,
+    UserCallParkResource,
+)
+from .bus_consume import ParkingLotEventsHandler
+from .notifier import ParkingNotifier
+from .services import ParkingService
+
+if TYPE_CHECKING:
+    from collections import Mapping
+    from flask_restful import Api
+    from xivo.token_renewer import Callback
+    from wazo_calld.ari_ import CoreARI as AriClient
+    from wazo_calld.bus import CoreBusConsumer, CoreBusPublisher
+
+
+class Plugin:
+    def load(self, dependencies: Mapping) -> None:
+        api: Api = dependencies['api']
+        ari: AriClient = dependencies['ari']
+        bus_consumer: CoreBusConsumer = dependencies['bus_consumer']
+        bus_publisher: CoreBusPublisher = dependencies['bus_publisher']
+        config: Mapping = dependencies['config']
+        token_changed_subscribe: Callable[[Callback], None] = dependencies[
+            'token_changed_subscribe'
+        ]
+
+        confd_client = ConfdClient(**config['confd'])
+        amid_client = AmidClient(**config['amid'])
+
+        token_changed_subscribe(confd_client.set_token)
+        token_changed_subscribe(amid_client.set_token)
+
+        notifier = ParkingNotifier(bus_publisher)
+        service = ParkingService(amid_client, ari, bus_consumer, confd_client, notifier)
+        ParkingLotEventsHandler(ari, bus_consumer, notifier)
+
+        self.set_resources(api, service)
+
+    def set_resources(self, api: Api, service: ParkingService) -> None:
+        api.add_resource(
+            ParkingLotResource,
+            '/parking_lots/<int:parking_id>',
+            resource_class_args=[service],
+        )
+
+        api.add_resource(
+            ParkCallResource,
+            '/calls/<call_id>/park',
+            resource_class_args=[service],
+        )
+
+        api.add_resource(
+            UserCallParkResource,
+            '/users/me/calls/<call_id>/collocutor/park',
+            resource_class_args=[service],
+        )

--- a/wazo_calld/plugins/parking_lots/schemas.py
+++ b/wazo_calld/plugins/parking_lots/schemas.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from marshmallow import EXCLUDE, Schema, post_dump, pre_dump
 from marshmallow.fields import Method
-from marshmallow.validate import Predicate
+from marshmallow.validate import Predicate, Range
 from xivo.mallow.fields import Integer, List, Nested, String
 
 from .helpers import timestamp, timestamp_since
@@ -62,7 +62,12 @@ class ParkCallRequestSchema(_Base):
     preferred_slot = String(
         validate=Predicate('isdigit'), allow_none=True, missing=None, load_only=True
     )
-    timeout = Integer(allow_none=True, missing=None, load_only=True)
+    timeout = Integer(
+        validate=Range(min=0, error='Must be a positive integer or 0'),
+        allow_none=True,
+        missing=None,
+        load_only=True,
+    )
 
 
 class ParkedCallPutResponseSchema(_Base):

--- a/wazo_calld/plugins/parking_lots/schemas.py
+++ b/wazo_calld/plugins/parking_lots/schemas.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
-from marshmallow import EXCLUDE, pre_dump, post_dump, Schema
+from marshmallow import EXCLUDE, Schema, post_dump, pre_dump
 from marshmallow.fields import Method
 from marshmallow.validate import Predicate
 from xivo.mallow.fields import Integer, List, Nested, String

--- a/wazo_calld/plugins/parking_lots/schemas.py
+++ b/wazo_calld/plugins/parking_lots/schemas.py
@@ -22,8 +22,6 @@ class _Base(Schema):
 
 
 class ParkingLotSchema(_Base):
-    name = String(dump_only=True)
-    exten = String(dump_only=True, default='')
     slots_start = Integer(dump_only=True)
     slots_end = Integer(dump_only=True)
     slots_total = Integer(dump_only=True, default=0)

--- a/wazo_calld/plugins/parking_lots/schemas.py
+++ b/wazo_calld/plugins/parking_lots/schemas.py
@@ -1,0 +1,92 @@
+# Copyright 2024 The Wazo Authors (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+from marshmallow import EXCLUDE, pre_dump, post_dump, Schema
+from marshmallow.fields import Method
+from marshmallow.validate import Predicate
+from xivo.mallow.fields import Integer, List, Nested, String
+
+if TYPE_CHECKING:
+    from .dataclasses_ import AsteriskParkedCall, ConfdParkingLot
+
+
+class _Base(Schema):
+    class Meta:
+        ordered = True
+        unknown = EXCLUDE
+
+
+class ParkingLotSchema(_Base):
+    name = String(dump_only=True)
+    exten = String(dump_only=True, default='')
+    slots_start = Integer(dump_only=True)
+    slots_end = Integer(dump_only=True)
+    slots_total = Integer(dump_only=True, default=0)
+    slots_remaining = Integer(dump_only=True, default=0)
+    default_timeout = Integer(attribute='timeout', dump_only=True)
+    calls = List(Nested("ParkedCallGetResponseSchema"))
+
+    @pre_dump
+    def calls_from_context(self, obj, **kwargs):
+        if 'calls' in self.context:
+            obj.calls = self.context['calls']
+        return obj
+
+    @post_dump
+    def compute_slots(self, obj, **kwargs):
+        total = 1 + (obj['slots_end'] - obj['slots_start'])
+        obj['slots_total'] = total
+        obj['slots_remaining'] = total - len(obj['calls'])
+        return obj
+
+    @post_dump(pass_original=True)
+    def extract_exten(self, data: dict, original_obj: ConfdParkingLot, **kwargs):
+        if original_obj.extensions:
+            data['exten'] = original_obj.extensions[0].exten
+
+        return data
+
+
+class ParkedCallGetResponseSchema(_Base):
+    call_id = String(attribute='parkee_uniqueid', dump_only=True)
+    slot = String(attribute='parking_space', dump_only=True)
+    parked_at = Method('compute_park_time', dump_only=True)
+    timeout_at = Method('compute_timeout', dump_only=True)
+
+    def compute_park_time(self, parked_call: AsteriskParkedCall) -> str:
+        now = datetime.now(timezone.utc)
+        parked_at = now - timedelta(seconds=int(parked_call.parking_duration))
+        return parked_at.isoformat()
+
+    def compute_timeout(self, parked_call: AsteriskParkedCall) -> str:
+        now = datetime.now(timezone.utc)
+        timeout_at = now + timedelta(seconds=int(parked_call.parking_timeout))
+        return timeout_at.isoformat()
+
+
+class ParkCallRequestSchema(_Base):
+    parking_id = Integer(allow_none=False, required=True, load_only=True)
+    preferred_slot = String(
+        validate=Predicate('isdigit'), allow_none=True, missing=None, load_only=True
+    )
+    timeout = Integer(allow_none=True, missing=None, load_only=True)
+
+
+class ParkedCallPutResponseSchema(_Base):
+    slot = String(attribute='parking_space', dump_only=True)
+    timeout_at = Method('compute_timeout', dump_only=True)
+
+    def compute_timeout(self, parked_call: AsteriskParkedCall) -> str:
+        now = datetime.now(timezone.utc)
+        timeout_at = now + timedelta(seconds=int(parked_call.parking_timeout))
+        return timeout_at.isoformat()
+
+
+park_call_request_schema = ParkCallRequestSchema()
+parked_call_get_response_schema = ParkedCallGetResponseSchema()
+parked_call_put_response_schema = ParkedCallPutResponseSchema()

--- a/wazo_calld/plugins/parking_lots/services.py
+++ b/wazo_calld/plugins/parking_lots/services.py
@@ -4,10 +4,10 @@
 from __future__ import annotations
 
 import logging
+from time import sleep
 from typing import TYPE_CHECKING, TypedDict
 
 from requests import RequestException
-from time import sleep
 from typing_extensions import NotRequired
 
 from wazo_calld.plugin_helpers.ari_ import Channel
@@ -90,7 +90,7 @@ class ParkingService:
             'Parkinglot': f'parkinglot-{parking.id}',
         }
 
-        if timeout:
+        if timeout is not None:
             # Convert to milliseconds for AMI action
             park_payload['Timeout'] = timeout * 1000
 

--- a/wazo_calld/plugins/parking_lots/services.py
+++ b/wazo_calld/plugins/parking_lots/services.py
@@ -26,6 +26,7 @@ from .exceptions import (
     NoSuchParking,
     ParkingFull,
 )
+from .helpers import DontCheckTenant, DONT_CHECK_TENANT
 from .notifier import ParkingNotifier
 
 if TYPE_CHECKING:
@@ -130,9 +131,11 @@ class ParkingService:
             raise NoSuchParkedCall(tenant_uuid, parking_id, call_id)
         return parked_call
 
-    def get_parking(self, tenant_uuid: str | None, parking_id: int) -> ConfdParkingLot:
+    def get_parking(
+        self, tenant_uuid: str | DontCheckTenant, parking_id: int
+    ) -> ConfdParkingLot:
         parking = self._parkings[parking_id]
-        if tenant_uuid and parking.tenant_uuid != tenant_uuid:
+        if tenant_uuid is not DONT_CHECK_TENANT and parking.tenant_uuid != tenant_uuid:
             raise NoSuchParking(parking_id)
         return parking
 

--- a/wazo_calld/plugins/parking_lots/services.py
+++ b/wazo_calld/plugins/parking_lots/services.py
@@ -105,7 +105,7 @@ class ParkingService:
             park_payload['TimeoutChannel'] = parked_call.parker_dial_string
 
         try:
-            self._amid.action('park', park_payload)
+            self._amid.action('Park', park_payload)
         except RequestException as e:
             raise WazoAmidError(self._amid, e)
 
@@ -148,7 +148,7 @@ class ParkingService:
 
         try:
             results: list[dict] = self._amid.action(
-                'parkedcalls', {'ParkingLot': f'parkinglot-{parking.id}'}
+                'ParkedCalls', {'ParkingLot': f'parkinglot-{parking.id}'}
             )
         except RequestException as e:
             raise WazoAmidError(self._amid, e)
@@ -165,7 +165,7 @@ class ParkingService:
 
         try:
             results: list[dict] = self._amid.action(
-                'parkedcalls', {'ParkingLot': f'parkinglot-{parking.id}'}
+                'ParkedCalls', {'ParkingLot': f'parkinglot-{parking.id}'}
             )
         except RequestException as e:
             raise WazoAmidError(self._amid, e)

--- a/wazo_calld/plugins/parking_lots/services.py
+++ b/wazo_calld/plugins/parking_lots/services.py
@@ -23,7 +23,7 @@ from .exceptions import (
     InvalidCall,
     NoSuchCall,
     NoSuchParkedCall,
-    NoSuchParkingException,
+    NoSuchParking,
     ParkingFull,
 )
 from .notifier import ParkingNotifier
@@ -130,10 +130,10 @@ class ParkingService:
             raise NoSuchParkedCall(tenant_uuid, parking_id, call_id)
         return parked_call
 
-    def get_parking(self, tenant_uuid: str, parking_id: int) -> ConfdParkingLot:
+    def get_parking(self, tenant_uuid: str | None, parking_id: int) -> ConfdParkingLot:
         parking = self._parkings[parking_id]
-        if parking.tenant_uuid != tenant_uuid:
-            raise NoSuchParkingException(parking_id)
+        if tenant_uuid and parking.tenant_uuid != tenant_uuid:
+            raise NoSuchParking(parking_id)
         return parking
 
     def list_parked_calls(

--- a/wazo_calld/plugins/parking_lots/services.py
+++ b/wazo_calld/plugins/parking_lots/services.py
@@ -208,7 +208,7 @@ class ParkingService:
             channel, parking, tenant_uuid, preferred_slot, timeout
         )
 
-    def park_collocutor_call(
+    def user_park_call(
         self,
         user_uuid: str,
         parking_id: int,

--- a/wazo_calld/plugins/parking_lots/services.py
+++ b/wazo_calld/plugins/parking_lots/services.py
@@ -4,17 +4,17 @@
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING, TypedDict
 
 from requests import RequestException
-from typing import TypedDict, TYPE_CHECKING
 from typing_extensions import NotRequired
 
 from wazo_calld.plugin_helpers.ari_ import Channel
 from wazo_calld.plugin_helpers.exceptions import (
-    WazoAmidError,
     NotEnoughChannels,
     TooManyChannels,
     UserPermissionDenied,
+    WazoAmidError,
 )
 
 from .cache import ParkingLotCache
@@ -26,14 +26,16 @@ from .exceptions import (
     NoSuchParking,
     ParkingFull,
 )
-from .helpers import DontCheckTenant, DONT_CHECK_TENANT
+from .helpers import DONT_CHECK_TENANT, DontCheckTenant
 from .notifier import ParkingNotifier
 
 if TYPE_CHECKING:
     from wazo_amid_client import Client as AmidClient
+    from wazo_confd_client import Client as ConfdClient
+
     from wazo_calld.ari_ import CoreARI as AriClient
     from wazo_calld.bus import CoreBusConsumer as BusConsumer
-    from wazo_confd_client import Client as ConfdClient
+
     from .dataclasses_ import ConfdParkingLot
 
 

--- a/wazo_calld/plugins/parking_lots/services.py
+++ b/wazo_calld/plugins/parking_lots/services.py
@@ -1,0 +1,215 @@
+# Copyright 2024 The Wazo Authors (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import logging
+
+from requests import RequestException
+from typing import cast, TypedDict, TYPE_CHECKING
+from typing_extensions import NotRequired
+
+from wazo_calld.plugin_helpers.ari_ import Channel
+from wazo_calld.plugin_helpers.exceptions import (
+    WazoAmidError,
+    NotEnoughChannels,
+    TooManyChannels,
+    UserPermissionDenied,
+)
+
+from .cache import ParkingLotCache
+from .dataclasses_ import AsteriskParkedCall
+from .exceptions import (
+    InvalidCall,
+    NoSuchCall,
+    NoSuchParkedCall,
+    NoSuchParkingException,
+    ParkingFull,
+)
+from .notifier import ParkingNotifier
+
+if TYPE_CHECKING:
+    from wazo_amid_client import Client as AmidClient
+    from wazo_calld.ari_ import CoreARI as AriClient
+    from wazo_calld.bus import CoreBusConsumer as BusConsumer
+    from wazo_confd_client import Client as ConfdClient
+    from .dataclasses_ import ConfdParkingLot
+
+
+PARKED_CHANNEL_VAR = 'WAZO_CALL_PARKED'
+logger = logging.getLogger(__name__)
+
+
+class ParkActionDict(TypedDict):
+    Channel: str
+    Parkinglot: str
+    Timeout: NotRequired[int]
+    ParkingSpace: NotRequired[str]
+    TimeoutChannel: NotRequired[str]
+    AnnounceChannel: NotRequired[str]
+
+
+class ParkingService:
+    def __init__(
+        self,
+        ami: AmidClient,
+        ari: AriClient,
+        bus: BusConsumer,
+        confd: ConfdClient,
+        notifier: ParkingNotifier,
+    ):
+        self._amid = ami
+        self._ari = ari
+        self._confd = confd
+        self._notifier = notifier
+        self._parkings = ParkingLotCache(bus, confd)
+
+    def _get_peer_channel(self, channel: Channel) -> Channel:
+        try:
+            return channel.only_connected_channel()
+        except NotEnoughChannels:
+            raise InvalidCall(channel.id, 'no parkable peer call found')
+        except TooManyChannels:
+            raise InvalidCall(channel.id, 'cannot park a conference call')
+
+    def find_parked_call(
+        self, tenant_uuid: str, parking_id: int, call_id: str
+    ) -> AsteriskParkedCall | None:
+        for call in self.list_parked_calls(tenant_uuid, parking_id):
+            if call.parkee_uniqueid == call_id:
+                return call
+        return None
+
+    def get_parked_call(
+        self, tenant_uuid: str, parking_id: int, call_id: str
+    ) -> AsteriskParkedCall:
+        parked_call = self.find_parked_call(tenant_uuid, parking_id, call_id)
+        if not parked_call:
+            raise NoSuchParkedCall(tenant_uuid, parking_id, call_id)
+        return parked_call
+
+    def get_parking(self, tenant_uuid: str, parking_id: int) -> ConfdParkingLot:
+        parking = self._parkings[parking_id]
+        if parking.tenant_uuid != tenant_uuid:
+            raise NoSuchParkingException(parking_id)
+        return parking
+
+    def list_parked_calls(
+        self, tenant_uuid: str, parking_id: int
+    ) -> list[AsteriskParkedCall]:
+        parking = self.get_parking(tenant_uuid, parking_id)
+
+        try:
+            results: list[dict] = self._amid.action(
+                'parkedcalls', {'ParkingLot': f'parkinglot-{parking.id}'}
+            )
+        except RequestException as e:
+            raise WazoAmidError(self._amid, e)
+
+        parked_calls = [
+            AsteriskParkedCall.from_dict(result)
+            for result in results
+            if result.get('Event') == 'ParkedCall'
+        ]
+        return parked_calls
+
+    def count_parked_calls(self, tenant_uuid: str, parking_id: int) -> int:
+        parking = self.get_parking(tenant_uuid, parking_id)
+
+        try:
+            results: list[dict] = self._amid.action(
+                'parkedcalls', {'ParkingLot': f'parkinglot-{parking.id}'}
+            )
+        except RequestException as e:
+            raise WazoAmidError(self._amid, e)
+
+        complete = results.pop()
+        if complete.get('Event') != 'ParkedCallsComplete':
+            raise WazoAmidError(self._amid, 'missing ParkedCallsComplete message')
+        return int(complete['Total'])
+
+    def is_parking_full(self, tenant_uuid: str, parking_id: int) -> bool:
+        parking = self.get_parking(tenant_uuid, parking_id)
+        total_slots = int(parking.slots_end) - int(parking.slots_start)
+        count = self.count_parked_calls(tenant_uuid, parking_id)
+        return count >= total_slots
+
+    def park_call(
+        self,
+        parking_id: int,
+        call_id: str,
+        *,
+        tenant_uuid: str | None = None,
+        preferred_slot: str | None = None,
+        timeout: int | None = None,
+    ) -> AsteriskParkedCall:
+        channel = Channel(call_id, self._ari.client)
+        if not channel.exists():
+            raise NoSuchCall(call_id)
+
+        if not tenant_uuid:
+            tenant_uuid = cast(str, channel.tenant_uuid())
+            if not tenant_uuid:
+                raise InvalidCall(call_id, 'call has no tenant_uuid')
+
+        parking = self.get_parking(tenant_uuid, parking_id)
+
+        park_payload: ParkActionDict = {
+            'Channel': channel.asterisk_name(),
+            'Parkinglot': f'parkinglot-{parking.id}',
+        }
+
+        if timeout:
+            # convert to milliseconds for AMI action
+            park_payload['Timeout'] = timeout * 1000
+
+        if preferred_slot:
+            # Attempt to use slot if it can, else it wil be auto-attributed
+            park_payload['ParkingSpace'] = preferred_slot
+
+        parked_call = self.find_parked_call(tenant_uuid, parking.id, call_id)
+        if not parked_call:
+            callback_channel = self._get_peer_channel(channel)
+            park_payload['TimeoutChannel'] = callback_channel.asterisk_name()
+        else:
+            # If call is already parked, preserve callback
+            park_payload['TimeoutChannel'] = parked_call.parker_dial_string
+
+        try:
+            self._amid.action('park', park_payload)
+        except RequestException as e:
+            raise WazoAmidError(self._amid, e)
+
+        # NOTE: Should probably wait for ParkedCall event to happen instead of polling
+        try:
+            return self.get_parked_call(tenant_uuid, parking.id, call_id)
+        except NoSuchParkedCall:
+            if self.is_parking_full(tenant_uuid, parking_id):
+                raise ParkingFull(tenant_uuid, parking_id, call_id)
+            raise
+
+    def park_peer_call(
+        self,
+        user_uuid: str,
+        parking_id: int,
+        call_id: str,
+        *,
+        preferred_slot: str | None = None,
+        timeout: int | None = None,
+    ) -> AsteriskParkedCall:
+        user_channel = Channel(call_id, self._ari.client)
+
+        if not user_channel.exists():
+            raise NoSuchCall(call_id)
+
+        if user_uuid != user_channel.user():
+            raise UserPermissionDenied(user_uuid, {'call': call_id})
+
+        tenant_uuid = user_channel.tenant_uuid()
+        if not tenant_uuid:
+            raise InvalidCall(call_id, 'call has no tenant_uuid')
+
+        peer_channel = self._get_peer_channel(user_channel)
+        return self.park_call(
+            parking_id, peer_channel.id, preferred_slot=preferred_slot, timeout=timeout
+        )

--- a/wazo_calld/plugins/parking_lots/tests/test_helpers.py
+++ b/wazo_calld/plugins/parking_lots/tests/test_helpers.py
@@ -29,8 +29,8 @@ class TestSplitParkingID(TestCase):
         )
 
         with raises(ValueError):
-            assert helpers.split_parking_id_from_name('default')
-            assert helpers.split_parking_id_from_name('parking_lot-1')
+            helpers.split_parking_id_from_name('default')
+            helpers.split_parking_id_from_name('parking_lot-1')
 
 
 @patch(f'{DATETIME}', Mock(now=Mock(return_value=datetime(2000, 1, 1, 0, 0))))

--- a/wazo_calld/plugins/parking_lots/tests/test_helpers.py
+++ b/wazo_calld/plugins/parking_lots/tests/test_helpers.py
@@ -1,0 +1,83 @@
+# Copyright 2024 The Wazo Authors (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import sys
+from datetime import datetime
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from pytest import raises
+
+import wazo_calld.plugins.parking_lots.helpers as helpers
+
+DATETIME = f'{helpers.__name__}.datetime'
+
+
+class TestCamelCaseToSnake(TestCase):
+    def test_camel_to_snake(self) -> None:
+        assert helpers.camel_to_snake('HelloWorld') == 'hello_world'
+        assert helpers.camel_to_snake('HTTPError') == 'http_error'
+        assert helpers.camel_to_snake('AbCdEfGh') == 'ab_cd_ef_gh'
+
+
+class TestSplitParkingID(TestCase):
+    def test_split_parking_id(self) -> None:
+        assert helpers.split_parking_id_from_name('parkinglot-1') == 1
+        assert (
+            helpers.split_parking_id_from_name('parkinglot-50424240342402')
+            == 50424240342402
+        )
+
+        with raises(ValueError):
+            assert helpers.split_parking_id_from_name('default')
+            assert helpers.split_parking_id_from_name('parking_lot-1')
+
+
+@patch(f'{DATETIME}', Mock(now=Mock(return_value=datetime(2000, 1, 1, 0, 0))))
+class TestTimestamp(TestCase):
+    def test_timestamp_zero(self) -> None:
+        assert helpers.timestamp(0) is None
+        assert helpers.timestamp('0') is None
+
+    def test_timestamp_empty(self) -> None:
+        assert helpers.timestamp('') is None
+
+    def test_timestamp_none(self) -> None:
+        assert helpers.timestamp(None) is None  # type: ignore[arg-type]
+
+    def test_timestamp_overflow(self) -> None:
+        max_unsigned = sys.maxsize * 2 + 1
+        assert helpers.timestamp(max_unsigned) is None
+
+    def test_timestamp(self) -> None:
+        assert helpers.timestamp(1) == '2000-01-01T00:00:01'
+        assert helpers.timestamp('1') == '2000-01-01T00:00:01'
+        assert helpers.timestamp(10) == '2000-01-01T00:00:10'
+        assert helpers.timestamp('10') == '2000-01-01T00:00:10'
+        assert helpers.timestamp(60) == '2000-01-01T00:01:00'
+        assert helpers.timestamp('60') == '2000-01-01T00:01:00'
+        assert helpers.timestamp(3601) == '2000-01-01T01:00:01'
+        assert helpers.timestamp('3601') == '2000-01-01T01:00:01'
+        assert helpers.timestamp(1234567) == '2000-01-15T06:56:07'
+        assert helpers.timestamp('1234567') == '2000-01-15T06:56:07'
+
+    def test_timestamp_negative(self) -> None:
+        assert helpers.timestamp(-1) == '1999-12-31T23:59:59'
+        assert helpers.timestamp('-1') == '1999-12-31T23:59:59'
+        assert helpers.timestamp(-3601) == '1999-12-31T22:59:59'
+        assert helpers.timestamp('-3601') == '1999-12-31T22:59:59'
+
+    def test_timestamp_since(self) -> None:
+        assert helpers.timestamp_since(1) == '1999-12-31T23:59:59'
+        assert helpers.timestamp_since(-1) == '1999-12-31T23:59:59'
+
+    def test_timestamp_since_overflow(self) -> None:
+        max_unsigned = sys.maxsize * 2 + 1
+        with raises(OverflowError):
+            helpers.timestamp_since(max_unsigned)
+
+    def test_timestamp_invalid_string(self) -> None:
+        with raises(ValueError):
+            helpers.timestamp('ABCDEF')
+            helpers.timestamp('None')
+            helpers.timestamp('null')

--- a/wazo_calld/plugins/relocates/services.py
+++ b/wazo_calld/plugins/relocates/services.py
@@ -4,6 +4,7 @@
 import logging
 import re
 import threading
+from abc import abstractmethod
 
 from wazo_calld.plugin_helpers import ami
 from wazo_calld.plugin_helpers.ari_ import AUTO_ANSWER_VARIABLES, ARINotFound, Channel
@@ -54,6 +55,10 @@ class Destination:
     def assert_is_valid(self):
         if not self.is_valid():
             raise InvalidDestination(self._details)
+
+    @abstractmethod
+    def is_valid(self) -> bool:
+        ...
 
 
 class InterfaceDestination(Destination):

--- a/wazo_calld/plugins/relocates/tests/test_schemas.py
+++ b/wazo_calld/plugins/relocates/tests/test_schemas.py
@@ -1,6 +1,7 @@
 # Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from typing import Any
 from unittest import TestCase
 
 from hamcrest import assert_that, calling, has_entry, raises
@@ -16,7 +17,7 @@ VALID_RELOCATE = {
 
 class Testclassname(TestCase):
     def test_given_invalid_location_when_load_then_raise(self):
-        relocate = dict(VALID_RELOCATE)
+        relocate: dict[str, Any] = dict(VALID_RELOCATE)
         relocate['destination'] = {'invalid': 'invalid'}
 
         assert_that(
@@ -33,7 +34,7 @@ class Testclassname(TestCase):
         )
 
     def test_given_line_destination_when_load_then_validation_may_fail(self):
-        relocate = dict(VALID_RELOCATE)
+        relocate: dict[str, Any] = dict(VALID_RELOCATE)
         relocate['destination'] = 'line'
         relocate['location'] = {'line_id': -12}
 

--- a/wazo_calld/plugins/transfers/state.py
+++ b/wazo_calld/plugins/transfers/state.py
@@ -3,6 +3,7 @@
 
 import logging
 import uuid
+from typing import ClassVar
 
 from ari.exceptions import ARINotFound
 
@@ -69,6 +70,8 @@ def transition(decorated):
 
 
 class TransferState:
+    name: ClassVar[str]
+
     def __init__(
         self,
         amid,

--- a/wazo_calld/plugins/voicemails/storage.py
+++ b/wazo_calld/plugins/voicemails/storage.py
@@ -221,7 +221,7 @@ class _MessageInfoParser:
         ]
 
     def parse(self, fobj):
-        result = {}
+        result: dict = {}
         parsed = set()
         for line in fobj:
             line = b'='.join([x.strip() for x in line.split(b'=')])
@@ -233,7 +233,7 @@ class _MessageInfoParser:
         # check that everything was parsed
         for prefix, _, _ in self._parse_table:
             if prefix not in parsed:
-                raise Exception(f'no line starting with {prefix}')
+                raise Exception(f'no line starting with {prefix.decode("utf-8")}')
         return result
 
     @staticmethod
@@ -315,7 +315,7 @@ class _MessageAccess:
 
 
 class _VoicemailMessagesCache:
-    _EMPTY_CACHE_ENTRY = {}
+    _EMPTY_CACHE_ENTRY: dict = {}
 
     def __init__(self, voicemail_storage, cache_cleanup_counter_max=1500):
         self._storage = voicemail_storage


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-bus/pull/102
Depends-On: https://github.com/wazo-platform/wazo-asterisk-config/pull/58
Depends-On: https://github.com/wazo-platform/wazo-auth-keys/pull/77
Depends-On: https://github.com/wazo-platform/wazo-calld-client/pull/57

__Provides an API to park a call__

- GET `/parking_lots/$parking-id`  Retrieve parking realtime information 
- PUT `/calls/$call-id/park`  Park the call into parking
- PUT `/users/me/calls/$call-id/park`  Park the user's recipient call

__To test__
1. mount unto stack
2. reload calld
3. User A calls User B
4. Using API, get User's A call-id: e.g: GET `/calls`
5. Using API, park the call:  PUT /calls/<call-id>/park
6. To retrieve the call, dial park slot (extension) or wait for timeout