### PR TITLE
Use marshmallow version 3.18.0 from Bookworm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ jinja2==3.0.3  # from flask
 jsonpatch==1.25
 kombu==5.0.2
 markupsafe==2.0.1 # from jinja
-marshmallow==3.10.0
+marshmallow==3.18.0
 python-consul==1.1.0
 pyyaml==5.3.1  # from xivo-lib-python
 requests==2.25.1

--- a/wazo_calld/plugins/applications/schemas.py
+++ b/wazo_calld/plugins/applications/schemas.py
@@ -25,10 +25,12 @@ class ApplicationCallPlaySchema(BaseSchema):
 class ApplicationCallRequestSchema(BaseSchema):
     exten = fields.String(validate=Length(min=1), required=True)
     context = fields.String(required=True)
-    autoanswer = fields.Boolean(required=False, missing=False)
-    variables = fields.Dict(validate=validate_string_dict, missing={})
-    displayed_caller_id_name = fields.String(missing='', validate=Length(max=256))
-    displayed_caller_id_number = fields.String(missing='', validate=Length(max=256))
+    autoanswer = fields.Boolean(required=False, load_default=False)
+    variables = fields.Dict(validate=validate_string_dict, load_default={})
+    displayed_caller_id_name = fields.String(load_default='', validate=Length(max=256))
+    displayed_caller_id_number = fields.String(
+        load_default='', validate=Length(max=256)
+    )
 
     @post_load
     def remove_extension_whitespace(self, call_request, **kwargs):
@@ -38,10 +40,12 @@ class ApplicationCallRequestSchema(BaseSchema):
 
 class ApplicationCallUserRequestSchema(BaseSchema):
     user_uuid = fields.String(required=True)
-    autoanswer = fields.Boolean(required=False, missing=False)
-    variables = fields.Dict(validate=validate_string_dict, missing={})
-    displayed_caller_id_name = fields.String(missing='', validate=Length(max=256))
-    displayed_caller_id_number = fields.String(missing='', validate=Length(max=256))
+    autoanswer = fields.Boolean(required=False, load_default=False)
+    variables = fields.Dict(validate=validate_string_dict, load_default={})
+    displayed_caller_id_name = fields.String(load_default='', validate=Length(max=256))
+    displayed_caller_id_number = fields.String(
+        load_default='', validate=Length(max=256)
+    )
 
 
 class ApplicationCallSchema(BaseSchema):
@@ -76,7 +80,7 @@ class ApplicationNodeSchema(BaseSchema):
 
 class ApplicationSnoopPutSchema(BaseSchema):
     whisper_mode = fields.String(
-        validate=OneOf(['in', 'out', 'both', 'none']), missing='none'
+        validate=OneOf(['in', 'out', 'both', 'none']), load_default='none'
     )
 
 

--- a/wazo_calld/plugins/calls/schemas.py
+++ b/wazo_calld/plugins/calls/schemas.py
@@ -13,11 +13,11 @@ class CallBaseSchema(Schema):
 
 
 class CallRequestSourceSchema(CallBaseSchema):
-    from_mobile = fields.Boolean(missing=False)
+    from_mobile = fields.Boolean(load_default=False)
     line_id = fields.Integer()
-    all_lines = fields.Boolean(missing=False)
+    all_lines = fields.Boolean(load_default=False)
     user = fields.String(required=True)
-    auto_answer = fields.Boolean(missing=False)
+    auto_answer = fields.Boolean(load_default=False)
 
 
 class CallRequestDestinationSchema(CallBaseSchema):
@@ -37,21 +37,21 @@ class CallRequestSchema(CallBaseSchema):
     variables = StrictDict(
         key_field=fields.String(required=True, validate=Length(min=1)),
         value_field=fields.String(required=True, validate=Length(min=1)),
-        missing=dict,
+        load_default=dict,
     )
 
 
 class UserCallRequestSchema(CallBaseSchema):
     extension = fields.String(validate=Length(min=1), required=True)
     line_id = fields.Integer()
-    all_lines = fields.Boolean(missing=False)
-    from_mobile = fields.Boolean(missing=False)
+    all_lines = fields.Boolean(load_default=False)
+    from_mobile = fields.Boolean(load_default=False)
     variables = StrictDict(
         key_field=fields.String(required=True, validate=Length(min=1)),
         value_field=fields.String(required=True, validate=Length(min=1)),
-        missing=dict,
+        load_default=dict,
     )
