### PR TITLE
WAZO-3740: Fix parking API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@
   * `conversation_id`
   * `caller_id_name`
   * `caller_id_num`
-  * `parker_name`
-  * `parker_num`
+  * `parker_caller_id_name`
+  * `parker_caller_id_num`
 
 ## 24.05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * The following attributes have been added to the `parked_call` object:
 
+  * `conversation_id`
   * `caller_id_name`
   * `caller_id_num`
   * `parker_name`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 * The `conversation_id` attribute has been added to the `application_call` object
 
+* New API to list parkings and parked calls
+
+  * GET `/parking_lots`
+
+* The following attributes have been added to the `parking_lot` object:
+
+  * `id`
+  * `name`
+
+* The following attributes have been added to the `parked_call` object:
+
+  * `caller_id_name`
+  * `caller_id_num`
+  * `parker_name`
+  * `parker_num`
+
 ## 24.05
 
 * New API to manage a call parking

--- a/wazo_calld/plugins/parking_lots/api.yml
+++ b/wazo_calld/plugins/parking_lots/api.yml
@@ -45,22 +45,22 @@ definitions:
         type: string
         example: 123456789.1
       caller_id_name:
-        description: parkee Caller ID name
+        description: Caller ID name of the person who's call was parked
         type: string
         example: Alice
       caller_id_num:
-        description: parkee Caller ID num (phone number, extension, etc...)
+        description: Caller ID num of the person who's call was parked
         type: string
         example: 1001
       conversation_id:
         type: string
         example: 123456789.0
-      parker_name:
-        description: Parker's Caller ID name
+      parker_caller_id_name:
+        description: Caller ID name of the person who parked the call
         type: string
         example: Bob
-      parker_num:
-        description: Parkes' Caller ID num (phone number, extension, etc...)
+      parker_caller_id_num:
+        description: Caller ID num of the person who parked the call
         type: string
         example: 1002
       slot:

--- a/wazo_calld/plugins/parking_lots/api.yml
+++ b/wazo_calld/plugins/parking_lots/api.yml
@@ -52,6 +52,9 @@ definitions:
         description: parkee Caller ID num (phone number, extension, etc...)
         type: string
         example: 1001
+      conversation_id:
+        type: string
+        example: 123456789.0
       parker_name:
         description: Parker's Caller ID name
         type: string

--- a/wazo_calld/plugins/parking_lots/api.yml
+++ b/wazo_calld/plugins/parking_lots/api.yml
@@ -8,6 +8,12 @@ definitions:
     title: Parking lot
     type: object
     properties:
+      id:
+        type: integer
+        example: 3
+      name:
+        type: string
+        example: My Parking Lot
       slots_start:
         type: string
         example: '501'
@@ -38,6 +44,22 @@ definitions:
       call_id:
         type: string
         example: 123456789.1
+      caller_id_name:
+        description: parkee Caller ID name
+        type: string
+        example: Alice
+      caller_id_num:
+        description: parkee Caller ID num (phone number, extension, etc...)
+        type: string
+        example: 1001
+      parker_name:
+        description: Parker's Caller ID name
+        type: string
+        example: Bob
+      parker_num:
+        description: Parkes' Caller ID num (phone number, extension, etc...)
+        type: string
+        example: 1002
       slot:
         description: Slots where this call has been parked
         type: string
@@ -108,6 +130,22 @@ parameters:
     schema:
       $ref: '#/definitions/ParkCallBody'
 paths:
+  /parkinglots:
+    get:
+      summary: Retrieve the list of parkings and park calls
+      description: '**Required ACL:** `calld.parkings.read`'
+      parameters:
+      - $ref: '#/parameters/TenantUUID'
+      tags:
+      - parking_lots
+      responses:
+        '200':
+          description: List of parkings and associated parked calls
+          schema:
+            items:
+              type: array
+              items:
+                $ref: '#/definitions/ParkingLot'
   /parkinglots/{parking_id}:
     get:
       summary: Retrieve parked calls for parking
@@ -122,6 +160,8 @@ paths:
           description: List of parked calls in parking lot
           schema:
             $ref: '#/definitions/ParkingLot'
+        '404':
+          $ref: '#/responses/NotFoundError'
   /calls/{call_id}/park:
     put:
       summary: Park a call

--- a/wazo_calld/plugins/parking_lots/api.yml
+++ b/wazo_calld/plugins/parking_lots/api.yml
@@ -142,10 +142,12 @@ paths:
         '200':
           description: List of parkings and associated parked calls
           schema:
