### PR TITLE
switchboards: fix race condition raising HTTP error

### DIFF
--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -1,5 +1,5 @@
 https://github.com/rsichny/swagger-py/archive/master.zip  # the digium release does not support python3
-https://github.com/wazo-platform/ari-py/archive/0.4.0.zip
+https://github.com/wazo-platform/ari-py/archive/master.zip
 https://github.com/wazo-platform/wazo-lib-rest-client/archive/master.zip
 https://github.com/wazo-platform/wazo-calld-client/archive/master.zip
 https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip

--- a/wazo_calld/plugins/applications/services.py
+++ b/wazo_calld/plugins/applications/services.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from ari.exceptions import ARINotFound
+from ari.exceptions import ARINotFound, ARIUnprocessable
 from requests import HTTPError
 
 from wazo_calld.plugin_helpers import ami, confd
@@ -260,10 +260,13 @@ class ApplicationService:
             self._ari.bridges.removeChannel(bridgeId=node_uuid, channel=call_id)
         except ARINotFound:
             raise NoSuchNode(node_uuid)
+        except ARIUnprocessable:
+            # the channel was not in the bridge
+            raise NoSuchCall(call_id)
         except HTTPError as e:
             response = getattr(e, 'response', None)
             status_code = getattr(response, 'status_code', None)
-            if status_code in (400, 422):
+            if status_code == 400:
                 raise NoSuchCall(call_id)
             raise
 

--- a/wazo_calld/plugins/switchboards/services.py
+++ b/wazo_calld/plugins/switchboards/services.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from ari.exceptions import ARINotFound
+from ari.exceptions import ARINotFound, ARIUnprocessable
 from xivo.caller_id import assemble_caller_id
 
 from wazo_calld.ari_ import DEFAULT_APPLICATION_NAME
@@ -213,6 +213,10 @@ class SwitchboardsService:
                 bridge = SwitchboardARI(switchboard_uuid, self._ari).get_bridge_queue()
                 bridge.removeChannel(channel=queued_call_id)
             except ARINotFound:
+                # the bridge does not exist
+                pass
+            except ARIUnprocessable:
+                # the channel was already moved to another bridge
                 pass
 
             return channel.id


### PR DESCRIPTION
Why:

* Error flow:
  * The HTTP request comes in to answer the queued call
  * The call to the operator is originated
  * The operator answers automatically
  * The operator call enters stasis and the two calls are bridged
  * wazo-call tries to remove the call from the queued bridge, but
    fails, since the caller channel has already been moved to another
    bridge

Depends-On: https://github.com/wazo-platform/ari-py/pull/5

PRE-MERGE STEPS:
* merge ari-py PR
* tag ari-py
* update requirements.txt