### PR TITLE
Pull request for WAZO-3690-transfer-race-condition-fix-3

### DIFF
--- a/integration_tests/assets/docker-compose.basic_rest.override.yml
+++ b/integration_tests/assets/docker-compose.basic_rest.override.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   sync:
     depends_on:

--- a/integration_tests/assets/docker-compose.documentation.override.yml
+++ b/integration_tests/assets/docker-compose.documentation.override.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   sync:
     depends_on:

--- a/integration_tests/assets/docker-compose.failing_ari.override.yml
+++ b/integration_tests/assets/docker-compose.failing_ari.override.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   sync:
     depends_on:

--- a/integration_tests/assets/docker-compose.no_ari.override.yml
+++ b/integration_tests/assets/docker-compose.no_ari.override.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   sync:
     depends_on:

--- a/integration_tests/assets/docker-compose.no_auth_server.override.yml
+++ b/integration_tests/assets/docker-compose.no_auth_server.override.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   sync:
     depends_on:

--- a/integration_tests/assets/docker-compose.no_rabbitmq.override.yml
+++ b/integration_tests/assets/docker-compose.no_rabbitmq.override.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   sync:
     depends_on:

--- a/integration_tests/assets/docker-compose.real_asterisk.override.yml
+++ b/integration_tests/assets/docker-compose.real_asterisk.override.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   sync:
     depends_on:

--- a/integration_tests/assets/docker-compose.real_asterisk_conference.override.yml
+++ b/integration_tests/assets/docker-compose.real_asterisk_conference.override.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   sync:
     depends_on:

--- a/integration_tests/assets/docker-compose.real_asterisk_fax.override.yml
+++ b/integration_tests/assets/docker-compose.real_asterisk_fax.override.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   sync:
     depends_on:

--- a/integration_tests/assets/docker-compose.real_asterisk_no_amid.override.yml
+++ b/integration_tests/assets/docker-compose.real_asterisk_no_amid.override.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   sync:
     depends_on:

--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   sync:
     image: wazoplatform/wait

--- a/integration_tests/suite/test_transfers.py
+++ b/integration_tests/suite/test_transfers.py
@@ -228,6 +228,7 @@ class TestTransfers(RealAsteriskIntegrationTest):
                     recipient_channel_id,
                 ),
             ),
+            'transfer bridge is missing one channel',
         )
 
         assert_that(
@@ -292,6 +293,7 @@ class TestTransfers(RealAsteriskIntegrationTest):
                     ),
                 )
             ),
+            'transfer_answered event wrong or missing',
         )
 
     def assert_transfer_is_cancelled(
@@ -2093,6 +2095,7 @@ class TestTransferFromNonStasis(TestTransfers):
                         ),
                     ),
                 ),
+                'transfer_updated event is wrong or missing',
             )
 
         until.assert_(transfer_was_updated, events, timeout=30)

--- a/wazo_calld/plugins/transfers/http.py
+++ b/wazo_calld/plugins/transfers/http.py
@@ -25,7 +25,7 @@ class TransfersResource(AuthResource):
             request_body['variables'],
             request_body['timeout'],
         )
-        return transfer.to_dict(), 201
+        return transfer.to_public_dict(), 201
 
 
 class UserTransfersResource(AuthResource):
@@ -37,7 +37,7 @@ class UserTransfersResource(AuthResource):
         user_uuid = get_token_user_uuid_from_request()
         transfers = self._transfers_service.list_from_user(user_uuid)
 
-        return {'items': [transfer.to_dict() for transfer in transfers]}, 200
+        return {'items': [transfer.to_public_dict() for transfer in transfers]}, 200
 
     @required_acl('calld.users.me.transfers.create')
     def post(self):
@@ -50,7 +50,7 @@ class UserTransfersResource(AuthResource):
             request_body['timeout'],
             user_uuid,
         )
-        return transfer.to_dict(), 201
+        return transfer.to_public_dict(), 201
 
 
 class TransferResource(AuthResource):
@@ -60,7 +60,7 @@ class TransferResource(AuthResource):
     @required_acl('calld.transfers.{transfer_id}.read')
     def get(self, transfer_id):
         transfer = self._transfers_service.get(transfer_id)