-    auto_answer_caller = fields.Boolean(missing=False)
+    auto_answer_caller = fields.Boolean(load_default=False)
 
     @post_load
     def remove_extension_whitespace(self, call_request, **kwargs):
@@ -98,7 +98,7 @@ class CallSchema(CallBaseSchema):
 class ConnectCallRequestBodySchema(CallBaseSchema):
     timeout = fields.Integer(
         validate=Range(min=0),
-        missing=30,
+        load_default=30,
         allow_none=True,
     )
 

--- a/wazo_calld/plugins/endpoints/schemas.py
+++ b/wazo_calld/plugins/endpoints/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo.mallow_helpers import Schema, fields
@@ -8,9 +8,9 @@ class EndpointBaseSchema(Schema):
     id = fields.Integer()
     name = fields.String()
     type = fields.String()
-    technology = fields.String(default='unknown')
-    registered = fields.Boolean(default=None)
-    current_call_count = fields.Integer(default=None)
+    technology = fields.String(dump_default='unknown')
+    registered = fields.Boolean(dump_default=None)
+    current_call_count = fields.Integer(dump_default=None)
 
 
 class LineEndpointSchema(EndpointBaseSchema):

--- a/wazo_calld/plugins/faxes/schemas.py
+++ b/wazo_calld/plugins/faxes/schemas.py
@@ -9,9 +9,9 @@ from xivo.mallow_helpers import Schema
 class FaxCreationRequestSchema(Schema):
     context = fields.String(required=True)
     extension = fields.String(required=True)
-    caller_id = fields.String(missing='Wazo Fax')
-    ivr_extension = fields.String(missing=None)
-    wait_time = fields.Integer(missing=None)
+    caller_id = fields.String(load_default='Wazo Fax')
+    ivr_extension = fields.String(load_default=None)
+    wait_time = fields.Integer(load_default=None)
 
     @post_load
     def remove_extension_whitespace(self, call_request, **kwargs):
@@ -21,9 +21,9 @@ class FaxCreationRequestSchema(Schema):
 
 class UserFaxCreationRequestSchema(Schema):
     extension = fields.String(required=True)
-    caller_id = fields.String(missing='Wazo Fax')
-    ivr_extension = fields.String(missing=None)
-    wait_time = fields.Integer(missing=None)
+    caller_id = fields.String(load_default='Wazo Fax')
+    ivr_extension = fields.String(load_default=None)
+    wait_time = fields.Integer(load_default=None)
 
     @post_load
     def remove_extension_whitespace(self, call_request, **kwargs):
@@ -36,9 +36,9 @@ class FaxSchema(Schema):
     call_id = fields.String(dump_only=True)
     context = fields.String(required=True)
     extension = fields.String(required=True)
-    caller_id = fields.String(missing='Wazo Fax')
-    ivr_extension = fields.String(missing=None)
-    wait_time = fields.Integer(missing=None)
+    caller_id = fields.String(load_default='Wazo Fax')
+    ivr_extension = fields.String(load_default=None)
+    wait_time = fields.Integer(load_default=None)
     user_uuid = fields.String(dump_only=True)
     tenant_uuid = fields.String(dump_only=True)
 

--- a/wazo_calld/plugins/parking_lots/schemas.py
+++ b/wazo_calld/plugins/parking_lots/schemas.py
@@ -23,10 +23,10 @@ class ParkingLotSchema(_Base):
     name = String(dump_only=True)
     slots_start = String(dump_only=True)
     slots_end = String(dump_only=True)
-    slots_total = Integer(dump_only=True, default=0)
-    slots_remaining = Integer(dump_only=True, default=0)
+    slots_total = Integer(dump_only=True, dump_default=0)
+    slots_remaining = Integer(dump_only=True, dump_default=0)
     default_timeout = Integer(attribute='timeout', dump_only=True)
-    calls = List(Nested("ParkedCallGetResponseSchema"), default=list)
+    calls = List(Nested("ParkedCallGetResponseSchema"), dump_default=list)
 
     @pre_dump
     def calls_from_context(self, obj, **kwargs):
