### PR TITLE
integration tests: reduce logs

### DIFF
--- a/integration_tests/assets/docker-compose.real_asterisk.override.yml
+++ b/integration_tests/assets/docker-compose.real_asterisk.override.yml
@@ -41,7 +41,7 @@ services:
       - "./etc/asterisk/voicemail.conf:/etc/asterisk/voicemail.conf"
       - "./ssl:/usr/local/share/ssl"
       - asterisk-voicemail:/var/spool/asterisk/voicemail
-    command: "asterisk -fTnvvvvvddddd"
+    command: "asterisk -fTnvvvvv"
 
   calld:
     volumes:


### PR DESCRIPTION
Why:

* Asterisk debug logs account for 80% of logs
* Asterisk debug logs are mainly useful during development, not
  test failure investigation