### PR TITLE
test: remove app_meetme from noload

### DIFF
--- a/integration_tests/assets/etc/asterisk/modules.conf
+++ b/integration_tests/assets/etc/asterisk/modules.conf
@@ -72,7 +72,6 @@ noload => res_xmpp.so
 ;; deprecated
 noload => res_monitor
 noload => res_adsi
-noload => app_meetme
 noload => app_url
 noload => app_getcpeid
 noload => res_adsi


### PR DESCRIPTION
why: this module is not enabled by default in wazoplatform/asterisk
image