### PR TITLE
WP-1311: add `conversation_id` to application call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 24.08
+
+* The `conversation_id` attribute has been added to the `application_call` object
+
 ## 24.05
 
 * New API to manage a call parking

--- a/integration_tests/suite/test_applications.py
+++ b/integration_tests/suite/test_applications.py
@@ -197,6 +197,7 @@ class TestStasisTriggers(BaseApplicationTestCase):
                                 application_uuid=app_uuid,
                                 call=has_entries(
                                     id=channel.id,
+                                    conversation_id=channel.id,
                                     is_caller=True,
                                     status='Up',
                                     on_hold=False,
@@ -230,6 +231,7 @@ class TestStasisTriggers(BaseApplicationTestCase):
                             data=has_entries(
                                 call=has_entries(
                                     id=channel.id,
+                                    conversation_id=channel.id,
                                     is_caller=True,
                                     status='Up',
                                     on_hold=False,
@@ -259,6 +261,7 @@ class TestStasisTriggers(BaseApplicationTestCase):
                                 application_uuid=app_uuid,
                                 call=has_entries(
                                     id=channel.id,
+                                    conversation_id=channel.id,
                                     status='Up',
                                     node_uuid=app_uuid,
                                     is_caller=True,
@@ -561,6 +564,7 @@ class TestApplication(BaseApplicationTestCase):
                                 application_uuid=self.node_app_uuid,
                                 call=has_entries(
                                     id=channel.id,
+                                    conversation_id=channel.id,
                                 ),
                             ),
                         ),
@@ -573,6 +577,7 @@ class TestApplication(BaseApplicationTestCase):
                                 application_uuid=self.node_app_uuid,
                                 call=has_entries(
                                     id=channel.id,
+                                    conversation_id=channel.id,
                                 ),
                             ),
                         ),
@@ -612,6 +617,7 @@ class TestApplication(BaseApplicationTestCase):
             contains_exactly(
                 has_entries(
                     id=channel.id,
+                    conversation_id=channel.id,
                     status='Up',
                     caller_id_name='Alice',
                     caller_id_number='555',
@@ -1195,6 +1201,7 @@ class TestApplicationMute(BaseApplicationTestCase):
                                 application_uuid=app_uuid,
                                 call=has_entries(
                                     id=channel.id,
+                                    conversation_id=channel.id,
                                     muted=True,
                                 ),
                             ),
@@ -1211,6 +1218,7 @@ class TestApplicationMute(BaseApplicationTestCase):
             contains_exactly(
                 has_entries(
                     id=channel.id,
+                    conversation_id=channel.id,
                     muted=True,
                 )
             ),
@@ -1249,6 +1257,7 @@ class TestApplicationMute(BaseApplicationTestCase):
                                 application_uuid=app_uuid,
                                 call=has_entries(
                                     id=channel.id,
+                                    conversation_id=channel.id,
                                     muted=False,
                                 ),
                             ),
@@ -1265,6 +1274,7 @@ class TestApplicationMute(BaseApplicationTestCase):
             contains_exactly(
                 has_entries(
                     id=channel.id,
+                    conversation_id=channel.id,
                     muted=False,
                 )
             ),
@@ -1306,6 +1316,7 @@ class TestApplicationHold(BaseApplicationTestCase):
                                 application_uuid=app_uuid,
                                 call=has_entries(
                                     id=channel.id,
+                                    conversation_id=channel.id,
                                     on_hold=True,
                                 ),
                             ),
@@ -1319,7 +1330,13 @@ class TestApplicationHold(BaseApplicationTestCase):
 
         assert_that(
             self.calld_client.applications.list_calls(app_uuid)['items'],
-            contains_exactly(has_entries(id=channel.id, on_hold=True)),
+            contains_exactly(
+                has_entries(
+                    id=channel.id,
+                    conversation_id=channel.id,
+                    on_hold=True,
+                )
+            ),
         )
 
     def test_put_hold_stop(self):
@@ -1369,6 +1386,7 @@ class TestApplicationHold(BaseApplicationTestCase):
                                 application_uuid=app_uuid,
                                 call=has_entries(
                                     id=channel.id,
+                                    conversation_id=channel.id,
                                     on_hold=False,
                                 ),
                             ),
@@ -1382,7 +1400,13 @@ class TestApplicationHold(BaseApplicationTestCase):
 
         assert_that(
             self.calld_client.applications.list_calls(app_uuid)['items'],
-            contains_exactly(has_entries(id=channel.id, on_hold=False)),
+            contains_exactly(
+                has_entries(
+                    id=channel.id,
+                    conversation_id=channel.id,
+                    on_hold=False,
+                )
+            ),
         )
 
 
