### PR TITLE
WP-1527: update trunk status on endpoint association

### DIFF
--- a/wazo_calld/plugins/endpoints/bus.py
+++ b/wazo_calld/plugins/endpoints/bus.py
@@ -168,6 +168,9 @@ class EventHandler:
             None,
             event['trunk']['tenant_uuid'],
         )
+        self._endpoint_status_cache.add_new_iax_endpoint(
+            event['endpoint_iax']['name'],
+        )
 
     def on_line_endpoint_custom_associated(self, event):
         self._confd_cache.add_line(

--- a/wazo_calld/plugins/endpoints/bus.py
+++ b/wazo_calld/plugins/endpoints/bus.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -155,6 +155,9 @@ class EventHandler:
             event['endpoint_sip']['name'],
             sip_username,
             event['trunk']['tenant_uuid'],
+        )
+        self._endpoint_status_cache.add_new_sip_endpoint(
+            event['endpoint_sip']['name'],
         )
 
     def on_trunk_endpoint_iax_associated(self, event):

--- a/wazo_calld/plugins/endpoints/bus.py
+++ b/wazo_calld/plugins/endpoints/bus.py
@@ -208,9 +208,10 @@ class EventHandler:
     def on_trunk_endpoint_deleted(self, event):
         trunk = self._confd_cache.get_trunk_by_id(event['id'])
         self._confd_cache.delete_trunk(event['id'])
-        self._endpoint_status_cache.pop(
-            self.techno_map[trunk['technology']], trunk['name']
-        )
+        if trunk:
+            self._endpoint_status_cache.pop(
+                self.techno_map[trunk['technology']], trunk['name']
+            )
 
     def on_endpoint_sip_updated(self, event):
         trunk = event['trunk']

--- a/wazo_calld/plugins/endpoints/bus.py
+++ b/wazo_calld/plugins/endpoints/bus.py
@@ -7,6 +7,12 @@ logger = logging.getLogger(__name__)
 
 
 class EventHandler:
+    techno_map = {
+        'sip': 'PJSIP',
+        'iax': 'IAX2',
+        'custom': 'custom',
+    }
+
     def __init__(self, endpoint_status_cache, confd_cache):
         self._endpoint_status_cache = endpoint_status_cache
         self._confd_cache = confd_cache
@@ -200,7 +206,11 @@ class EventHandler:
         self._confd_cache.delete_line(event['id'])
 
     def on_trunk_endpoint_deleted(self, event):
+        trunk = self._confd_cache.get_trunk_by_id(event['id'])
         self._confd_cache.delete_trunk(event['id'])
+        self._endpoint_status_cache.pop(
+            self.techno_map[trunk['technology']], trunk['name']
+        )
 
     def on_endpoint_sip_updated(self, event):
         trunk = event['trunk']

--- a/wazo_calld/plugins/endpoints/services.py
+++ b/wazo_calld/plugins/endpoints/services.py
@@ -84,6 +84,12 @@ class StatusCache:
 
         return self._endpoints.get(techno, {}).get(name)
 
+    def pop(self, techno, name):
+        if self._endpoints is None:
+            raise CalldUninitializedError()
+
+        return self._endpoints.get(techno, {}).pop(name, None)
+
     def initialize(self):
         logger.debug('initializing endpoint status...')
         for endpoint in self._ari.endpoints.list():
@@ -157,8 +163,9 @@ class ConfdCache:
             'name': name,
             'tenant_uuid': tenant_uuid,
         }
-        self._trunks.setdefault(techno, {'name': {}, 'username': {}})
+        self._trunks.setdefault(techno, {'id': {}, 'name': {}, 'username': {}})
         self._trunks[techno]['name'][name] = value
+        self._trunks[techno]['id'][trunk_id] = value
         if username:
             self._trunks[techno].setdefault('username', {})
             self._trunks[techno]['username'][username] = value
@@ -192,6 +199,14 @@ class ConfdCache:
 
     def get_trunk(self, techno, name):
         return self._get_endpoint_by_index(techno, name, self._trunks, index='name')
+
+    def get_trunk_by_id(self, trunk_id):
+        for techno in self._trunks.keys():
+            if trunk := self._get_endpoint_by_index(
+                techno, trunk_id, self._trunks, index='id'
+            ):
+                return trunk
+        return None
 
     def get_trunk_by_username(self, techno, username):
         return self._get_endpoint_by_index(
@@ -303,8 +318,9 @@ class ConfdCache:
                 'tenant_uuid': trunk['tenant_uuid'],
             }
 
-            self._trunks.setdefault(techno, {'name': {}, 'username': {}})
+            self._trunks.setdefault(techno, {'id': {}, 'name': {}, 'username': {}})
             self._trunks[techno]['name'][name] = value
+            self._trunks[techno]['id'][trunk['id']] = value
             self._trunks[techno]['username'][username] = value
 
         for trunk in trunks:

