### PR TITLE
transfers: fix race condition when starting a transfer

### DIFF
--- a/wazo_calld/plugins/transfers/state.py
+++ b/wazo_calld/plugins/transfers/state.py
@@ -44,7 +44,10 @@ class StateFactory:
         if transfer:
             transfer.status = state_class.name
             dependencies.append(transfer)
-        return state_class(*dependencies)
+
+        new_object = state_class(*dependencies)
+        new_object.update_cache()  # ensure the transfer is stored in Asterisk vars cache
+        return new_object
 
     def state(self, wrapped_class):
         self._state_constructors[wrapped_class.name] = wrapped_class


### PR DESCRIPTION
Why:

* The transition from non-stasis to stasis expects to find the
  XIVO_TRANSFERS_$id global variable
* This variable is created *after* having sent the ARI commands to move
  channels to Stasis
* Hence, there is a race condition between Asterisk setting the global
  variable and wazo-calld processing the StasisStart event