-        return transfer.to_dict(), 200
+        return transfer.to_public_dict(), 200
 
     @required_acl('calld.transfers.{transfer_id}.delete')
     def delete(self, transfer_id):

--- a/wazo_calld/plugins/transfers/notifier.py
+++ b/wazo_calld/plugins/transfers/notifier.py
@@ -22,42 +22,56 @@ class TransferNotifier:
 
     def created(self, transfer):
         event = CallTransferCreatedEvent(
-            transfer.to_dict(), transfer.initiator_tenant_uuid, transfer.initiator_uuid
+            transfer.to_public_dict(),
+            transfer.initiator_tenant_uuid,
+            transfer.initiator_uuid,
         )
         self._bus_producer.publish(event)
 
     def updated(self, transfer):
         event = CallTransferUpdatedEvent(
-            transfer.to_dict(), transfer.initiator_tenant_uuid, transfer.initiator_uuid
+            transfer.to_public_dict(),
+            transfer.initiator_tenant_uuid,
+            transfer.initiator_uuid,
         )
         self._bus_producer.publish(event)
 
     def answered(self, transfer):
         event = CallTransferAnsweredEvent(
-            transfer.to_dict(), transfer.initiator_tenant_uuid, transfer.initiator_uuid
+            transfer.to_public_dict(),
+            transfer.initiator_tenant_uuid,
+            transfer.initiator_uuid,
         )
         self._bus_producer.publish(event)
 
     def cancelled(self, transfer):
         event = CallTransferCancelledEvent(
-            transfer.to_dict(), transfer.initiator_tenant_uuid, transfer.initiator_uuid
+            transfer.to_public_dict(),
+            transfer.initiator_tenant_uuid,
+            transfer.initiator_uuid,
         )
         self._bus_producer.publish(event)
 
     def completed(self, transfer):
         event = CallTransferCompletedEvent(
-            transfer.to_dict(), transfer.initiator_tenant_uuid, transfer.initiator_uuid
+            transfer.to_public_dict(),
+            transfer.initiator_tenant_uuid,
+            transfer.initiator_uuid,
         )
         self._bus_producer.publish(event)
 
     def abandoned(self, transfer):
         event = CallTransferAbandonedEvent(
-            transfer.to_dict(), transfer.initiator_tenant_uuid, transfer.initiator_uuid
+            transfer.to_public_dict(),
+            transfer.initiator_tenant_uuid,
+            transfer.initiator_uuid,
         )
         self._bus_producer.publish(event)
 
     def ended(self, transfer):
         event = CallTransferEndedEvent(
-            transfer.to_dict(), transfer.initiator_tenant_uuid, transfer.initiator_uuid
+            transfer.to_public_dict(),
+            transfer.initiator_tenant_uuid,
+            transfer.initiator_uuid,
         )
         self._bus_producer.publish(event)

--- a/wazo_calld/plugins/transfers/plugin.py
+++ b/wazo_calld/plugins/transfers/plugin.py
@@ -63,6 +63,7 @@ class Plugin:
         ari.client_initialized_subscribe(startup_callback_collector.new_source())
         startup_callback_collector.subscribe(transfers_stasis.initialize)
 
+        state_factory.set_state_persistor(state_persistor)
         state_factory.set_dependencies(
             amid_client,
             ari.client,

--- a/wazo_calld/plugins/transfers/stasis.py
+++ b/wazo_calld/plugins/transfers/stasis.py
@@ -251,9 +251,7 @@ class TransfersStasis:
             timeout = None if timeout_str == 'None' else int(timeout_str)
 
             transfer_state = self.state_factory.make(transfer)
-            new_state = transfer_state.start(
-                transfer, context, exten, variables, timeout
-            )
+            new_state = transfer_state.start(context, exten, variables, timeout)
             if new_state.transfer.flow == 'blind':
                 new_state.complete()
 

--- a/wazo_calld/plugins/transfers/state.py
+++ b/wazo_calld/plugins/transfers/state.py
@@ -41,13 +41,11 @@ class StateFactory:
         dependencies = list(self._dependencies) + [transfer]
         return self._state_constructors[transfer.status](*dependencies)
 
-    def make_from_class(self, state_class, transfer=None):
+    def make_from_class(self, state_class, transfer):
         if not self._configured:
             raise RuntimeError('StateFactory is not configured')
-        dependencies = list(self._dependencies)
-        if transfer:
-            transfer.status = state_class.name
-            dependencies.append(transfer)
+        dependencies = list(self._dependencies) + [transfer]
+        transfer.status = state_class.name
 
         new_object = state_class(*dependencies)
         new_object.update_cache()  # ensure the transfer is stored in Asterisk vars cache
@@ -89,7 +87,7 @@ class TransferState:
         services,
         state_persistor,
         transfer_lock,
-        transfer=None,
+        transfer,
     ):
         self._amid = amid
         self._ari = ari