@@ -1929,6 +1953,7 @@ class TestApplicationMoh(BaseApplicationTestCase):
                                 application_uuid=app_uuid,
                                 call=has_entries(
                                     id=channel.id,
+                                    conversation_id=channel.id,
                                     moh_uuid=self.moh_uuid,
                                 ),
                             ),
@@ -1942,6 +1967,7 @@ class TestApplicationMoh(BaseApplicationTestCase):
                                 application_uuid=app_uuid,
                                 call=has_entries(
                                     id=channel.id,
+                                    conversation_id=channel.id,
                                     moh_uuid=None,
                                 ),
                             ),
@@ -1955,7 +1981,13 @@ class TestApplicationMoh(BaseApplicationTestCase):
 
         assert_that(
             self.calld_client.applications.list_calls(app_uuid)['items'],
-            contains_exactly(has_entries(id=channel.id, moh_uuid=None)),
+            contains_exactly(
+                has_entries(
+                    id=channel.id,
+                    conversation_id=channel.id,
+                    moh_uuid=None,
+                )
+            ),
         )
 
     def test_confd_moh_created_event_update_cache(self):
@@ -1979,7 +2011,14 @@ class TestApplicationMoh(BaseApplicationTestCase):
 
         calls = self.calld_client.applications.list_calls(app_uuid)['items']
         assert_that(
-            calls, contains_exactly(has_entries(id=channel.id, moh_uuid=moh_uuid))
+            calls,
+            contains_exactly(
+                has_entries(
+                    id=channel.id,
+                    conversation_id=channel.id,
+                    moh_uuid=moh_uuid,
+                )
+            ),
         )
 
     def test_confd_moh_deleted_event_update_cache(self):
@@ -2210,6 +2249,7 @@ class TestApplicationAnswer(BaseApplicationTestCase):
                                 application_uuid=self.node_app_uuid,
                                 call=has_entries(
                                     id=channel.id,
+                                    conversation_id=channel.id,
                                     status='Up',
                                 ),
                             ),
@@ -2223,7 +2263,13 @@ class TestApplicationAnswer(BaseApplicationTestCase):
 
         assert_that(
             self.calld_client.applications.list_calls(self.node_app_uuid)['items'],
-            contains_exactly(has_entries(id=channel.id, status='Up')),
+            contains_exactly(
+                has_entries(
+                    id=channel.id,
+                    conversation_id=channel.id,
+                    status='Up',
+                )
+            ),
         )
 
 
@@ -2266,6 +2312,7 @@ class TestApplicationProgress(BaseApplicationTestCase):
                                 application_uuid=self.node_app_uuid,
                                 call=has_entries(
                                     id=channel.id,
+                                    conversation_id=channel.id,
                                     status='Progress',
                                 ),
                             ),
@@ -2279,7 +2326,13 @@ class TestApplicationProgress(BaseApplicationTestCase):
 
         assert_that(
             self.calld_client.applications.list_calls(self.node_app_uuid)['items'],
-            contains_exactly(has_entries(id=channel.id, status='Progress')),
+            contains_exactly(
+                has_entries(
+                    id=channel.id,
+                    conversation_id=channel.id,
+                    status='Progress',
+                )
+            ),
         )
 
     def test_progress_stop(self):
@@ -2320,6 +2373,7 @@ class TestApplicationProgress(BaseApplicationTestCase):
                                 application_uuid=self.node_app_uuid,
                                 call=has_entries(
                                     id=channel.id,
+                                    conversation_id=channel.id,
                                     status='Ring',
                                 ),
                             ),
@@ -2333,7 +2387,13 @@ class TestApplicationProgress(BaseApplicationTestCase):
 
         assert_that(
             self.calld_client.applications.list_calls(self.node_app_uuid)['items'],
-            contains_exactly(has_entries(id=channel.id, status='Ring')),
+            contains_exactly(
+                has_entries(
+                    id=channel.id,
+                    conversation_id=channel.id,
+                    status='Ring',
+                )
+            ),
         )
 
 