--- a/wazo_calld/plugins/endpoints/services.py
+++ b/wazo_calld/plugins/endpoints/services.py
@@ -72,6 +72,9 @@ class StatusCache:
 
         self._endpoints[endpoint.techno][endpoint.name] = endpoint
 
+    def add_new_sip_endpoint(self, endpoint_name):
+        self.add_endpoint(Endpoint('PJSIP', endpoint_name, None, []))
+
     def get(self, techno, name):
         if self._endpoints is None:
             raise CalldUninitializedError()

--- a/wazo_calld/plugins/endpoints/services.py
+++ b/wazo_calld/plugins/endpoints/services.py
@@ -75,6 +75,9 @@ class StatusCache:
     def add_new_sip_endpoint(self, endpoint_name):
         self.add_endpoint(Endpoint('PJSIP', endpoint_name, None, []))
 
+    def add_new_iax_endpoint(self, endpoint_name):
+        self.add_endpoint(Endpoint('IAX2', endpoint_name, None, []))
+
     def get(self, techno, name):
         if self._endpoints is None:
             raise CalldUninitializedError()

--- a/wazo_calld/plugins/endpoints/tests/test_bus.py
+++ b/wazo_calld/plugins/endpoints/tests/test_bus.py
@@ -316,7 +316,6 @@ class TestBusEvent(TestCase):
             username,
             tenant_uuid,
         )
-
         self.endpoint_status_cache.add_new_sip_endpoint.assert_called_once_with(
             event['endpoint_sip']['name']
         )
@@ -374,7 +373,6 @@ class TestBusEvent(TestCase):
             None,
             tenant_uuid,
         )
-
         self.endpoint_status_cache.add_new_iax_endpoint.assert_called_once_with(
             event['endpoint_iax']['name']
         )
@@ -489,11 +487,17 @@ class TestBusEvent(TestCase):
         self.confd_cache.delete_line.assert_called_once_with(42)
 
     def test_on_trunk_deleted(self):
+        self.confd_cache.get_trunk_by_id.return_value = {
+            'technology': 'sip',
+            'name': 'foobar',
+        }
         event = {'id': 42}
 
         self.handler.on_trunk_endpoint_deleted(event)
 
         self.confd_cache.delete_trunk.assert_called_once_with(42)
+        self.confd_cache.get_trunk_by_id.assert_called_once_with(42)
+        self.endpoint_status_cache.pop.assert_called_once_with('PJSIP', 'foobar')
 
     def test_on_line_edited(self):
         event = {

--- a/wazo_calld/plugins/endpoints/tests/test_bus.py
+++ b/wazo_calld/plugins/endpoints/tests/test_bus.py
@@ -9,14 +9,14 @@ from unittest.mock import sentinel as s
 from hamcrest import assert_that, calling, has_properties, not_, raises
 
 from ..bus import EventHandler
-from ..services import ConfdCache, Endpoint
+from ..services import ConfdCache, Endpoint, StatusCache
 
 
 class TestBusEvent(TestCase):
     def setUp(self):
         endpoint = self.updated_endpoint = Mock(Endpoint)
 
-        class StatusCacheMock:
+        class StatusCacheMock(Mock):
             call_count = 0
 
             def assert_not_called(self):
@@ -29,7 +29,7 @@ class TestBusEvent(TestCase):
                 endpoint.name = name
                 yield endpoint
 
-        self.endpoint_status_cache = StatusCacheMock()
+        self.endpoint_status_cache = StatusCacheMock(StatusCache)
         self.confd_cache = Mock(ConfdCache)
         self.handler = EventHandler(self.endpoint_status_cache, self.confd_cache)
 
@@ -315,6 +315,10 @@ class TestBusEvent(TestCase):
             name,
             username,
             tenant_uuid,
+        )
+
+        self.endpoint_status_cache.add_new_sip_endpoint.assert_called_once_with(
+            event['endpoint_sip']['name']
         )
 
     def test_on_line_endpoint_sccp_associated(self):

--- a/wazo_calld/plugins/endpoints/tests/test_bus.py
+++ b/wazo_calld/plugins/endpoints/tests/test_bus.py
@@ -375,6 +375,10 @@ class TestBusEvent(TestCase):
             tenant_uuid,
         )
 
+        self.endpoint_status_cache.add_new_iax_endpoint.assert_called_once_with(
+            event['endpoint_iax']['name']
+        )
+
     def test_on_line_endpoint_custom_associated(self):
         line_id = 42
         tenant_uuid = '2c34c282-433e-4bb8-8d56-fec14ff7e1e9'


### PR DESCRIPTION
This PR adds the trunk's endpoint to the endpoint cache when a new trunk is created so that it's status can be updated on asterisk's Registry event

Change in behavior:
- `GET /trunks` will return accurate information instead of stale data

note 1: Only sip and iax endpoints are considered, custom is not used

#### Tests
1. create a trunk on a tenant
2. check that /trunks returns correct registration status after Registry event (can take up to 10 seconds)
3. verify that key registered changes from `null` to either `true` or `false` (will only happen if trunk actually tries to authenticate)