--- a/wazo_calld/plugins/transfers/state.py
+++ b/wazo_calld/plugins/transfers/state.py
@@ -327,9 +327,7 @@ class TransferStateMovingToStasis(TransferState):
     name = TransferStatus.starting
 
     @transition
-    def start(self, transfer, context, exten, variables, timeout):
-        self.transfer = transfer
-
+    def start(self, context, exten, variables, timeout):
         try:
             ari_helpers.hold_transferred_call(
                 self._ari, self._amid, self.transfer.transferred_call

--- a/wazo_calld/plugins/transfers/state.py
+++ b/wazo_calld/plugins/transfers/state.py
@@ -22,6 +22,10 @@ logger = logging.getLogger(__name__)
 
 
 class StateFactory:
+    '''
+    Purpose: inject static dependencies in states
+    '''
+
     def __init__(self, ari=None):
         self._state_constructors = {}
         self._ari = ari

--- a/wazo_calld/plugins/transfers/state_persistor.py
+++ b/wazo_calld/plugins/transfers/state_persistor.py
@@ -46,7 +46,7 @@ class StatePersistor:
     def upsert(self, transfer):
         logger.debug('transfer: %s upsert starting', transfer.id)
         with self._lock:
-            self._transfers.set(transfer.id, transfer.to_dict())
+            self._transfers.set(transfer.id, transfer.to_internal_dict())
             index = set(self._index.get(default=[]))
             index.add(transfer.id)
             self._index.set(list(index))

--- a/wazo_calld/plugins/transfers/transfer.py
+++ b/wazo_calld/plugins/transfers/transfer.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -13,7 +13,7 @@ class Transfer:
         self.status = 'invalid'
         self.flow = 'attended'
 
-    def to_dict(self):
+    def to_internal_dict(self):
         return {
             'id': self.id,
             'initiator_uuid': self.initiator_uuid,
@@ -24,6 +24,28 @@ class Transfer:
             'status': self.status,
             'flow': self.flow,
         }
+
+    def to_public_dict(self):
+        return {
+            'id': self.id,
+            'initiator_uuid': self.initiator_uuid,
+            'initiator_tenant_uuid': self.initiator_tenant_uuid,
+            'transferred_call': self.transferred_call,
+            'initiator_call': self.initiator_call,
+            'recipient_call': self.recipient_call,
+            'status': self.public_status(),
+            'flow': self.flow,
+        }
+
+    def public_status(self):
+        # we don't want to expose stasis-related statuses
+        if self.status in (
+            'none_moved_to_stasis',
+            'initiator_moved_to_stasis',
+            'transferred_moved_to_stasis',
+        ):
+            return 'starting'
+        return self.status
 
     @classmethod
     def from_dict(cls, dict_):

--- a/wazo_calld/plugins/transfers/transfer_lock.py
+++ b/wazo_calld/plugins/transfers/transfer_lock.py
@@ -1,4 +1,4 @@
-# Copyright 2017 The Wazo Authors  (see AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -8,6 +8,10 @@ logger = logging.getLogger(__name__)
 
 
 class TransferLock:
+    '''
+    Purpose: prevent starting the same transfer twice
+    '''
+
     def __init__(self):
         self._locked_calls = set()
         self._lock = threading.Lock()


### PR DESCRIPTION
## transfers: fix state.start() signature


## transfers: add purpose for classes


## transfers: make transfer object mandatory for states


## transfer states: add thread synchronization lock

Why:

* In some circumstances, the API thread is not finished with creating
  the transfer, when the Stasis thread already receives events for the
  channels creating the transfer, creating weird race conditions.