@@ -2411,6 +2471,7 @@ class TestApplicationNode(BaseApplicationTestCase):
                                 application_uuid=self.no_node_app_uuid,
                                 call=has_entries(
                                     id=channel.id,
+                                    conversation_id=channel.id,
                                     caller_id_name='Alice',
                                     caller_id_number='555',
                                     is_caller=True,
@@ -2504,6 +2565,7 @@ class TestApplicationNode(BaseApplicationTestCase):
                             data=has_entries(
                                 call=has_entries(
                                     id=channel.id,
+                                    conversation_id=channel.id,
                                     node_uuid=node['uuid'],
                                 )
                             ),
@@ -2612,6 +2674,7 @@ class TestApplicationNode(BaseApplicationTestCase):
                                 application_uuid=self.no_node_app_uuid,
                                 call=has_entries(
                                     id=channel.id,
+                                    conversation_id=channel.id,
                                     caller_id_name='Alice',
                                     caller_id_number='555',
                                     status='Up',
@@ -2627,6 +2690,7 @@ class TestApplicationNode(BaseApplicationTestCase):
                                 application_uuid=self.no_node_app_uuid,
                                 call=has_entries(
                                     id=channel.id,
+                                    conversation_id=channel.id,
                                 ),
                             ),
                         ),
@@ -2706,6 +2770,7 @@ class TestApplicationNodeCall(BaseApplicationTestCase):
                                 application_uuid=self.node_app_uuid,
                                 call=has_entries(
                                     id=channel.id,
+                                    conversation_id=channel.id,
                                     caller_id_name='Alice',
                                     caller_id_number='555',
                                     status='Up',

--- a/integration_tests/suite/test_applications.py
+++ b/integration_tests/suite/test_applications.py
@@ -2894,6 +2894,29 @@ class TestApplicationNodeCall(BaseApplicationTestCase):
             raises(CalldError).matching(has_properties(status_code=404)),
         )
 
+    def test_node_conversation_id(self):
+        calls = self.calld_client.applications.list_calls(self.no_node_app_uuid)[
+            'items'
+        ]
+        assert_that(calls, empty())
+
+        channel1 = self.call_app(self.node_app_uuid)
+        channel2 = self.call_app(self.node_app_uuid)
+        channel3 = self.call_app(self.node_app_uuid)
+        self.calld_client.applications.create_node(
+            self.node_app_uuid, [channel1.id, channel2.id, channel3.id]
+        )
+
+        calls = self.calld_client.applications.list_calls(self.node_app_uuid)['items']
+        assert_that(
+            calls,
+            has_items(
+                has_entries(id=channel1.id, conversation_id=channel1.id),
+                has_entries(id=channel2.id, conversation_id=channel1.id),
+                has_entries(id=channel3.id, conversation_id=channel1.id),
+            ),
+        )
+
 
 class TestDTMFEvents(BaseApplicationTestCase):
     def test_that_events_are_received(self):

--- a/wazo_calld/plugins/applications/api.yml
+++ b/wazo_calld/plugins/applications/api.yml
@@ -694,6 +694,8 @@ definitions:
         type: string
       caller_id_number:
         type: string
+      conversation_id:
+        type: string
       creation_time:
         type: string
       node_uuid:

--- a/wazo_calld/plugins/applications/models.py
+++ b/wazo_calld/plugins/applications/models.py
@@ -36,6 +36,7 @@ class ApplicationCall:
 
     def __init__(self, id_):
         self.id_ = id_
+        self.conversation_id: str | None = None
         self.moh_uuid = None
         self.muted = False
         self.user_uuid = None
@@ -61,6 +62,7 @@ class CallFormatter:
         call.caller_id_name = channel.json['caller']['name']
         call.caller_id_number = channel.json['caller']['number']
         call.snoops = self._get_snoops(channel)
+        call.conversation_id = channel.json['channelvars'].get('CHANNEL(linkedid)')
 
         if node_uuid:
             call.node_uuid = node_uuid
@@ -70,6 +72,7 @@ class CallFormatter:
             call.on_hold = channel_helper.on_hold()
             call.is_caller = channel_helper.is_caller()
             call.dialed_extension = channel_helper.dialed_extension()
+
             try:
                 call.moh_uuid = (
                     channel.getChannelVar(variable='WAZO_MOH_UUID').get('value') or None

--- a/wazo_calld/plugins/applications/schemas.py
+++ b/wazo_calld/plugins/applications/schemas.py
@@ -49,6 +49,7 @@ class ApplicationCallSchema(BaseSchema):
     caller_id_name = fields.String()
     caller_id_number = fields.String()
     creation_time = fields.String()
+    conversation_id = fields.String(dump_only=True)
     status = fields.String()
     on_hold = fields.Boolean()
     is_caller = fields.Boolean()


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-bus/pull/107

This PR adds the `conversation_id` to application_call objects (endpoints + events)