### PR TITLE
[WAZO-1908] voicemail: do not move messages to Old directory when recording accessed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * The following endpoints are not marking a voicemail message as read anymore when accessed:
   * `GET /1.0/voicemails/<voicemail_id>/messages/<message_id>/recording`
-  * `GET /1.0/vusers/me/oicemails/<voicemail_id>/messages/<message_id>/recording`
+  * `GET /1.0/users/me/voicemails/<voicemail_id>/messages/<message_id>/recording`
   If you want to mark a message as read, use the
   `PUT /1.0/voicemails/<voicemail_id>/messages/<message_id>` API to change the `folder_id` of the
   message to the `Old` folder (id 2).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 24.16
+
+* The following endpoints are not marking a voicemail message as read anymore when accessed:
+  * `GET /1.0/voicemails/<voicemail_id>/messages/<message_id>/recording`
+  * `GET /1.0/vusers/me/oicemails/<voicemail_id>/messages/<message_id>/recording`
+  If you want to mark a message as read, use the
+  `PUT /1.0/voicemails/<voicemail_id>/messages/<message_id>` API to change the `folder_id` of the
+  message to the `Old` folder (id 2).
+
 ## 24.13
 
 * The following endpoints now enforce tenant isolation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   * `GET /1.0/voicemails/<voicemail_id>/messages/<message_id>/recording`
   * `GET /1.0/users/me/voicemails/<voicemail_id>/messages/<message_id>/recording`
   If you want to mark a message as read, use the
-  `PUT /1.0/voicemails/<voicemail_id>/messages/<message_id>` API to change the `folder_id` of the
+  `PUT /1.0/voicemails/<voicemail_id>/messages/<message_id>` or
+  `PUT /1.0/users/me/voicemails/messages/<message_id>` API to change the `folder_id` of the
   message to the `Old` folder (id 2).
 
 ## 24.13

--- a/integration_tests/suite/test_voicemail.py
+++ b/integration_tests/suite/test_voicemail.py
@@ -853,6 +853,18 @@ class TestVoicemails(RealAsteriskIntegrationTest):
         )
         assert content == b'some-wav-data\n'
 
+    def test_voicemail_get_message_recording_does_not_mark_message_as_old(self):
+        content = self.calld_client.voicemails.get_voicemail_recording(
+            self._voicemail_id, self._message_id
+        )
+        assert content == b'some-wav-data\n'
+
+        message = self.calld_client.voicemails.get_voicemail_message(
+            self._voicemail_id, self._message_id
+        )
+        assert message['id'] == self._message_id
+        assert message['folder']['id'] == self._folder_id
+
     def test_voicemail_head_greeting_invalid_voicemail(self):
         exists = self.calld_client.voicemails.voicemail_greeting_exists(
             'not-exists', 'busy'

--- a/wazo_calld/plugins/voicemails/services.py
+++ b/wazo_calld/plugins/voicemails/services.py
@@ -13,7 +13,6 @@ from .exceptions import (
     NoSuchVoicemailGreeting,
     VoicemailGreetingAlreadyExists,
 )
-from .storage import VoicemailFolderType
 
 
 class VoicemailsService:
@@ -55,12 +54,7 @@ class VoicemailsService:
         return self._get_message_recording(vm_conf, message_id)
 
     def _get_message_recording(self, vm_conf, message_id):
-        message_info, recording = self._storage.get_message_info_and_recording(
-            vm_conf, message_id
-        )
-        if message_info['folder'].is_unread:
-            dest_folder = self._storage.get_folder_by_type(VoicemailFolderType.old)
-            self._move_message(vm_conf, message_info, dest_folder)
+        _, recording = self._storage.get_message_info_and_recording(vm_conf, message_id)
         return recording
 
     def move_message(self, tenant_uuid, voicemail_id, message_id, dest_folder_id):


### PR DESCRIPTION
Why: it's an undocumented side-effect of a GET, which is not really RESTful since it acts directly on the accessed resource.