### PR TITLE
dial_mobile: avoid getting stuck in Stasis

### DIFF
--- a/integration_tests/suite/test_dial_mobile.py
+++ b/integration_tests/suite/test_dial_mobile.py
@@ -1,0 +1,37 @@
+# Copyright 2024 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from uuid import uuid4
+
+from ari.exceptions import ARINotFound
+from wazo_test_helpers import until
+
+from .helpers.constants import ENDPOINT_AUTOANSWER
+from .helpers.real_asterisk import RealAsteriskIntegrationTest
+
+
+class TestDialMobile(RealAsteriskIntegrationTest):
+    asset = 'real_asterisk'
+
+    def test_that_dial_mobile_join_with_no_bridge_does_not_block(self):
+        unknown_bridge_id = str(uuid4())
+        channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app='dial_mobile',
+            appArgs=['join', unknown_bridge_id],
+        )
+
+        def channel_is_gone(ari, channel_id):
+            try:
+                ari.channels.get(channelId=channel_id)
+                return False
+            except ARINotFound:
+                return True
+
+        until.true(
+            channel_is_gone,
+            self.ari,
+            channel.id,
+            timeout=10,
+            message='Channel is stuck in stasis',
+        )

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -228,6 +228,11 @@ class DialMobileService:
         dialer = self._contact_dialers.pop(future_bridge_uuid, None)
         logger.debug('Removing dialer: %s', str(dialer))
         if not dialer:
+            try:
+                self._ari.channels.hangup(channelId=channel_id)
+            except ARINotFound:
+                # If its already gone do nothing
+                pass
             return
 
         dialer.stop()
@@ -239,6 +244,11 @@ class DialMobileService:
                 'the caller (%s) left the call before being bridged',
                 outgoing_channel_id,
             )
+            try:
+                self._ari.channels.hangup(channelId=channel_id)
+            except ARINotFound:
+                # If its already gone do nothing
+                pass
             return
 
         try:


### PR DESCRIPTION
if a call tries to join a future bridge that does not exist or that has already been "consumed" by another call we hangup to avoid the call from being stuck in Stasis doing nothing