### PR TITLE
Revert WAZO-3690-transfer-race-condition

### DIFF
--- a/integration_tests/suite/test_transfers.py
+++ b/integration_tests/suite/test_transfers.py
@@ -701,12 +701,9 @@ class TestUserListTransfers(TestTransfers):
         user_uuid = 'user-uuid'
         self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
 
-        def list_is_empty():
-            result = self.calld.list_my_transfers(token)
-            assert_that(result['items'], empty())
+        result = self.calld.list_my_transfers(token)
 
-        # previous tests may take some time before channels are hungup and processed
-        until.assert_(list_is_empty, tries=5)
+        assert_that(result['items'], empty())
 
     def test_given_one_transfer_when_list_then_all_fields_are_listed(self):
         token = 'my-token'

--- a/wazo_calld/plugins/transfers/plugin.py
+++ b/wazo_calld/plugins/transfers/plugin.py
@@ -38,13 +38,10 @@ class Plugin:
         state_persistor = StatePersistor(ari.client)
         transfer_lock = TransferLock()
 
-        notifier = TransferNotifier(bus_publisher)
-
         transfers_service = TransfersService(
             amid_client,
             ari.client,
             confd_client,
-            notifier,
             state_factory,
             state_persistor,
             transfer_lock,
@@ -62,6 +59,8 @@ class Plugin:
         startup_callback_collector = CallbackCollector()
         ari.client_initialized_subscribe(startup_callback_collector.new_source())
         startup_callback_collector.subscribe(transfers_stasis.initialize)
+
+        notifier = TransferNotifier(bus_publisher)
 
         state_factory.set_dependencies(
             amid_client,

--- a/wazo_calld/plugins/transfers/services.py
+++ b/wazo_calld/plugins/transfers/services.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
-import uuid
 
 from ari.exceptions import ARINotFound
 from xivo.caller_id import assemble_caller_id
@@ -25,8 +24,7 @@ from .exceptions import (
     TransferCreationError,
 )
 from .lock import HangupLock, InvalidLock
-from .state import TransferStateNonStasis, TransferStateReady
-from .transfer import Transfer
+from .state import TransferStateReady, TransferStateReadyNonStasis
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +35,6 @@ class TransfersService:
         amid_client,
         ari,
         confd_client,
-        notifier,
         state_factory,
         state_persistor,
         transfer_lock,
@@ -45,7 +42,6 @@ class TransfersService:
         self.amid_client = amid_client
         self.ari = ari
         self.confd_client = confd_client
-        self.notifier = notifier
         self.state_persistor = state_persistor
         self.state_factory = state_factory
         self.transfer_lock = transfer_lock
@@ -71,37 +67,29 @@ class TransfersService:
         if not self.transfer_lock.acquire(initiator_call):
             raise TransferAlreadyStarted(initiator_call)
 
-        channel = Channel(initiator_channel.id, self.ari)
-        initiator_uuid = channel.user()
-        if initiator_uuid is None:
-            raise TransferCreationError('initiator has no user UUID')
-        initiator_tenant_uuid = channel.tenant_uuid()
-        transfer_id = str(uuid.uuid4())
-        transfer = Transfer(transfer_id, initiator_uuid, initiator_tenant_uuid)
-        transfer.transferred_call = transferred_channel.id
-        transfer.initiator_call = initiator_channel.id
-        transfer.flow = flow
-
         if not (
             Channel(transferred_call, self.ari).is_in_stasis()
             and Channel(initiator_call, self.ari).is_in_stasis()
         ):
             transfer_state = self.state_factory.make_from_class(
-                TransferStateNonStasis, transfer
+                TransferStateReadyNonStasis
             )
         else:
-            transfer_state = self.state_factory.make_from_class(
-                TransferStateReady, transfer
-            )
+            transfer_state = self.state_factory.make_from_class(TransferStateReady)
 
         try:
-            new_state = transfer_state.start(context, exten, variables, timeout)
+            new_state = transfer_state.create(
+                transferred_channel,
+                initiator_channel,
+                context,
+                exten,
+                flow,
+                variables,
+                timeout,
+            )
         except Exception:
             self.transfer_lock.release(initiator_call)
             raise
-
-        self.notifier.created(new_state.transfer)
-
         if flow == 'blind':
             new_state = new_state.complete()
 


### PR DESCRIPTION
This reverts commits e018bc371b42e1d9b5ba43fefbafd1dc8beef7db to
80949619db2ea42f0de903cb7f27496c63717a3d.

Why:

* causes failures in wazo-acceptance tests