### PR TITLE
lines API: fix line status after creation

### DIFF
--- a/integration_tests/suite/helpers/bus.py
+++ b/integration_tests/suite/helpers/bus.py
@@ -251,6 +251,25 @@ class BusClient(bus_helper.BusClient):
             headers={'name': 'application_deleted'},
         )
 
+    def send_line_endpoint_sip_associated_event(
+        self, tenant_uuid, line_id, endpoint_id, endpoint_name
+    ):
+        payload = {
+            'data': {
+                'line': {'id': line_id, 'tenant_uuid': tenant_uuid},
+                'endpoint_sip': {
+                    'id': endpoint_id,
+                    'name': endpoint_name,
+                    'auth_section_options': [['username', endpoint_name]],
+                },
+            },
+            'name': 'line_endpoint_sip_associated',
+        }
+        self.send_event(
+            payload,
+            headers={'name': 'line_endpoint_sip_associated'},
+        )
+
     def send_trunk_endpoint_associated_event(self, trunk_id, endpoint_id):
         payload = {
             'data': {'trunk_id': trunk_id, 'endpoint_id': endpoint_id},

--- a/wazo_calld/plugins/endpoints/bus.py
+++ b/wazo_calld/plugins/endpoints/bus.py
@@ -130,6 +130,9 @@ class EventHandler:
             sip_username,
             event['line']['tenant_uuid'],
         )
+        self._endpoint_status_cache.add_new_sip_endpoint(
+            event['endpoint_sip']['name'],
+        )
 
     def on_line_endpoint_sccp_associated(self, event):
         self._confd_cache.add_line(

--- a/wazo_calld/plugins/endpoints/services.py
+++ b/wazo_calld/plugins/endpoints/services.py
@@ -73,10 +73,18 @@ class StatusCache:
         self._endpoints[endpoint.techno][endpoint.name] = endpoint
 
     def add_new_sip_endpoint(self, endpoint_name):
-        self.add_endpoint(Endpoint('PJSIP', endpoint_name, None, []))
+        if self._endpoints is None:
+            raise CalldUninitializedError()
+
+        # endpoint is unlikely to exist in ARI yet, so create it as unregistered
+        self.add_endpoint(Endpoint('PJSIP', endpoint_name, False, []))
 
     def add_new_iax_endpoint(self, endpoint_name):
-        self.add_endpoint(Endpoint('IAX2', endpoint_name, None, []))
+        if self._endpoints is None:
+            raise CalldUninitializedError()
+
+        # endpoint is unlikely to exist in ARI yet, so create it as unregistered
+        self.add_endpoint(Endpoint('IAX2', endpoint_name, False, []))
 
     def get(self, techno, name):
         if self._endpoints is None:


### PR DESCRIPTION
Why:

* line status was left to null until wazo-calld restart