### PR TITLE
Pull request for WAZO-3690-transfer-race-condition

### DIFF
--- a/integration_tests/suite/test_transfers.py
+++ b/integration_tests/suite/test_transfers.py
@@ -701,9 +701,12 @@ class TestUserListTransfers(TestTransfers):
         user_uuid = 'user-uuid'
         self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
 
-        result = self.calld.list_my_transfers(token)
+        def list_is_empty():
+            result = self.calld.list_my_transfers(token)
+            assert_that(result['items'], empty())
 
-        assert_that(result['items'], empty())
+        # previous tests may take some time before channels are hungup and processed
+        until.assert_(list_is_empty, tries=5)
 
     def test_given_one_transfer_when_list_then_all_fields_are_listed(self):
         token = 'my-token'

--- a/wazo_calld/plugins/transfers/plugin.py
+++ b/wazo_calld/plugins/transfers/plugin.py
@@ -38,10 +38,13 @@ class Plugin:
         state_persistor = StatePersistor(ari.client)
         transfer_lock = TransferLock()
 
+        notifier = TransferNotifier(bus_publisher)
+
         transfers_service = TransfersService(
             amid_client,
             ari.client,
             confd_client,
+            notifier,
             state_factory,
             state_persistor,
             transfer_lock,
@@ -59,8 +62,6 @@ class Plugin:
         startup_callback_collector = CallbackCollector()
         ari.client_initialized_subscribe(startup_callback_collector.new_source())
         startup_callback_collector.subscribe(transfers_stasis.initialize)
-
-        notifier = TransferNotifier(bus_publisher)
 
         state_factory.set_dependencies(
             amid_client,

--- a/wazo_calld/plugins/transfers/services.py
+++ b/wazo_calld/plugins/transfers/services.py
@@ -81,12 +81,9 @@ class TransfersService:
             new_state = transfer_state.create(
                 transferred_channel,
                 initiator_channel,
-                context,
-                exten,
                 flow,
-                variables,
-                timeout,
             )
+            new_state = new_state.start(context, exten, flow, variables, timeout)
         except Exception:
             self.transfer_lock.release(initiator_call)
             raise

--- a/wazo_calld/plugins/transfers/services.py
+++ b/wazo_calld/plugins/transfers/services.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
+import uuid
 
 from ari.exceptions import ARINotFound
 from xivo.caller_id import assemble_caller_id
@@ -25,6 +26,7 @@ from .exceptions import (
 )
 from .lock import HangupLock, InvalidLock
 from .state import TransferStateNonStasis, TransferStateReady
+from .transfer import Transfer
 
 logger = logging.getLogger(__name__)
 
@@ -69,21 +71,31 @@ class TransfersService:
         if not self.transfer_lock.acquire(initiator_call):
             raise TransferAlreadyStarted(initiator_call)
 
+        channel = Channel(initiator_channel.id, self.ari)
+        initiator_uuid = channel.user()
+        if initiator_uuid is None:
+            raise TransferCreationError('initiator has no user UUID')
+        initiator_tenant_uuid = channel.tenant_uuid()
+        transfer_id = str(uuid.uuid4())
+        transfer = Transfer(transfer_id, initiator_uuid, initiator_tenant_uuid)
+        transfer.transferred_call = transferred_channel.id
+        transfer.initiator_call = initiator_channel.id
+        transfer.flow = flow
+
         if not (
             Channel(transferred_call, self.ari).is_in_stasis()
             and Channel(initiator_call, self.ari).is_in_stasis()
         ):
-            transfer_state = self.state_factory.make_from_class(TransferStateNonStasis)
+            transfer_state = self.state_factory.make_from_class(
+                TransferStateNonStasis, transfer
+            )
         else:
-            transfer_state = self.state_factory.make_from_class(TransferStateReady)
+            transfer_state = self.state_factory.make_from_class(
+                TransferStateReady, transfer
+            )
 
         try:
-            new_state = transfer_state.create(
-                transferred_channel,
-                initiator_channel,
-                flow,
-            )
-            new_state = new_state.start(context, exten, flow, variables, timeout)
+            new_state = transfer_state.start(context, exten, variables, timeout)
         except Exception:
             self.transfer_lock.release(initiator_call)
             raise

--- a/wazo_calld/plugins/transfers/services.py
+++ b/wazo_calld/plugins/transfers/services.py
@@ -24,7 +24,7 @@ from .exceptions import (
     TransferCreationError,
 )
 from .lock import HangupLock, InvalidLock
-from .state import TransferStateReady, TransferStateReadyNonStasis
+from .state import TransferStateNonStasis, TransferStateReady
 
 logger = logging.getLogger(__name__)
 
@@ -71,9 +71,7 @@ class TransfersService:
             Channel(transferred_call, self.ari).is_in_stasis()
             and Channel(initiator_call, self.ari).is_in_stasis()
         ):
-            transfer_state = self.state_factory.make_from_class(
-                TransferStateReadyNonStasis
-            )
+            transfer_state = self.state_factory.make_from_class(TransferStateNonStasis)
         else:
             transfer_state = self.state_factory.make_from_class(TransferStateReady)
 

--- a/wazo_calld/plugins/transfers/services.py
+++ b/wazo_calld/plugins/transfers/services.py
@@ -35,6 +35,7 @@ class TransfersService:
         amid_client,
         ari,
         confd_client,
+        notifier,
         state_factory,
         state_persistor,
         transfer_lock,
@@ -42,6 +43,7 @@ class TransfersService:
         self.amid_client = amid_client
         self.ari = ari
         self.confd_client = confd_client
+        self.notifier = notifier
         self.state_persistor = state_persistor
         self.state_factory = state_factory
         self.transfer_lock = transfer_lock
@@ -85,6 +87,9 @@ class TransfersService:
         except Exception:
             self.transfer_lock.release(initiator_call)
             raise
+
+        self.notifier.created(new_state.transfer)
+
         if flow == 'blind':
             new_state = new_state.complete()
 

--- a/wazo_calld/plugins/transfers/state.py
+++ b/wazo_calld/plugins/transfers/state.py
@@ -308,8 +308,8 @@ class TransferStateReady(TransferState):
 
 
 @state_factory.state
-class TransferStateReadyNonStasis(TransferState):
-    name = 'ready_non_stasis'
+class TransferStateNonStasis(TransferState):
+    name = 'non_stasis'
 
     @transition
     def create(
@@ -330,7 +330,7 @@ class TransferStateReadyNonStasis(TransferState):
         self.transfer.status = self.name
         self.transfer.flow = flow
 
-        return TransferStateReadyNonStasis.from_state(self)
+        return TransferStateNonStasis.from_state(self)
 
     @transition
     def start(
@@ -356,14 +356,14 @@ class TransferStateReadyNonStasis(TransferState):
             raise TransferCreationError('channel not found')
         self._notifier.created(self.transfer)
 
-        return TransferStateStarting.from_state(self)
+        return TransferStateMovingToStasis.from_state(self)
 
     def update_cache(self):
         self._state_persistor.upsert(self.transfer)
 
 
 @state_factory.state
-class TransferStateStarting(TransferState):
+class TransferStateMovingToStasis(TransferState):
     name = TransferStatus.starting
 
     @transition

--- a/wazo_calld/plugins/transfers/state.py
+++ b/wazo_calld/plugins/transfers/state.py
@@ -299,7 +299,6 @@ class TransferStateReady(TransferState):
         )
 
         self.transfer.recipient_call = recipient_call
-        self._notifier.created(self.transfer)
 
         return TransferStateRingback.from_state(self)
 
@@ -354,7 +353,6 @@ class TransferStateNonStasis(TransferState):
             )
         except ARINotFound:
             raise TransferCreationError('channel not found')
-        self._notifier.created(self.transfer)
 
         return TransferStateMovingToStasis.from_state(self)
 


### PR DESCRIPTION
## transfers: split transfer object creation from transfer initiation

Why:

* Scenario:
  * transfer is initiated
  * channels are moved to stasis by the API thread
  * channels both enter stasis into the bus thread
  * the transfer object is not created yet in the API thread, preventing
    the transfer to start
  * the transfer is created too late by the API thread

## transfers: rename non-stasis states

Why:

* clarify the state we're in

## transfers: move event code to the service

Why:

* remove duplication

## tests: allow for some time for transfer deletion


## fixup! transfers: move event code to the service


## transfers: move creation logic to service

Why:

* avoid duplication between TransferStateReady and
  TransferStateNonStasis