### PR TITLE
WP-2020: Ring group recording

### DIFF
--- a/wazo_calld/plugins/calls/bus_consume.py
+++ b/wazo_calld/plugins/calls/bus_consume.py
@@ -276,6 +276,12 @@ class CallsBusEventHandler:
                 return
             participant_channels.append(channel)
 
+        participant_channels = [
+            ch
+            for ch in participant_channels
+            if not ch.json['name'].startswith('Local/')
+        ]
+
         call_direction = self.services.conversation_direction_from_channels(
             self.ari, [channel.id for channel in participant_channels]
         )
@@ -319,6 +325,12 @@ class CallsBusEventHandler:
                 return
 
             participant_channels.append(channel)
+
+        participant_channels = [
+            ch
+            for ch in participant_channels
+            if not ch.json['name'].startswith('Local/')
+        ]
 
         call_direction = self.services.conversation_direction_from_channels(
             self.ari, [channel.id for channel in participant_channels]

--- a/wazo_calld/plugins/calls/bus_consume.py
+++ b/wazo_calld/plugins/calls/bus_consume.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -263,6 +263,8 @@ class CallsBusEventHandler:
             for ch in participant_channels
             if not ch.json['name'].startswith('Local/')
         ]
+        if not participant_channels:
+            return
 
         call_direction = self.services.conversation_direction_from_channels(
             self.ari, [channel.id for channel in participant_channels]
@@ -313,6 +315,8 @@ class CallsBusEventHandler:
             for ch in participant_channels
             if not ch.json['name'].startswith('Local/')
         ]