-            items:
-              type: array
+            type: object
+            properties:
               items:
-                $ref: '#/definitions/ParkingLot'
+                type: array
+                items:
+                  $ref: '#/definitions/ParkingLot'
   /parkinglots/{parking_id}:
     get:
       summary: Retrieve parked calls for parking

--- a/wazo_calld/plugins/parking_lots/dataclasses_.py
+++ b/wazo_calld/plugins/parking_lots/dataclasses_.py
@@ -70,3 +70,22 @@ class AsteriskParkedCall(_FromDictMixin):
     parking_space: str
     parking_timeout: str
     parking_duration: str
+
+
+@dataclass(frozen=True)
+class AsteriskUnparkedCall(AsteriskParkedCall):
+    retriever_channel: str
+    retriever_channel_state: str
+    retriever_channel_state_desc: ChannelStateDesc
+    retriever_caller_id_num: str
+    retriever_caller_id_name: str
+    retriever_connected_line_num: str
+    retriever_connected_line_name: str
+    retriever_language: str
+    retriever_account_code: str
+    retriever_context: str
+    retriever_exten: str
+    retriever_priority: str
+    retriever_uniqueid: str
+    retriever_linkedid: str
+    retriever_chan_variable: str

--- a/wazo_calld/plugins/parking_lots/notifier.py
+++ b/wazo_calld/plugins/parking_lots/notifier.py
@@ -11,61 +11,68 @@ from wazo_bus.resources.calls.parking import (
     ParkedCallHungupEvent,
     ParkedCallTimedOutEvent,
 )
+from wazo_bus.resources.calls.types import ParkedCallDict, UnparkedCallDict
 
 from .helpers import split_parking_id_from_name, timestamp, timestamp_since
 
 if TYPE_CHECKING:
     from wazo_calld.bus import CoreBusPublisher
 
-    from .dataclasses_ import AsteriskParkedCall
+    from .dataclasses_ import AsteriskParkedCall, AsteriskUnparkedCall
 
 
 class ParkingNotifier:
     def __init__(self, bus_publisher: CoreBusPublisher):
         self._publisher = bus_publisher
 
+    def _convert_to_dict(
+        self, parked_call: AsteriskParkedCall, **extra_kwargs
+    ) -> ParkedCallDict:
+        return {
+            'parking_id': split_parking_id_from_name(parked_call.parkinglot),
+            'call_id': parked_call.parkee_uniqueid,
+            'conversation_id': parked_call.parkee_linkedid,
+            'caller_id_name': parked_call.parkee_caller_id_name,
+            'caller_id_num': parked_call.parkee_caller_id_num,
+            'parker_caller_id_name': parked_call.parkee_connected_line_name,
+            'parker_caller_id_num': parked_call.parkee_connected_line_num,
+            'slot': parked_call.parking_space,
+            'parked_at': timestamp_since(parked_call.parking_duration),
+            'timeout_at': timestamp(parked_call.parking_timeout),
+            **extra_kwargs,
+        }
+
     def call_parked(self, parked_call: AsteriskParkedCall, tenant_uuid: str) -> None:
-        event = CallParkedEvent(
-            parked_call.parkee_uniqueid,
-            split_parking_id_from_name(parked_call.parkinglot),
-            parked_call.parking_space,
-            timestamp(parked_call.parking_timeout),
-            tenant_uuid,
-        )
+        payload = self._convert_to_dict(parked_call)
+        event = CallParkedEvent(payload, tenant_uuid=tenant_uuid)
         self._publisher.publish(event)
 
     def call_unparked(
-        self, parked_call: AsteriskParkedCall, retriever_call: str, tenant_uuid: str
+        self,
+        unparked_call: AsteriskUnparkedCall,
+        tenant_uuid: str,
     ) -> None:
