### PR TITLE
Pull request for fix-integration-tests-call-direction

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 *.pyc
 .git
+.mypy_cache
 .tox
 debian
 integration_tests

--- a/integration_tests/suite/helpers/calld.py
+++ b/integration_tests/suite/helpers/calld.py
@@ -390,8 +390,14 @@ class LegacyCalldClient:
         requests.put = old_put
 
 
-def new_call_id(leap=0):
-    return format(time.time() + leap, '.2f')
+call_id_counter = 0
+
+
+def new_call_id():
+    current_time = int(time.time())
+    global call_id_counter
+    call_id_counter += 1
+    return f'{current_time}.{call_id_counter}'
 
 
 def new_uuid():

--- a/integration_tests/suite/test_calls.py
+++ b/integration_tests/suite/test_calls.py
@@ -71,7 +71,7 @@ class TestListCalls(_BaseTestCalls):
     def test_given_some_calls_with_user_id_when_list_calls_then_calls_are_complete(
         self,
     ):
-        first_id, second_id = new_call_id(), new_call_id(leap=1)
+        first_id, second_id = new_call_id(), new_call_id()
         self.ari.set_channels(
             MockChannel(
                 id=first_id,
@@ -161,7 +161,7 @@ class TestListCalls(_BaseTestCalls):
         )
 
     def test_call_direction(self):
-        first_id, second_id = new_call_id(), new_call_id(leap=1)
+        first_id, second_id = new_call_id(), new_call_id()
         self.ari.set_channels(MockChannel(id=first_id), MockChannel(id=second_id))
         self._set_channel_variable(
             {
@@ -186,7 +186,7 @@ class TestListCalls(_BaseTestCalls):
     def test_given_some_calls_and_no_user_id_when_list_calls_then_list_calls_with_no_user_uuid(
         self,
     ):
-        first_id, second_id = new_call_id(), new_call_id(leap=1)
+        first_id, second_id = new_call_id(), new_call_id()
         self.ari.set_channels(MockChannel(id=first_id), MockChannel(id=second_id))
         self._set_channel_variable({first_id: {}, second_id: {}})
 
@@ -207,8 +207,8 @@ class TestListCalls(_BaseTestCalls):
     ):
         first_id, second_id, third_id = (
             new_call_id(),
-            new_call_id(leap=1),
-            new_call_id(leap=2),
+            new_call_id(),
+            new_call_id(),
         )
         self.ari.set_channels(
             MockChannel(id=first_id),
@@ -235,7 +235,7 @@ class TestListCalls(_BaseTestCalls):
     def test_given_some_calls_and_no_applications_when_list_calls_by_application_then_no_calls(
         self,
     ):
-        first_id, second_id = new_call_id(), new_call_id(leap=1)
+        first_id, second_id = new_call_id(), new_call_id()
         self.ari.set_channels(MockChannel(id=first_id), MockChannel(id=second_id))
         self._set_channel_variable({first_id: {}, second_id: {}})
 
@@ -248,9 +248,9 @@ class TestListCalls(_BaseTestCalls):
     ):
         first_id, second_id, third_id, fourth_id = (
             new_call_id(),
-            new_call_id(leap=1),
-            new_call_id(leap=2),
-            new_call_id(leap=3),
+            new_call_id(),
+            new_call_id(),
+            new_call_id(),
         )
         self.ari.set_channels(
             MockChannel(id=first_id),
@@ -296,7 +296,7 @@ class TestListCalls(_BaseTestCalls):
     def test_given_some_calls_and_application_bound_to_all_channels_when_list_calls_by_application_then_all_calls(
         self,
     ):
-        first_id, second_id = new_call_id(), new_call_id(leap=1)
+        first_id, second_id = new_call_id(), new_call_id()
         self.ari.set_channels(MockChannel(id=first_id), MockChannel(id=second_id))
         self._set_channel_variable({first_id: {}, second_id: {}})
         self.ari.set_applications(
@@ -318,7 +318,7 @@ class TestListCalls(_BaseTestCalls):
     def test_given_some_calls_and_application_bound_to_all_channels_when_list_calls_by_application_instance_then_calls_are_still_filtered_by_application(
         self,
     ):
-        first_id, second_id = new_call_id(), new_call_id(leap=1)
+        first_id, second_id = new_call_id(), new_call_id()
         self.ari.set_channels(MockChannel(id=first_id), MockChannel(id=second_id))
         self._set_channel_variable({first_id: {}, second_id: {}})
         self.ari.set_global_variables(
@@ -350,7 +350,7 @@ class TestListCalls(_BaseTestCalls):
         )
 
     def test_given_local_channels_when_list_then_talking_to_is_none(self):
-        first_id, second_id = new_call_id(), new_call_id(leap=1)
+        first_id, second_id = new_call_id(), new_call_id()
         self.ari.set_channels(
             MockChannel(id=first_id),
             MockChannel(id=second_id, name=SOME_LOCAL_CHANNEL_NAME),
@@ -383,7 +383,7 @@ class TestListCalls(_BaseTestCalls):
         user_uuid_2 = str(uuid.uuid4())
         tenant_uuid_1 = str(uuid.uuid4())
         tenant_uuid_2 = str(uuid.uuid4())
-        first_id, second_id = new_call_id(), new_call_id(leap=1)
+        first_id, second_id = new_call_id(), new_call_id()
         self.ari.set_channels(MockChannel(id=first_id), MockChannel(id=second_id))
         self._set_channel_variable(
             {
@@ -421,7 +421,7 @@ class TestListCalls(_BaseTestCalls):
         user_uuid_2 = str(uuid.uuid4())
         top_tenant_uuid = CALLD_SERVICE_TENANT
         subtenant_uuid = VALID_TENANT
-        first_id, second_id = new_call_id(), new_call_id(leap=1)
+        first_id, second_id = new_call_id(), new_call_id()
         self.ari.set_channels(MockChannel(id=first_id), MockChannel(id=second_id))
         self._set_channel_variable(
             {
@@ -500,9 +500,9 @@ class TestUserListCalls(_BaseTestCalls):
     ):
         user_uuid = 'user-uuid'
         my_call_id = new_call_id()
-        my_second_call_id = new_call_id(leap=1)
-        others_call_id = new_call_id(leap=2)
-        no_user_call_id = new_call_id(leap=3)
+        my_second_call_id = new_call_id()
+        others_call_id = new_call_id()
+        no_user_call_id = new_call_id()
         self.ari.set_channels(
             MockChannel(id=my_call_id, channelvars={'WAZO_USERUUID': user_uuid}),
             MockChannel(id=my_second_call_id, channelvars={'WAZO_USERUUID': user_uuid}),
@@ -536,8 +536,8 @@ class TestUserListCalls(_BaseTestCalls):
     ):
         first_id, second_id, third_id = (
             new_call_id(),
-            new_call_id(leap=1),
-            new_call_id(leap=2),
+            new_call_id(),
+            new_call_id(),
         )
         user_uuid = 'user-uuid'
         self.ari.set_channels(
@@ -572,7 +572,7 @@ class TestUserListCalls(_BaseTestCalls):
     def test_given_some_calls_and_no_applications_when_list_calls_by_application_then_no_calls(
         self,
     ):
-        first_id, second_id = new_call_id(), new_call_id(leap=1)
+        first_id, second_id = new_call_id(), new_call_id()
         user_uuid = 'user-uuid'
         self.ari.set_channels(MockChannel(id=first_id), MockChannel(id=second_id))
         self._set_channel_variable(
@@ -592,9 +592,9 @@ class TestUserListCalls(_BaseTestCalls):
     ):
         first_id, second_id, third_id, fourth_id = (
             new_call_id(),
-            new_call_id(leap=1),
-            new_call_id(leap=2),
-            new_call_id(leap=3),
+            new_call_id(),
+            new_call_id(),
+            new_call_id(),
         )
         user_uuid = 'user-uuid'
         self.ari.set_channels(
@@ -645,7 +645,7 @@ class TestUserListCalls(_BaseTestCalls):
         )
 
     def test_given_local_channels_when_list_then_local_channels_are_ignored(self):
-        first_id, second_id = new_call_id(), new_call_id(leap=1)
+        first_id, second_id = new_call_id(), new_call_id()
         user_uuid = 'user-uuid'
         self.ari.set_channels(
             MockChannel(id=first_id),
@@ -673,7 +673,7 @@ class TestUserListCalls(_BaseTestCalls):
     def test_extra_fields_on_user_calls(self):
         user_uuid = 'user-uuid'
         my_call = new_call_id()
-        my_second_call = new_call_id(leap=1)
+        my_second_call = new_call_id()
         self.ari.set_channels(
             MockChannel(
                 id=my_call,
@@ -723,7 +723,7 @@ class TestGetCall(_BaseTestCalls):
         )
 
     def test_given_one_call_when_get_call_then_get_call(self):
-        first_id, second_id = new_call_id(), new_call_id(leap=1)
+        first_id, second_id = new_call_id(), new_call_id()
         self.ari.set_channels(
             MockChannel(
                 id=first_id,
@@ -775,7 +775,7 @@ class TestGetCall(_BaseTestCalls):
         user_uuid_2 = str(uuid.uuid4())
         tenant_uuid_1 = str(uuid.uuid4())
         tenant_uuid_2 = str(uuid.uuid4())
-        first_id, second_id = new_call_id(), new_call_id(leap=1)
+        first_id, second_id = new_call_id(), new_call_id()
         self.ari.set_channels(MockChannel(id=first_id), MockChannel(id=second_id))
         self._set_channel_variable(
             {
@@ -2440,7 +2440,7 @@ class TestConnectUser(_BaseTestCalls):
         self,
     ):
         call_id = new_call_id()
-        my_new_call_id = new_call_id(leap=1)
+        my_new_call_id = new_call_id()
         self.ari.set_channels(
             MockChannel(id=call_id),
             MockChannel(id=my_new_call_id),
@@ -2486,7 +2486,7 @@ class TestConnectUser(_BaseTestCalls):
         self,
     ):
         call_id = new_call_id()
-        my_new_call_id = new_call_id(leap=1)
+        my_new_call_id = new_call_id()
         self.ari.set_channels(
             MockChannel(id=call_id),
             MockChannel(id=my_new_call_id),
@@ -3157,9 +3157,9 @@ class TestCallHold(_BaseTestCalls):
 
     def test_user_hold(self):
         user_channel_id = new_call_id()
-        someone_else_channel_id = new_call_id(leap=1)
-        user_channel_id_device_no_plugin = new_call_id(leap=2)
-        user_channel_id_no_device = new_call_id(leap=3)
+        someone_else_channel_id = new_call_id()
+        user_channel_id_device_no_plugin = new_call_id()
+        user_channel_id_no_device = new_call_id()
         user_uuid = str(uuid.uuid4())
         someone_else_uuid = str(uuid.uuid4())
         token = self.given_user_token(user_uuid)
@@ -3248,9 +3248,9 @@ class TestCallHold(_BaseTestCalls):
 
     def test_user_unhold(self):
         user_channel_id = new_call_id()
-        someone_else_channel_id = new_call_id(leap=1)
-        user_channel_id_device_no_plugin = new_call_id(leap=2)
-        user_channel_id_no_device = new_call_id(leap=3)
+        someone_else_channel_id = new_call_id()
+        user_channel_id_device_no_plugin = new_call_id()
+        user_channel_id_no_device = new_call_id()
         user_uuid = str(uuid.uuid4())
         someone_else_uuid = str(uuid.uuid4())
         token = self.given_user_token(user_uuid)
@@ -3405,9 +3405,9 @@ class TestCallAnswer(_BaseTestCalls):
         someone_else_uuid = str(uuid.uuid4())
         token = self.given_user_token(user_uuid)
         user_channel_id = new_call_id()
-        someone_else_channel_id = new_call_id(leap=1)
-        user_channel_id_device_no_plugin = new_call_id(leap=2)
-        user_channel_id_no_device = new_call_id(leap=3)
+        someone_else_channel_id = new_call_id()
+        user_channel_id_device_no_plugin = new_call_id()
+        user_channel_id_no_device = new_call_id()
         self.calld_client.set_token(token)
         self.ari.set_channels(
             MockChannel(

--- a/integration_tests/suite/test_calls_bus_consume.py
+++ b/integration_tests/suite/test_calls_bus_consume.py
@@ -216,9 +216,9 @@ class TestBusConsume(IntegrationTest):
         until.assert_(assert_function, tries=5)
 
     def test_when_channel_leaves_bridge_call_direction_updated(self):
-        first_channel_id = new_call_id(1)
-        second_channel_id = new_call_id(2)
-        third_channel_id = new_call_id(3)
+        first_channel_id = new_call_id()
+        second_channel_id = new_call_id()
+        third_channel_id = new_call_id()
         self.ari.set_bridges(
             MockBridge(
                 first_channel_id,

--- a/integration_tests/suite/test_calls_bus_consume.py
+++ b/integration_tests/suite/test_calls_bus_consume.py
@@ -151,6 +151,12 @@ class TestBusConsume(IntegrationTest):
                 },
             }
         )
+        self.ari.set_bridges(
+            MockBridge(
+                first_channel_id,
+                channels=[first_channel_id, second_channel_id],
+            )
+        )
 
         events = self.bus.accumulator(headers={'name': 'call_updated'})
 

--- a/integration_tests/suite/test_endpoints_bus_consume.py
+++ b/integration_tests/suite/test_endpoints_bus_consume.py
@@ -29,9 +29,7 @@ class TestTrunkBusConsume(IntegrationTest):
         name = 'abcdef'
 
         self.ari.set_endpoints(
-            MockEndpoint(
-                'PJSIP', name, 'online', channel_ids=[call_id, new_call_id(leap=1)]
-            )
+            MockEndpoint('PJSIP', name, 'online', channel_ids=[call_id, new_call_id()])
         )
         self.confd.set_trunks(
             MockTrunk(
@@ -82,7 +80,7 @@ class TestTrunkBusConsume(IntegrationTest):
                 'PJSIP',
                 name,
                 'online',
-                channel_ids=[new_call_id(), new_call_id(leap=1)],
+                channel_ids=[new_call_id(), new_call_id()],
             )
         )
         self.confd.set_trunks(
@@ -102,7 +100,7 @@ class TestTrunkBusConsume(IntegrationTest):
         self.reset_clients()
         self.wait_strategy.wait(self)
         self.bus.send_ami_newchannel_event(
-            new_call_id(leap=2), channel='PJSIP/abcdef-00000001'
+            new_call_id(), channel='PJSIP/abcdef-00000001'
         )
 
         def assert_function():
@@ -336,9 +334,7 @@ class TestLineBusConsume(IntegrationTest):
         name = 'abcdef'
 
         self.ari.set_endpoints(
-            MockEndpoint(
-                'PJSIP', name, 'online', channel_ids=[call_id, new_call_id(leap=1)]
-            )
+            MockEndpoint('PJSIP', name, 'online', channel_ids=[call_id, new_call_id()])
         )
         self.confd.set_lines(
             MockLine(
@@ -389,7 +385,7 @@ class TestLineBusConsume(IntegrationTest):
                 'PJSIP',
                 name,
                 'online',
-                channel_ids=[new_call_id(), new_call_id(leap=1)],
+                channel_ids=[new_call_id(), new_call_id()],
             )
         )
         self.confd.set_lines(
@@ -411,7 +407,7 @@ class TestLineBusConsume(IntegrationTest):
         self.reset_clients()
         self.wait_strategy.wait(self)
         self.bus.send_ami_newchannel_event(
-            new_call_id(leap=2), channel='PJSIP/abcdef-00000001'
+            new_call_id(), channel='PJSIP/abcdef-00000001'
         )
 
         def assert_function():


### PR DESCRIPTION
## test calls direction: fix missing precondition


## tests: make new_call_id usable multiple times easily

Why:

* Forgetting the `leap` argument was too easy

## dockerignore: ignore mypy cache