+        if not participant_channels:
+            return
 
         call_direction = self.services.conversation_direction_from_channels(
             self.ari, [channel.id for channel in participant_channels]

--- a/wazo_calld/plugins/calls/bus_consume.py
+++ b/wazo_calld/plugins/calls/bus_consume.py
@@ -81,29 +81,38 @@ class CallsBusEventHandler:
         except ARINotFound:
             logger.debug('channel %s not found', channel_id)
 
-    def _relay_channel_created(self, event):
+    def _get_call_from_event(self, event, action):
         channel_id = event['Uniqueid']
         if event['Channel'].startswith('Local/'):
-            logger.debug('Ignoring local channel creation: %s', channel_id)
-            return
-        logger.debug('Relaying to bus: channel %s created', channel_id)
+            logger.debug('Ignoring local channel %s: %s', action, channel_id)
+            return None
+        logger.debug('Relaying to bus: channel %s %s', channel_id, action)
         try:
             channel = self.ari.channels.get(channelId=channel_id)
         except ARINotFound:
             logger.debug('channel %s not found', channel_id)
-            return
-
+            return None
         call = self.services.make_call_from_channel(self.ari, channel)
         if call.is_autoprov:
             logger.debug(
                 'ignoring event %s because this is a device in autoprov', event['Event']
             )
-            return
+            return None
+        return call, channel
+
+    def _ensure_call_direction(self, call, channel):
         if self._call_direction_unknown(call):
             call.direction = self.services.conversation_direction_from_channels(
                 self.ari, [channel.id]
             )
-            self._set_conversation_direction_cache(channel_id, call.direction)
+            self._set_conversation_direction_cache(channel.id, call.direction)
+
+    def _relay_channel_created(self, event):
+        result = self._get_call_from_event(event, 'created')
+        if result is None:
+            return
+        call, channel = result
+        self._ensure_call_direction(call, channel)
         self.notifier.call_created(call)
 
     def _collectd_channel_created(self, event):
@@ -112,54 +121,27 @@ class CallsBusEventHandler:
         self.collectd.publish(ChannelCreatedCollectdEvent())
 
     def _relay_channel_updated(self, event):
-        channel_id = event['Uniqueid']
-        if event['Channel'].startswith('Local/'):
-            logger.debug('Ignoring local channel update: %s', channel_id)
+        result = self._get_call_from_event(event, 'updated')
+        if result is None:
             return
-        logger.debug('Relaying to bus: channel %s updated', channel_id)
-        try:
-            channel = self.ari.channels.get(channelId=channel_id)
-        except ARINotFound:
-            logger.debug('channel %s not found', channel_id)
-            return
-        call = self.services.make_call_from_channel(self.ari, channel)
-        if call.is_autoprov:
-            logger.debug(
-                'ignoring event %s because this is a device in autoprov', event['Event']
-            )
-            return
+        call, _channel = result
         self.notifier.call_updated(call)
 
     def _relay_channel_answered(self, event):
         if event['ChannelStateDesc'] != 'Up':
             return
-        channel_id = event['Uniqueid']
         if event['Channel'].startswith('Local/'):
-            logger.debug('Ignoring local channel answer: %s', channel_id)
             return
-
-        logger.debug('Relaying to bus: channel %s answered', channel_id)
+        channel_id = event['Uniqueid']
         try:
             self.services.set_answered_time(channel_id)
         except NoSuchCall:
             return
-
-        try:
-            channel = self.ari.channels.get(channelId=channel_id)
-        except ARINotFound:
-            logger.debug('channel %s not found', channel_id)
+        result = self._get_call_from_event(event, 'answered')
+        if result is None:
             return
-        call = self.services.make_call_from_channel(self.ari, channel)
-        if call.is_autoprov:
-            logger.debug(
-                'ignoring event %s because this is a device in autoprov', event['Event']
-            )
-            return
-        if self._call_direction_unknown(call):
-            call.direction = self.services.conversation_direction_from_channels(
-                self.ari, [channel.id]
-            )
-            self._set_conversation_direction_cache(channel_id, call.direction)
+        call, channel = result
+        self._ensure_call_direction(call, channel)
         self.notifier.call_answered(call)
 
     def _collectd_channel_ended(self, event):

--- a/wazo_calld/plugins/calls/services.py
+++ b/wazo_calld/plugins/calls/services.py
@@ -748,7 +748,7 @@ class CallsService:
 
         set_channel_id_var_sync(
             self._ari,
-            channel_id,
+            channel.id,
             'WAZO_RECORDING_UUID',
             recording_uuid,
             bypass_stasis=True,
@@ -791,8 +791,8 @@ class CallsService:
         except ARINotFound:
             recording_beep = None
 
-        ami.record_stop(self._ami, channel_id)
-        ami.play_beep(self._ami, channel_id, recording_beep or DEFAULT_RECORD_BEEP)
+        ami.record_stop(self._ami, channel.id)
+        ami.play_beep(self._ami, channel.id, recording_beep or DEFAULT_RECORD_BEEP)
         call = self.make_call_from_channel(self._ari, channel)
         self._notifier.call_record_stopped(call)
 
@@ -836,7 +836,7 @@ class CallsService:
             )
 
         set_channel_id_var_sync(
-            self._ari, channel_id, 'WAZO_RECORDING_PAUSED', '1', bypass_stasis=True
+            self._ari, channel.id, 'WAZO_RECORDING_PAUSED', '1', bypass_stasis=True
         )
 
         try:
@@ -846,8 +846,8 @@ class CallsService:
         except ARINotFound:
             recording_beep = None
 
-        ami.record_stop(self._ami, channel_id)
-        ami.play_beep(self._ami, channel_id, recording_beep or DEFAULT_RECORD_BEEP)
+        ami.record_stop(self._ami, channel.id)
+        ami.play_beep(self._ami, channel.id, recording_beep or DEFAULT_RECORD_BEEP)
 
         call = self.make_call_from_channel(self._ari, channel)
         filename = CALL_RECORDING_FILENAME_TEMPLATE.format(
@@ -894,7 +894,7 @@ class CallsService:
 
         if channel_variables.get('WAZO_RECORDING_PAUSED') == '1':
             set_channel_id_var_sync(
-                self._ari, channel_id, 'WAZO_RECORDING_PAUSED', '0', bypass_stasis=True
+                self._ari, channel.id, 'WAZO_RECORDING_PAUSED', '0', bypass_stasis=True
             )
 
         recording_uuid = channel_variables['WAZO_RECORDING_UUID']

--- a/wazo_calld/plugins/calls/services.py
+++ b/wazo_calld/plugins/calls/services.py
@@ -735,7 +735,7 @@ class CallsService:
         if channel_variables['WAZO_CALL_RECORD_ACTIVE'] == '1':
             return
 
-        if self._is_automated_recording(channel.id):
+        if self._is_automated_recording(channel_id):
             logger.debug('bypassing configured toggle permissions for auto-recording')
         elif not self._toggle_record_allowed(channel):
             raise RecordingUnauthorized(call_id)

--- a/wazo_calld/plugins/calls/services.py
+++ b/wazo_calld/plugins/calls/services.py
@@ -775,10 +775,7 @@ class CallsService:
         if tenant_uuid and channel_helper.tenant_uuid() != tenant_uuid:
             raise NoSuchCall(call_id)
 
-        try:
-            channel = self._ari.channels.get(channelId=channel_id)
-        except ARINotFound:
-            raise NoSuchCall(call_id)
+        channel = self._find_channel_to_record(channel_id)
 
         if not self._toggle_record_allowed(channel):
             raise RecordingUnauthorized(call_id)
@@ -810,10 +807,7 @@ class CallsService:
         if tenant_uuid and channel_helper.tenant_uuid() != tenant_uuid:
             raise NoSuchCall(call_id)
 
-        try:
-            channel = self._ari.channels.get(channelId=channel_id)
-        except ARINotFound:
-            raise NoSuchCall(call_id)
+        channel = self._find_channel_to_record(channel_id)
 
         if not self._toggle_record_allowed(channel):
             raise RecordingUnauthorized(call_id)

--- a/wazo_calld/plugins/calls/services.py
+++ b/wazo_calld/plugins/calls/services.py
@@ -735,7 +735,7 @@ class CallsService:
         if channel_variables['WAZO_CALL_RECORD_ACTIVE'] == '1':
             return
 
-        if self._is_automated_recording(channel_id):
+        if self._is_automated_recording(channel.id):
             logger.debug('bypassing configured toggle permissions for auto-recording')
         elif not self._toggle_record_allowed(channel):
             raise RecordingUnauthorized(call_id)

--- a/wazo_calld/plugins/calls/tests/test_bus_consume.py
+++ b/wazo_calld/plugins/calls/tests/test_bus_consume.py
@@ -31,6 +31,60 @@ class TestCallsBusEventHandler(TestCase):
             notifier,
         )
 
+    def _make_channel(self, channel_id, name):
+        channel = Mock()
+        channel.id = channel_id
+        channel.json = {'name': name}
+        return channel
+
+    def test_relay_channel_entered_bridge_skips_local_channels(self):
+        pjsip_channel = self._make_channel('chan-1', 'PJSIP/abc-00000001')
+        local_channel = self._make_channel('chan-2', 'Local/s@wazo-record;1')
+
+        bridge = Mock()
+        bridge.json = {'channels': ['chan-1', 'chan-2']}
+        self.handler.ari.bridges.get.return_value = bridge
+        self.handler.ari.channels.get.side_effect = lambda channelId: {
+            'chan-1': pjsip_channel,
+            'chan-2': local_channel,
+        }[channelId]
+
+        event = {
+            'Uniqueid': 'chan-1',
+            'BridgeUniqueid': 'bridge-1',
+            'BridgeNumChannels': '2',
+        }
+        self.handler._relay_channel_entered_bridge(event)
+
+        self.services.make_call_from_channel.assert_called_once_with(
+            self.handler.ari, pjsip_channel
+        )
+        self.handler.notifier.call_updated.assert_called_once()
+
+    def test_relay_channel_left_bridge_skips_local_channels(self):
+        pjsip_channel = self._make_channel('chan-1', 'PJSIP/abc-00000001')
+        local_channel = self._make_channel('chan-2', 'Local/s@wazo-record;1')
+
+        bridge = Mock()
+        bridge.json = {'channels': ['chan-1', 'chan-2']}
+        self.handler.ari.bridges.get.return_value = bridge
+        self.handler.ari.channels.get.side_effect = lambda channelId: {
+            'chan-1': pjsip_channel,
+            'chan-2': local_channel,
+        }[channelId]
+
+        event = {
+            'Uniqueid': 'chan-2',
+            'BridgeUniqueid': 'bridge-1',
+            'BridgeNumChannels': '1',
+        }
+        self.handler._relay_channel_left_bridge(event)
+
+        self.services.make_call_from_channel.assert_called_once_with(
+            self.handler.ari, pjsip_channel
+        )
+        self.handler.notifier.call_updated.assert_called_once()
+
     def test_relay_channel_answered_channel_is_gone(self):
         uniqueid = '123456789.1234'
         event = {

--- a/wazo_calld/plugins/calls/tests/test_bus_consume.py
+++ b/wazo_calld/plugins/calls/tests/test_bus_consume.py
@@ -48,6 +48,10 @@ class TestCallsBusEventHandler(TestCase):
             'chan-1': pjsip_channel,
             'chan-2': local_channel,
         }[channelId]
+        self.services.conversation_direction_from_channels.return_value = 'internal'
+        self.handler.ari.channels.getChannelVar.return_value = {
+            'value': 'internal',
+        }
 
         event = {
             'Uniqueid': 'chan-1',
@@ -72,6 +76,10 @@ class TestCallsBusEventHandler(TestCase):
             'chan-1': pjsip_channel,
             'chan-2': local_channel,
         }[channelId]
+        self.services.conversation_direction_from_channels.return_value = 'internal'
+        self.handler.ari.channels.getChannelVar.return_value = {
+            'value': 'internal',
+        }
 
         event = {
             'Uniqueid': 'chan-2',

--- a/wazo_calld/plugins/calls/tests/test_services.py
+++ b/wazo_calld/plugins/calls/tests/test_services.py
@@ -4,8 +4,10 @@
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
-from hamcrest import assert_that, equal_to
+from ari.exceptions import ARINotFound
+from hamcrest import assert_that, calling, equal_to, is_, raises
 
+from ..exceptions import NoSuchCall
 from ..services import CallsService
 
 
@@ -238,8 +240,37 @@ class TestServices(TestCase):
         )
 
 
+def _make_channel_mock(
+    channel_id: str,
+    name: str,
+    channelvars: dict | None = None,
+    getvar_side_effect: dict | None = None,
+) -> Mock:
+    default_vars = {
+        'WAZO_LOCAL_CHAN_MATCH_UUID': '',
+        'WAZO_CALL_RECORD_SIDE': 'caller',
+    }
+    if channelvars:
+        default_vars.update(channelvars)
+
+    channel = Mock()
+    channel.id = channel_id
+    channel.json = {'name': name, 'channelvars': default_vars}
+
+    def _getvar(variable=''):
+        if getvar_side_effect and variable in getvar_side_effect:
+            result = getvar_side_effect[variable]
+            if isinstance(result, Exception):
+                raise result
+            return result
+        raise ARINotFound(Mock(), Mock())
+
+    channel.getChannelVar = Mock(side_effect=_getvar)
+    return channel
+
+
 class TestFindChannelToRecord(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.ari = Mock()
         self.services = CallsService(
             Mock(), Mock(), self.ari, Mock(), Mock(), Mock(), Mock()
@@ -292,3 +323,320 @@ class TestFindChannelToRecord(TestCase):
         result = self.services._find_channel_to_record('local-chan-id')
 
         assert_that(result, equal_to(local_channel))
+
+    def test_channel_not_found_raises_no_such_call(self) -> None:
+        self.ari.channels.get.side_effect = ARINotFound(Mock(), Mock())
+
+        assert_that(
+            calling(self.services._find_channel_to_record).with_args('missing-id'),
+            raises(NoSuchCall),
+        )
+
+    def test_non_local_channel_returned_as_is(self) -> None:
+        channel = _make_channel_mock('chan-1', 'PJSIP/abcd-00000001')
+        self.ari.channels.get.return_value = channel
+
+        result = self.services._find_channel_to_record('chan-1')
+
+        assert_that(result, is_(channel))
+
+    def test_local_side_2_returned_as_is(self) -> None:
+        channel = _make_channel_mock('chan-1', 'Local/s@group;2')
+        self.ari.channels.get.return_value = channel
+
+        result = self.services._find_channel_to_record('chan-1')
+
+        assert_that(result, is_(channel))
+
+    def test_local_side_1_not_group_nor_queue_returned_as_is(self) -> None:
+        channel = _make_channel_mock('chan-1', 'Local/s@some-context;1')
+        self.ari.channels.get.return_value = channel
+
+        result = self.services._find_channel_to_record('chan-1')
+
+        assert_that(result, is_(channel))
+
+    def test_local_side_1_group_callee_returns_real_channel(self) -> None:
+        local_channel = _make_channel_mock(
+            'local-1',
+            'Local/s@group;1',
+            channelvars={'WAZO_LOCAL_CHAN_MATCH_UUID': 'match-uuid'},
+            getvar_side_effect={
+                'WAZO_RECORD_GROUP_CALLEE': {'value': '1'},
+            },
+        )
+        real_channel = _make_channel_mock(
+            'real-1',
+            'PJSIP/abcd-00000001',
+            channelvars={
+                'WAZO_LOCAL_CHAN_MATCH_UUID': 'match-uuid',
+                'WAZO_CALL_RECORD_SIDE': 'callee',
+            },
+        )
+        self.ari.channels.get.return_value = local_channel
+        self.ari.channels.list.return_value = [local_channel, real_channel]
+
+        result = self.services._find_channel_to_record('local-1')
+
+        assert_that(result, is_(real_channel))
+
+    def test_local_side_1_queue_callee_returns_real_channel(self) -> None:
+        local_channel = _make_channel_mock(
+            'local-1',
+            'Local/s@queue;1',
+            channelvars={'WAZO_LOCAL_CHAN_MATCH_UUID': 'match-uuid'},
+            getvar_side_effect={
+                'WAZO_RECORD_GROUP_CALLEE': ARINotFound(Mock(), Mock()),
+                'WAZO_RECORD_QUEUE_CALLEE': {'value': '1'},
+            },
+        )
+        real_channel = _make_channel_mock(
+            'real-1',
+            'PJSIP/abcd-00000001',
+            channelvars={
+                'WAZO_LOCAL_CHAN_MATCH_UUID': 'match-uuid',
+                'WAZO_CALL_RECORD_SIDE': 'callee',
+            },
+        )
+        self.ari.channels.get.return_value = local_channel
+        self.ari.channels.list.return_value = [real_channel]
+
+        result = self.services._find_channel_to_record('local-1')
+
+        assert_that(result, is_(real_channel))
+
+    def test_local_side_1_agent_callback_returns_real_channel(self) -> None:
+        local_channel = _make_channel_mock(
+            'local-1',
+            'Local/s@agentcallback;1',
+            channelvars={'WAZO_LOCAL_CHAN_MATCH_UUID': 'match-uuid'},
+        )
+        real_channel = _make_channel_mock(
+            'real-1',
+            'PJSIP/abcd-00000001',
+            channelvars={
+                'WAZO_LOCAL_CHAN_MATCH_UUID': 'match-uuid',
+                'WAZO_CALL_RECORD_SIDE': 'callee',
+            },
+        )
+        self.ari.channels.get.return_value = local_channel
+        self.ari.channels.list.return_value = [real_channel]
+
+        result = self.services._find_channel_to_record('local-1')
+
+        assert_that(result, is_(real_channel))
+
+    def test_local_side_1_group_callee_no_match_uuid_returns_local(self) -> None:
+        local_channel = _make_channel_mock(
+            'local-1',
+            'Local/s@group;1',
+            channelvars={'WAZO_LOCAL_CHAN_MATCH_UUID': ''},
+            getvar_side_effect={
+                'WAZO_RECORD_GROUP_CALLEE': {'value': '1'},
+            },
+        )
+        self.ari.channels.get.return_value = local_channel
+
+        result = self.services._find_channel_to_record('local-1')
+
+        assert_that(result, is_(local_channel))
+
+    def test_local_side_1_group_callee_no_matching_channel_returns_local(self) -> None:
+        local_channel = _make_channel_mock(
+            'local-1',
+            'Local/s@group;1',
+            channelvars={'WAZO_LOCAL_CHAN_MATCH_UUID': 'match-uuid'},
+            getvar_side_effect={
+                'WAZO_RECORD_GROUP_CALLEE': {'value': '1'},
+            },
+        )
+        unrelated_channel = _make_channel_mock(
+            'other-1',
+            'PJSIP/xyz-00000002',
+            channelvars={
+                'WAZO_LOCAL_CHAN_MATCH_UUID': 'different-uuid',
+                'WAZO_CALL_RECORD_SIDE': 'callee',
+            },
+        )
+        self.ari.channels.get.return_value = local_channel
+        self.ari.channels.list.return_value = [local_channel, unrelated_channel]
+
+        result = self.services._find_channel_to_record('local-1')
+
+        assert_that(result, is_(local_channel))
+
+    def test_skips_local_channels_when_searching(self) -> None:
+        local_channel = _make_channel_mock(
+            'local-1',
+            'Local/s@group;1',
+            channelvars={'WAZO_LOCAL_CHAN_MATCH_UUID': 'match-uuid'},
+            getvar_side_effect={
+                'WAZO_RECORD_GROUP_CALLEE': {'value': '1'},
+            },
+        )
+        other_local = _make_channel_mock(
+            'local-2',
+            'Local/s@other;2',
+            channelvars={
+                'WAZO_LOCAL_CHAN_MATCH_UUID': 'match-uuid',
+                'WAZO_CALL_RECORD_SIDE': 'callee',
+            },
+        )
+        self.ari.channels.get.return_value = local_channel
+        self.ari.channels.list.return_value = [local_channel, other_local]
+
+        result = self.services._find_channel_to_record('local-1')
+
+        assert_that(result, is_(local_channel))
+
+    def test_skips_caller_side_channels_when_searching(self) -> None:
+        local_channel = _make_channel_mock(
+            'local-1',
+            'Local/s@group;1',
+            channelvars={'WAZO_LOCAL_CHAN_MATCH_UUID': 'match-uuid'},
+            getvar_side_effect={
+                'WAZO_RECORD_GROUP_CALLEE': {'value': '1'},
+            },
+        )
+        caller_channel = _make_channel_mock(
+            'caller-1',
+            'PJSIP/abcd-00000001',
+            channelvars={
+                'WAZO_LOCAL_CHAN_MATCH_UUID': 'match-uuid',
+                'WAZO_CALL_RECORD_SIDE': 'caller',
+            },
+        )
+        self.ari.channels.get.return_value = local_channel
+        self.ari.channels.list.return_value = [caller_channel]
+
+        result = self.services._find_channel_to_record('local-1')
+
+        assert_that(result, is_(local_channel))
+
+
+class TestRecordingUsesFoundChannel(TestCase):
+    """Verify that record_start/stop/pause/resume use the channel returned by
+    _find_channel_to_record (channel.id) rather than the original call_id for
+    AMI and ARI operations."""
+
+    def setUp(self) -> None:
+        self.ari = Mock()
+        self.amid = Mock()
+        self.notifier = Mock()
+        self.services = CallsService(
+            self.amid, Mock(), self.ari, Mock(), Mock(), Mock(), self.notifier
+        )
+
+        self.call_id = 'original-call-id'
+        self.found_channel_id = 'found-channel-id'
+
+        self.found_channel = _make_channel_mock(
+            self.found_channel_id,
+            'PJSIP/abcd-00000001',
+            channelvars={
+                'WAZO_CALL_RECORD_ACTIVE': '0',
+                'WAZO_TENANT_UUID': 'tenant-1',
+                'WAZO_USERUUID': 'user-1',
+                'WAZO_RECORDING_UUID': 'rec-uuid',
+                'WAZO_RECORDING_PAUSED': '0',
+                'WAZO_QUEUENAME': '',
+                'WAZO_GROUPNAME': '',
+                'WAZO_CALL_RECORD_SIDE': 'caller',
+                'WAZO_QUEUE_DTMF_RECORD_TOGGLE_ENABLED': '0',
+                'WAZO_GROUP_DTMF_RECORD_TOGGLE_ENABLED': '0',
+                'WAZO_USER_DTMF_RECORD_TOGGLE_ENABLED': '1',
+                'WAZO_RECORD_GROUP_CALLEE': '0',
+                'WAZO_RECORD_QUEUE_CALLEE': '0',
+            },
+        )
+
+        # _find_channel_to_record returns a different channel than call_id
+        find_patcher = patch.object(
+            self.services, '_find_channel_to_record', return_value=self.found_channel
+        )
+        self.mock_find = find_patcher.start()
+        self.addCleanup(find_patcher.stop)
+
+        # _is_automated_recording fetches channel by id from ARI
+        self.ari.channels.get.return_value = self.found_channel
+
+        # Bypass tenant check
+        tenant_patcher = patch(
+            'wazo_calld.plugins.calls.services.Channel',
+        )
+        mock_channel_cls = tenant_patcher.start()
+        mock_channel_cls.return_value.tenant_uuid.return_value = None
+        self.addCleanup(tenant_patcher.stop)
+
+        # make_call_from_channel is used in stop/pause/resume
+        make_call_patcher = patch.object(
+            self.services, 'make_call_from_channel', return_value=Mock()
+        )
+        make_call_patcher.start()
+        self.addCleanup(make_call_patcher.stop)
+
+    @patch('wazo_calld.plugins.calls.services.ami')
+    @patch('wazo_calld.plugins.calls.services.set_channel_id_var_sync')
+    def test_record_start_uses_found_channel_id(
+        self, mock_set_var: Mock, mock_ami: Mock
+    ) -> None:
+        self.services.record_start(None, self.call_id)
+
+        mock_set_var.assert_called_once()
+        assert_that(mock_set_var.call_args[0][1], equal_to(self.found_channel_id))
+        mock_ami.record_start.assert_called_once()
+        assert_that(
+            mock_ami.record_start.call_args[0][1], equal_to(self.found_channel_id)
+        )
+        mock_ami.play_beep.assert_called_once()
+        assert_that(mock_ami.play_beep.call_args[0][1], equal_to(self.found_channel_id))
+
+    @patch('wazo_calld.plugins.calls.services.ami')
+    def test_record_stop_uses_found_channel_id(self, mock_ami: Mock) -> None:
+        self.found_channel.json['channelvars']['WAZO_CALL_RECORD_ACTIVE'] = '1'
+
+        self.services.record_stop(None, self.call_id)
+
+        mock_ami.record_stop.assert_called_once()
+        assert_that(
+            mock_ami.record_stop.call_args[0][1], equal_to(self.found_channel_id)
+        )
+        mock_ami.play_beep.assert_called_once()
+        assert_that(mock_ami.play_beep.call_args[0][1], equal_to(self.found_channel_id))
+
+    @patch('wazo_calld.plugins.calls.services.ami')
+    @patch('wazo_calld.plugins.calls.services.set_channel_id_var_sync')
+    def test_record_pause_uses_found_channel_id(
+        self, mock_set_var: Mock, mock_ami: Mock
+    ) -> None:
+        self.found_channel.json['channelvars']['WAZO_CALL_RECORD_ACTIVE'] = '1'
+
+        self.services.record_pause(None, self.call_id)
+
+        mock_set_var.assert_called_once()
+        assert_that(mock_set_var.call_args[0][1], equal_to(self.found_channel_id))
+        mock_ami.record_stop.assert_called_once()
+        assert_that(
+            mock_ami.record_stop.call_args[0][1], equal_to(self.found_channel_id)
+        )
+        mock_ami.play_beep.assert_called_once()
+        assert_that(mock_ami.play_beep.call_args[0][1], equal_to(self.found_channel_id))
+
+    @patch('wazo_calld.plugins.calls.services.ami')
+    @patch('wazo_calld.plugins.calls.services.set_channel_id_var_sync')
+    def test_record_resume_uses_found_channel_id(
+        self, mock_set_var: Mock, mock_ami: Mock
+    ) -> None:
+        self.found_channel.json['channelvars']['WAZO_CALL_RECORD_ACTIVE'] = '1'
+        self.found_channel.json['channelvars']['WAZO_RECORDING_PAUSED'] = '1'
+
+        self.services.record_resume(None, self.call_id)
+
+        mock_set_var.assert_called_once()
+        assert_that(mock_set_var.call_args[0][1], equal_to(self.found_channel_id))
+        mock_ami.record_resume.assert_called_once()
+        assert_that(
+            mock_ami.record_resume.call_args[0][1], equal_to(self.found_channel_id)
+        )
+        mock_ami.play_beep.assert_called_once()
+        assert_that(mock_ami.play_beep.call_args[0][1], equal_to(self.found_channel_id))

--- a/wazo_calld/plugins/calls/tests/test_services.py
+++ b/wazo_calld/plugins/calls/tests/test_services.py
@@ -255,7 +255,7 @@ def _make_channel_mock(
 
     channel = Mock()
     channel.id = channel_id
-    channel.json = {'name': name, 'channelvars': default_vars}
+    channel.json = {'name': name, 'state': 'Up', 'channelvars': default_vars}
 
     def _getvar(variable=''):
         if getvar_side_effect and variable in getvar_side_effect:


### PR DESCRIPTION
- **recording: Fetch correct channel to stop record**
- **recording: Use channel found instead of the received one**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes call recording channel selection and updates how call direction/bus events treat `Local/` channels, which can affect recording control and call state notifications in production call flows.
> 
> **Overview**
> Fixes recording control for ring group/queue/agent-callback calls by resolving a *real* non-`Local/` ARI channel via `_find_channel_to_record()` and then using `channel.id` (not the incoming `call_id`) for ARI var updates and AMI record start/stop/pause/resume actions.
> 
> Refactors `bus_consume` event relaying to share common channel/call lookup, ensures conversation direction is cached using the resolved channel ID, and filters `Local/` channels out of bridge enter/leave direction updates; adds targeted unit tests for both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d79b29ee8f81517457a135a992c66dfa0f08e00e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->