-        event = CallUnparkedEvent(
-            parked_call.parkee_uniqueid,
-            split_parking_id_from_name(parked_call.parkinglot),
-            parked_call.parking_space,
-            retriever_call,
-            tenant_uuid,
+        payload: UnparkedCallDict = self._convert_to_dict(
+            unparked_call,
+            retriever_call_id=unparked_call.retriever_uniqueid,
+            retriever_caller_id_name=unparked_call.retriever_caller_id_name,
+            retriever_caller_id_num=unparked_call.retriever_caller_id_num,
         )
+        event = CallUnparkedEvent(payload, tenant_uuid)
         self._publisher.publish(event)
 
     def parked_call_timed_out(
         self, parked_call: AsteriskParkedCall, tenant_uuid: str
     ) -> None:
-        event = ParkedCallTimedOutEvent(
-            parked_call.parkee_uniqueid,
-            split_parking_id_from_name(parked_call.parkinglot),
-            parked_call.parker_dial_string,
-            timestamp_since(parked_call.parking_duration),
-            tenant_uuid,
+        payload = self._convert_to_dict(
+            parked_call, dialed_extension=parked_call.parker_dial_string
         )
+        event = ParkedCallTimedOutEvent(payload, tenant_uuid)
         self._publisher.publish(event)
 
     def parked_call_hangup(
         self, parked_call: AsteriskParkedCall, tenant_uuid: str
     ) -> None:
-        event = ParkedCallHungupEvent(
-            parked_call.parkee_uniqueid,
-            split_parking_id_from_name(parked_call.parkinglot),
-            parked_call.parking_space,
-            timestamp_since(parked_call.parking_duration),
-            tenant_uuid,
-        )
+        payload = self._convert_to_dict(parked_call)
+        event = ParkedCallHungupEvent(payload, tenant_uuid)
         self._publisher.publish(event)

--- a/wazo_calld/plugins/parking_lots/plugin.py
+++ b/wazo_calld/plugins/parking_lots/plugin.py
@@ -9,7 +9,12 @@ from wazo_amid_client import Client as AmidClient
 from wazo_confd_client import Client as ConfdClient
 
 from .bus_consume import ParkingLotEventsHandler
-from .http import ParkCallResource, ParkingLotResource, UserCallParkResource
+from .http import (
+    ParkCallResource,
+    ParkingLotListResource,
+    ParkingLotResource,
+    UserCallParkResource,
+)
 from .notifier import ParkingNotifier
 from .services import ParkingService
 
@@ -48,19 +53,25 @@ class Plugin:
 
     def set_resources(self, api: Api, service: ParkingService) -> None:
         api.add_resource(
+            ParkingLotListResource,
+            '/parkinglots',
+            resource_class_args=(service,),
+        )
+
+        api.add_resource(
             ParkingLotResource,
             '/parkinglots/<int:parking_id>',
-            resource_class_args=[service],
+            resource_class_args=(service,),
         )
 
         api.add_resource(
             ParkCallResource,
             '/calls/<call_id>/park',
-            resource_class_args=[service],
+            resource_class_args=(service,),
         )
 
         api.add_resource(
             UserCallParkResource,
             '/users/me/calls/<call_id>/park',
-            resource_class_args=[service],
+            resource_class_args=(service,),
         )

--- a/wazo_calld/plugins/parking_lots/schemas.py
+++ b/wazo_calld/plugins/parking_lots/schemas.py
@@ -59,12 +59,13 @@ class ParkedCallGetResponseSchema(_Base):
     conversation_id = String(attribute='parkee_linkedid', dump_only=True)
     caller_id_name = String(attribute='parkee_caller_id_name', dump_only=True)
     caller_id_num = String(attribute='parkee_caller_id_num', dump_only=True)
-    connected_line_name = String(attribute='parkee_connected_line_name', dump_only=True)
-    connected_line_num = String(attribute='parkee_connected_line_num', dump_only=True)
+    parker_caller_id_name = String(
+        attribute='parkee_connected_line_name', dump_only=True
+    )
+    parker_caller_id_num = String(attribute='parkee_connected_line_num', dump_only=True)
     slot = String(attribute='parking_space', dump_only=True)
     parked_at = Method('compute_park_time', dump_only=True)
     timeout_at = Method('compute_timeout', allow_none=True, dump_only=True)
-    timeout = Integer(attribute='parking_timeout', dump_only=True)
 
     def compute_park_time(self, parked_call: AsteriskParkedCall) -> str:
         return timestamp_since(parked_call.parking_duration)

--- a/wazo_calld/plugins/parking_lots/schemas.py
+++ b/wazo_calld/plugins/parking_lots/schemas.py
@@ -23,12 +23,14 @@ class _Base(Schema):
 
 
 class ParkingLotSchema(_Base):
+    id = Integer(dump_only=True)
+    name = String(dump_only=True)
     slots_start = Integer(dump_only=True)
     slots_end = Integer(dump_only=True)
     slots_total = Integer(dump_only=True, default=0)
     slots_remaining = Integer(dump_only=True, default=0)
     default_timeout = Integer(attribute='timeout', dump_only=True)
-    calls = List(Nested("ParkedCallGetResponseSchema"))
+    calls = List(Nested("ParkedCallGetResponseSchema"), default=list)
 
     @pre_dump
     def calls_from_context(self, obj, **kwargs):
@@ -44,11 +46,24 @@ class ParkingLotSchema(_Base):
         return obj
 
 
+class ParkingLotListSchema(ParkingLotSchema):
+    @pre_dump
+    def unwrap_calls(self, obj, **kwargs):
+        parkinglot, calls = obj
+        parkinglot.calls = calls
+        return parkinglot
+
+
 class ParkedCallGetResponseSchema(_Base):
     call_id = String(attribute='parkee_uniqueid', dump_only=True)
+    caller_id_name = String(attribute='parkee_caller_id_name', dump_only=True)
+    caller_id_num = String(attribute='parkee_caller_id_num', dump_only=True)
+    connected_line_name = String(attribute='parkee_connected_line_name', dump_only=True)
+    connected_line_num = String(attribute='parkee_connected_line_num', dump_only=True)
     slot = String(attribute='parking_space', dump_only=True)
     parked_at = Method('compute_park_time', dump_only=True)
     timeout_at = Method('compute_timeout', allow_none=True, dump_only=True)
+    timeout = Integer(attribute='parking_timeout', dump_only=True)
 
     def compute_park_time(self, parked_call: AsteriskParkedCall) -> str:
         return timestamp_since(parked_call.parking_duration)

--- a/wazo_calld/plugins/parking_lots/schemas.py
+++ b/wazo_calld/plugins/parking_lots/schemas.py
@@ -56,6 +56,7 @@ class ParkingLotListSchema(ParkingLotSchema):
 
 class ParkedCallGetResponseSchema(_Base):
     call_id = String(attribute='parkee_uniqueid', dump_only=True)
+    conversation_id = String(attribute='parkee_linkedid', dump_only=True)
     caller_id_name = String(attribute='parkee_caller_id_name', dump_only=True)
     caller_id_num = String(attribute='parkee_caller_id_num', dump_only=True)
     connected_line_name = String(attribute='parkee_connected_line_name', dump_only=True)

--- a/wazo_calld/plugins/parking_lots/schemas.py
+++ b/wazo_calld/plugins/parking_lots/schemas.py
@@ -25,8 +25,8 @@ class _Base(Schema):
 class ParkingLotSchema(_Base):
     id = Integer(dump_only=True)
     name = String(dump_only=True)
-    slots_start = Integer(dump_only=True)
-    slots_end = Integer(dump_only=True)
+    slots_start = String(dump_only=True)
+    slots_end = String(dump_only=True)
     slots_total = Integer(dump_only=True, default=0)
     slots_remaining = Integer(dump_only=True, default=0)
     default_timeout = Integer(attribute='timeout', dump_only=True)
@@ -40,7 +40,7 @@ class ParkingLotSchema(_Base):
 
     @post_dump
     def compute_slots(self, obj, **kwargs):
-        total = 1 + (obj['slots_end'] - obj['slots_start'])
+        total = 1 + (int(obj['slots_end']) - int(obj['slots_start']))
         obj['slots_total'] = total
         obj['slots_remaining'] = total - len(obj['calls'])
         return obj

--- a/wazo_calld/plugins/parking_lots/services.py
+++ b/wazo_calld/plugins/parking_lots/services.py
@@ -27,7 +27,7 @@ from .exceptions import (
     NoSuchParking,
     ParkingFull,
 )
-from .helpers import DONT_CHECK_TENANT, DontCheckTenant
+from .helpers import DONT_CHECK_TENANT, DontCheckTenant, split_parking_id_from_name
 from .notifier import ParkingNotifier
 
 if TYPE_CHECKING:
@@ -40,8 +40,10 @@ if TYPE_CHECKING:
     from .dataclasses_ import ConfdParkingLot
 
 
-RETRIES = 5
+CHECK_PARKING_DELAY_BETWEEN_RETRIES = 0.2
+CHECK_PARKING_MAX_RETRIES = 5
 PARKED_CHANNEL_VAR = 'WAZO_CALL_PARKED'
+
 logger = logging.getLogger(__name__)
 
 
@@ -112,15 +114,30 @@ class ParkingService:
             raise WazoAmidError(self._amid, e)
 
         check_full: bool | None = None
-        for _ in range(RETRIES):
+        for _ in range(CHECK_PARKING_MAX_RETRIES):
             try:
                 return self.get_parked_call(tenant_uuid, parking.id, parkee.id)
             except NoSuchParkedCall:
                 if check_full is None:
                     if check_full := self.is_parking_full(tenant_uuid, parking.id):
                         raise ParkingFull(tenant_uuid, parking.id, parkee.id)
-                sleep(0.2)  # wait 200 ms between attempts
+                sleep(CHECK_PARKING_DELAY_BETWEEN_RETRIES)
         raise NoSuchParkedCall(tenant_uuid, parking.id, parkee.id)
+
+    def count_parked_calls(self, tenant_uuid: str, parking_id: int) -> int:
+        parking = self.get_parking(tenant_uuid, parking_id)
+
+        try:
+            results: list[dict] = self._amid.action(
+                'ParkedCalls', {'ParkingLot': f'parkinglot-{parking.id}'}
+            )
+        except RequestException as e:
+            raise WazoAmidError(self._amid, e)
+
+        complete = results.pop()
+        if complete.get('Event') != 'ParkedCallsComplete':
+            raise WazoAmidError(self._amid, 'missing ParkedCallsComplete message')
+        return int(complete['Total'])
 
     def find_parked_call(
         self, tenant_uuid: str, parking_id: int, call_id: str
@@ -146,6 +163,12 @@ class ParkingService:
             raise NoSuchParking(parking_id)
         return parking
 
+    def is_parking_full(self, tenant_uuid: str, parking_id: int) -> bool:
+        parking = self.get_parking(tenant_uuid, parking_id)
+        total_slots = int(parking.slots_end) - int(parking.slots_start)
+        count = self.count_parked_calls(tenant_uuid, parking_id)
+        return count >= total_slots
+
     def list_parked_calls(
         self, tenant_uuid: str, parking_id: int
     ) -> list[AsteriskParkedCall]:
@@ -165,26 +188,24 @@ class ParkingService:
         ]
         return parked_calls
 
-    def count_parked_calls(self, tenant_uuid: str, parking_id: int) -> int:
-        parking = self.get_parking(tenant_uuid, parking_id)
-
+    def list_parkings(self, tenant_uuid: str) -> list[ConfdParkingLot]:
         try:
-            results: list[dict] = self._amid.action(
-                'ParkedCalls', {'ParkingLot': f'parkinglot-{parking.id}'}
-            )
+            results: list[dict] = self._amid.action('Parkinglots')
         except RequestException as e:
             raise WazoAmidError(self._amid, e)
 
-        complete = results.pop()
-        if complete.get('Event') != 'ParkedCallsComplete':
-            raise WazoAmidError(self._amid, 'missing ParkedCallsComplete message')
-        return int(complete['Total'])
-
-    def is_parking_full(self, tenant_uuid: str, parking_id: int) -> bool:
-        parking = self.get_parking(tenant_uuid, parking_id)
-        total_slots = int(parking.slots_end) - int(parking.slots_start)
-        count = self.count_parked_calls(tenant_uuid, parking_id)
-        return count >= total_slots
+        parkinglots: list[ConfdParkingLot] = []
+        for result in results:
+            if result.get('Event') != 'Parkinglot':
+                continue
+            try:
+                id_ = split_parking_id_from_name(result['Name'])
+            except ValueError:
+                continue
+            parkinglot = self._parkings[id_]
+            if parkinglot.tenant_uuid == tenant_uuid:
+                parkinglots.append(parkinglot)
+        return parkinglots
 
     def park_call(
         self,

--- a/wazo_calld/plugins/parking_lots/services.py
+++ b/wazo_calld/plugins/parking_lots/services.py
@@ -165,7 +165,7 @@ class ParkingService:
 
     def is_parking_full(self, tenant_uuid: str, parking_id: int) -> bool:
         parking = self.get_parking(tenant_uuid, parking_id)
-        total_slots = int(parking.slots_end) - int(parking.slots_start)
+        total_slots = 1 + int(parking.slots_end) - int(parking.slots_start)
         count = self.count_parked_calls(tenant_uuid, parking_id)
         return count >= total_slots
 


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-auth-keys/pull/78
Depends-On: https://github.com/wazo-platform/wazo-bus/pull/108
Depends-On: https://github.com/wazo-platform/wazo-calld-client/pull/58

This PR attempts to fix the parking API by making it a bit more usable

1. adds new `/parkinglots` endpoint to list all parkings and their parked calls
2. adds more information on parkinglot resource (`id` and `name`) since users can't access parking on confd
3. adds `conversation_id` on parked call object
4. adds retriever and parker information on parked call objects (caller_id name and num for each)
5.  enable unpark events