### PR TITLE
calls: handle blind transfer events from a stasis channel

### DIFF
--- a/integration_tests/suite/helpers/stasis.py
+++ b/integration_tests/suite/helpers/stasis.py
@@ -101,6 +101,34 @@ class StasisClient:
         }
         return self._send_stasis_event(body)
 
+    def event_stasis_start_from_non_api_blind_transfer(
+        self, channel_id, stasis_app, tenant_uuid
+    ):
+        body = {
+            "application": stasis_app,
+            "args": [],
+            "channel": {
+                "accountcode": "code",
+                "caller": {"name": "my-name", "number": "my-number"},
+                "connected": {"name": "", "number": ""},
+                "creationtime": "2016-02-04T14:25:00.007-0500",
+                "dialplan": {"context": "default", "exten": "my-exten", "priority": 1},
+                "id": channel_id,
+                "language": "fr_FR",
+                "name": "my-name",
+                "state": "Ring",
+            },
+            "replace_channel": {
+                "id": "channel id being replaced by the blind transfer",
+                "channelvars": {
+                    "WAZO_TENANT_UUID": tenant_uuid,
+                },
+            },
+            "timestamp": "2016-02-04T14:25:00.408-0500",
+            "type": "StasisStart",
+        }
+        return self._send_stasis_event(body)
+
     def event_channel_destroyed(
         self,
         channel_id,

--- a/integration_tests/suite/test_calls_stasis.py
+++ b/integration_tests/suite/test_calls_stasis.py
@@ -148,6 +148,34 @@ class TestDialedFrom(IntegrationTest):
 
         until.assert_(assert_function, tries=5)
 
+    def test_when_stasis_channel_coming_from_non_api_blind_transfer(self):
+        call_id = new_call_id()
+
+        self.stasis.event_stasis_start_from_non_api_blind_transfer(
+            channel_id=call_id,
+            stasis_app=STASIS_APP,
+            tenant_uuid=VALID_TENANT,
+        )
+
+        def assert_function():
+            assert_that(
+                self.ari.requests(),
+                has_entries(
+                    requests=has_item(
+                        has_entries(
+                            method='POST',
+                            path=f'/ari/channels/{call_id}/variable',
+                            query=has_items(
+                                ['variable', '__WAZO_TENANT_UUID'],
+                                ['value', VALID_TENANT],
+                            ),
+                        )
+                    )
+                ),
+            )
+
+        until.assert_(assert_function, tries=5)
+
     def test_when_stasis_channel_destroyed(self):
         call_id = new_call_id()
         events = self.bus.accumulator(headers={'name': 'call_ended'})


### PR DESCRIPTION
Why:

* When starting a blind transfer from the phone (SIP REFER), Asterisk
  will create a new Local channel
* the ;1 channel will be sent to Stasis in the same application as the
  transfer initiator. It has no variable set, and does not go through
  dialplan, resulting in an empty tenant uuid when processing events
  from this channel.