@@ -73,12 +73,15 @@ class ParkedCallGetResponseSchema(_Base):
 class ParkCallRequestSchema(_Base):
     parking_id = Integer(allow_none=False, required=True, load_only=True)
     preferred_slot = String(
-        validate=Predicate('isdigit'), allow_none=True, missing=None, load_only=True
+        validate=Predicate('isdigit'),
+        allow_none=True,
+        load_default=None,
+        load_only=True,
     )
     timeout = Integer(
         validate=Range(min=0, error='Must be a positive integer or 0'),
         allow_none=True,
-        missing=None,
+        load_default=None,
         load_only=True,
     )
 

--- a/wazo_calld/plugins/relocates/schemas.py
+++ b/wazo_calld/plugins/relocates/schemas.py
@@ -53,12 +53,12 @@ class UserRelocateRequestSchema(Schema):
 
     initiator_call = fields.Str(validate=Length(min=1), required=True)
     destination = fields.Str(validate=OneOf(LocationField.locations))
-    location = LocationField(missing=dict)
+    location = LocationField(load_default=dict)
     completions = fields.List(
-        fields.Str(validate=OneOf(VALID_COMPLETIONS)), missing=['answer']
+        fields.Str(validate=OneOf(VALID_COMPLETIONS)), load_default=['answer']
     )
-    timeout = fields.Integer(validate=Range(min=1), missing=30)
-    auto_answer = fields.Boolean(missing=False)
+    timeout = fields.Integer(validate=Range(min=1), load_default=30)
+    auto_answer = fields.Boolean(load_default=False)
 
 
 user_relocate_request_schema = UserRelocateRequestSchema()
@@ -79,11 +79,11 @@ class RelocateSchema(Schema):
         validate=Length(min=1), required=True, attribute='recipient_channel'
     )
     completions = fields.List(
-        fields.Str(validate=OneOf(VALID_COMPLETIONS)), missing=['answer']
+        fields.Str(validate=OneOf(VALID_COMPLETIONS)), load_default=['answer']
     )
     initiator = fields.Str(validate=Length(equal=36), required=True)
-    timeout = fields.Integer(validate=Range(min=1), missing=30)
-    auto_answer = fields.Boolean(missing=False)
+    timeout = fields.Integer(validate=Range(min=1), load_default=30)
+    auto_answer = fields.Boolean(load_default=False)
 
 
 relocate_schema = RelocateSchema()

--- a/wazo_calld/plugins/switchboards/schemas.py
+++ b/wazo_calld/plugins/switchboards/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import Schema, fields
@@ -23,7 +23,7 @@ held_call_schema = HeldCallSchema()
 
 
 class AnswerCallSchema(Schema):
-    line_id = fields.Integer(missing=None)
+    line_id = fields.Integer(load_default=None)
 
 
 answer_call_schema = AnswerCallSchema()

--- a/wazo_calld/plugins/transfers/schemas.py
+++ b/wazo_calld/plugins/transfers/schemas.py
@@ -12,13 +12,13 @@ class TransferRequestSchema(Schema):
     initiator_call = fields.Str(validate=Length(min=1), required=True)
     context = fields.Str(validate=Length(min=1), required=True)
     exten = fields.Str(validate=Length(min=1), required=True)
-    flow = fields.Str(validate=OneOf(['attended', 'blind']), missing='attended')
+    flow = fields.Str(validate=OneOf(['attended', 'blind']), load_default='attended')
     variables = StrictDict(
         key_field=fields.String(required=True, validate=Length(min=1)),
         value_field=fields.String(required=True, validate=Length(min=1)),
-        missing=dict,
+        load_default=dict,
     )
-    timeout = fields.Integer(missing=None, min=1, allow_none=True)
+    timeout = fields.Integer(load_default=None, min=1, allow_none=True)
 
     @post_load
     def remove_extension_whitespace(self, call_request, **kwargs):
@@ -32,8 +32,8 @@ transfer_request_schema = TransferRequestSchema()
 class UserTransferRequestSchema(Schema):
     initiator_call = fields.Str(validate=Length(min=1), required=True)
     exten = fields.Str(validate=Length(min=1), required=True)
-    flow = fields.Str(validate=OneOf(['attended', 'blind']), missing='attended')
-    timeout = fields.Integer(missing=None, min=1, allow_none=True)
+    flow = fields.Str(validate=OneOf(['attended', 'blind']), load_default='attended')
+    timeout = fields.Integer(load_default=None, min=1, allow_none=True)
 
     @post_load
     def remove_extension_whitespace(self, call_request, **kwargs):


### PR DESCRIPTION
This change uses the Bookworm version of marshmallow to reduce the scope of changes that are going to happen when doing the upgrade