### PR TITLE
TASK 225 add admin voicemails messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 26.05
 
+* New admin endpoint `GET /1.0/voicemails/messages` to list all voicemail messages in a tenant.
+
 * The `transcription` attribute has been added to voicemail messages. It contains the transcription text when available, or `null` otherwise.
 
 * New events for voicemail transcriptions:

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -12,8 +12,8 @@ build-ari:
 	docker build -t ari-real --pull -f $(CHAN_TEST_DIR)/Dockerfile $(CHAN_TEST_DIR)
 
 build-call-logd:
-	docker build -t call-logd-test -f docker/Dockerfile-call-logd-test .
-	docker build -t call-logd-db-test -f docker/Dockerfile-call-logd-db .
+	docker build --pull -t call-logd-test -f docker/Dockerfile-call-logd-test .
+	docker build --pull -t call-logd-db-test -f docker/Dockerfile-call-logd-db .
 
 clean:
 	docker rmi -f wazoplatform/wazo-calld

--- a/integration_tests/suite/test_voicemail.py
+++ b/integration_tests/suite/test_voicemail.py
@@ -2235,8 +2235,8 @@ class TestVoicemails(RealAsteriskIntegrationTest):
         # from inclusive, until exclusive
         result = calld.voicemails.list_voicemail_messages(
             **{
-                'from': '2024-08-23T18:11:28',
-                'until': '2024-08-23T18:16:35',
+                'from': '2024-08-23T18:11:28Z',
+                'until': '2024-08-23T18:16:35Z',
             }
         )
         assert_that(
@@ -2254,7 +2254,7 @@ class TestVoicemails(RealAsteriskIntegrationTest):
         # only from
         result = calld.voicemails.list_voicemail_messages(
             **{
-                'from': '2024-08-23T18:12:35',
+                'from': '2024-08-23T18:12:35Z',
             }
         )
         assert_that(
@@ -2296,7 +2296,7 @@ class TestVoicemails(RealAsteriskIntegrationTest):
         # 3 messages match from >= 2024-08-23T18:11:28, paginate with limit=1, offset=1
         result = calld.voicemails.list_voicemail_messages(
             **{
-                'from': '2024-08-23T18:11:28',
+                'from': '2024-08-23T18:11:28Z',
                 'limit': 1,
                 'offset': 1,
             }
@@ -2310,4 +2310,30 @@ class TestVoicemails(RealAsteriskIntegrationTest):
                 total=4,
                 filtered=3,
             ),
+        )
+
+    def test_admin_list_messages_rejects_naive_datetime(self):
+        user_uuid = str(uuid.uuid4())
+        voicemail = MockVoicemail(
+            111,
+            '8000',
+            'voicemail',
+            'default',
+            tenant_uuid=VALID_TENANT_MULTITENANT_1,
+        )
+        self.confd.set_voicemails(voicemail)
+        calld = self.make_user_calld(user_uuid, tenant_uuid=VALID_TENANT_MULTITENANT_1)
+
+        assert_that(
+            calling(calld.voicemails.list_voicemail_messages).with_args(
+                **{'from': '2024-08-23T18:11:28'}
+            ),
+            raises(CalldError).matching(has_properties(status_code=400)),
+        )
+
+        assert_that(
+            calling(calld.voicemails.list_voicemail_messages).with_args(
+                until='2024-08-23T18:11:28'
+            ),
+            raises(CalldError).matching(has_properties(status_code=400)),
         )

--- a/integration_tests/suite/test_voicemail.py
+++ b/integration_tests/suite/test_voicemail.py
@@ -1935,6 +1935,7 @@ class TestVoicemails(RealAsteriskIntegrationTest):
                     ),
                 ),
                 total=4,
+                filtered=4,
             ),
         )
 
@@ -1973,6 +1974,7 @@ class TestVoicemails(RealAsteriskIntegrationTest):
                     has_entries(id='1724107750-00000011'),
                 ),
                 total=1,
+                filtered=1,
             ),
         )
 
@@ -1984,6 +1986,7 @@ class TestVoicemails(RealAsteriskIntegrationTest):
                     has_entries(id='1724107750-00000021'),
                 ),
                 total=1,
+                filtered=1,
             ),
         )
 
@@ -2024,6 +2027,7 @@ class TestVoicemails(RealAsteriskIntegrationTest):
                     ),
                 ),
                 total=1,
+                filtered=1,
             ),
         )
 
@@ -2040,6 +2044,7 @@ class TestVoicemails(RealAsteriskIntegrationTest):
                     ),
                 ),
                 total=3,
+                filtered=3,
             ),
         )
 
@@ -2076,6 +2081,7 @@ class TestVoicemails(RealAsteriskIntegrationTest):
                     has_entries(id='1724436995-00000003'),
                 ),
                 total=3,
+                filtered=3,
             ),
         )
 
@@ -2118,6 +2124,7 @@ class TestVoicemails(RealAsteriskIntegrationTest):
                     ),
                 ),
                 total=4,
+                filtered=4,
             ),
         )
 
@@ -2162,6 +2169,7 @@ class TestVoicemails(RealAsteriskIntegrationTest):
                     has_entries(id=message_id_4),
                 ),
                 total=4,
+                filtered=4,
             ),
         )
 
@@ -2178,6 +2186,7 @@ class TestVoicemails(RealAsteriskIntegrationTest):
                     has_entries(id=message_id_1),
                 ),
                 total=4,
+                filtered=4,
             ),
         )
 
@@ -2190,6 +2199,7 @@ class TestVoicemails(RealAsteriskIntegrationTest):
                     has_entries(id=message_id_2),
                 ),
                 total=4,
+                filtered=4,
             ),
         )
 
@@ -2201,6 +2211,7 @@ class TestVoicemails(RealAsteriskIntegrationTest):
                     has_entries(id=message_id_3),
                 ),
                 total=4,
+                filtered=4,
             ),
         )
 

--- a/integration_tests/suite/test_voicemail.py
+++ b/integration_tests/suite/test_voicemail.py
@@ -2085,6 +2085,24 @@ class TestVoicemails(RealAsteriskIntegrationTest):
             ),
         )
 
+    def test_admin_list_messages_filter_unknown_voicemail_id(self):
+        user_uuid = str(uuid.uuid4())
+        voicemail = MockVoicemail(
+            111,
+            '8000',
+            'voicemail',
+            'default',
+            tenant_uuid=VALID_TENANT_MULTITENANT_1,
+        )
+        self.confd.set_voicemails(voicemail)
+        calld = self.make_user_calld(user_uuid, tenant_uuid=VALID_TENANT_MULTITENANT_1)
+
+        result = calld.voicemails.list_voicemail_messages(voicemail_id=99999)
+        assert_that(
+            result,
+            has_entries(items=[], total=0, filtered=0),
+        )
+
     def test_admin_list_messages_filter_user_uuid(self):
         user_uuid = str(uuid.uuid4())
         voicemail_id_1 = 111

--- a/integration_tests/suite/test_voicemail.py
+++ b/integration_tests/suite/test_voicemail.py
@@ -2219,10 +2219,6 @@ class TestVoicemails(RealAsteriskIntegrationTest):
         user_uuid = str(uuid.uuid4())
         voicemail_id_1 = 111
         voicemail_id_2 = 222
-        # ts 1724107750 = 2024-08-19T22:49:10
-        # ts 1724436688 = 2024-08-23T18:11:28
-        # ts 1724436755 = 2024-08-23T18:12:35
-        # ts 1724436995 = 2024-08-23T18:16:35
         global_voicemail = MockVoicemail(
             voicemail_id_1,
             '8000',
@@ -2243,7 +2239,8 @@ class TestVoicemails(RealAsteriskIntegrationTest):
         self.confd.set_voicemails(global_voicemail, personal_voicemail)
         calld = self.make_user_calld(user_uuid, tenant_uuid=VALID_TENANT_MULTITENANT_1)
 
-        # from inclusive, until exclusive
+        # ts 1724436688 = 2024-08-23T18:11:28
+        # ts 1724436755 = 2024-08-23T18:12:35
         result = calld.voicemails.list_voicemail_messages(
             **{
                 'from': '2024-08-23T18:11:28Z',
@@ -2262,7 +2259,8 @@ class TestVoicemails(RealAsteriskIntegrationTest):
             ),
         )
 
-        # only from
+        # ts 1724107750 = 2024-08-19T22:49:10
+        # ts 1724436995 = 2024-08-23T18:16:35
         result = calld.voicemails.list_voicemail_messages(
             **{
                 'from': '2024-08-23T18:12:35Z',

--- a/integration_tests/suite/test_voicemail.py
+++ b/integration_tests/suite/test_voicemail.py
@@ -1883,3 +1883,431 @@ class TestVoicemails(RealAsteriskIntegrationTest):
             ('put', f'users/me/voicemails/messages/{message_id}'),
         ]
         self.assert_empty_body_returns_400(urls)
+
+    def test_admin_list_all_messages_in_tenant(self):
+        user_uuid = str(uuid.uuid4())
+        voicemail_id_1 = 111
+        voicemail_id_2 = 222
+        message_id_1 = '1724107750-00000001'
+        message_id_2 = '1724436688-00000001'
+        message_id_3 = '1724436755-00000002'
+        message_id_4 = '1724436995-00000003'
+        global_voicemail = MockVoicemail(
+            voicemail_id_1,
+            '8000',
+            'global-voicemail',
+            'default',
+            accesstype='global',
+            tenant_uuid=VALID_TENANT_MULTITENANT_1,
+        )
+        personal_voicemail = MockVoicemail(
+            voicemail_id_2,
+            '8001',
+            'personal-voicemail',
+            'default',
+            user_uuids=[user_uuid],
+            tenant_uuid=VALID_TENANT_MULTITENANT_1,
+        )
+        self.confd.set_user_voicemails({user_uuid: [personal_voicemail]})
+        self.confd.set_voicemails(global_voicemail, personal_voicemail)
+        calld = self.make_user_calld(user_uuid, tenant_uuid=VALID_TENANT_MULTITENANT_1)
+
+        result = calld.voicemails.list_voicemail_messages()
+        assert_that(
+            result,
+            has_entries(
+                items=has_items(
+                    has_entries(
+                        id=message_id_1,
+                        voicemail=has_entry('accesstype', 'global'),
+                    ),
+                    has_entries(
+                        id=message_id_2,
+                        voicemail=has_entry('accesstype', 'personal'),
+                    ),
+                    has_entries(
+                        id=message_id_3,
+                        voicemail=has_entry('accesstype', 'personal'),
+                    ),
+                    has_entries(
+                        id=message_id_4,
+                        voicemail=has_entry('accesstype', 'personal'),
+                    ),
+                ),
+                total=4,
+            ),
+        )
+
+    def test_admin_list_messages_tenant_isolation(self):
+        user_uuid_1 = str(uuid.uuid4())
+        user_uuid_2 = str(uuid.uuid4())
+        voicemail_t1 = MockVoicemail(
+            301,
+            '8001',
+            'vm-tenant1',
+            'multitenant-1',
+            user_uuids=[user_uuid_1],
+            tenant_uuid=VALID_TENANT_MULTITENANT_1,
+        )
+        voicemail_t2 = MockVoicemail(
+            302,
+            '8002',
+            'vm-tenant2',
+            'multitenant-2',
+            user_uuids=[user_uuid_2],
+            tenant_uuid=VALID_TENANT_MULTITENANT_2,
+        )
+        self.confd.set_voicemails(voicemail_t1, voicemail_t2)
+        calld_t1 = self.make_user_calld(
+            user_uuid_1, tenant_uuid=VALID_TENANT_MULTITENANT_1
+        )
+        calld_t2 = self.make_user_calld(
+            user_uuid_2, tenant_uuid=VALID_TENANT_MULTITENANT_2
+        )
+
+        result_t1 = calld_t1.voicemails.list_voicemail_messages()
+        assert_that(
+            result_t1,
+            has_entries(
+                items=contains_exactly(
+                    has_entries(id='1724107750-00000011'),
+                ),
+                total=1,
+            ),
+        )
+
+        result_t2 = calld_t2.voicemails.list_voicemail_messages()
+        assert_that(
+            result_t2,
+            has_entries(
+                items=contains_exactly(
+                    has_entries(id='1724107750-00000021'),
+                ),
+                total=1,
+            ),
+        )
+
+    def test_admin_list_messages_filter_voicemail_type(self):
+        user_uuid = str(uuid.uuid4())
+        voicemail_id_1 = 111
+        voicemail_id_2 = 222
+        global_voicemail = MockVoicemail(
+            voicemail_id_1,
+            '8000',
+            'global-voicemail',
+            'default',
+            accesstype='global',
+            tenant_uuid=VALID_TENANT_MULTITENANT_1,
+        )
+        personal_voicemail = MockVoicemail(
+            voicemail_id_2,
+            '8001',
+            'personal-voicemail',
+            'default',
+            user_uuids=[user_uuid],
+            tenant_uuid=VALID_TENANT_MULTITENANT_1,
+        )
+        self.confd.set_user_voicemails({user_uuid: [personal_voicemail]})
+        self.confd.set_voicemails(global_voicemail, personal_voicemail)
+        calld = self.make_user_calld(user_uuid, tenant_uuid=VALID_TENANT_MULTITENANT_1)
+
+        result_global = calld.voicemails.list_voicemail_messages(
+            voicemail_type='global'
+        )
+        assert_that(
+            result_global,
+            has_entries(
+                items=contains_exactly(
+                    has_entries(
+                        id='1724107750-00000001',
+                        voicemail=has_entry('accesstype', 'global'),
+                    ),
+                ),
+                total=1,
+            ),
+        )
+
+        result_personal = calld.voicemails.list_voicemail_messages(
+            voicemail_type='personal'
+        )
+        assert_that(
+            result_personal,
+            has_entries(
+                items=has_items(
+                    has_entries(
+                        id='1724436688-00000001',
+                        voicemail=has_entry('accesstype', 'personal'),
+                    ),
+                ),
+                total=3,
+            ),
+        )
+
+    def test_admin_list_messages_filter_voicemail_id(self):
+        user_uuid = str(uuid.uuid4())
+        voicemail_id_1 = 111
+        voicemail_id_2 = 222
+        global_voicemail = MockVoicemail(
+            voicemail_id_1,
+            '8000',
+            'global-voicemail',
+            'default',
+            accesstype='global',
+            tenant_uuid=VALID_TENANT_MULTITENANT_1,
+        )
+        personal_voicemail = MockVoicemail(
+            voicemail_id_2,
+            '8001',
+            'personal-voicemail',
+            'default',
+            user_uuids=[user_uuid],
+            tenant_uuid=VALID_TENANT_MULTITENANT_1,
+        )
+        self.confd.set_voicemails(global_voicemail, personal_voicemail)
+        calld = self.make_user_calld(user_uuid, tenant_uuid=VALID_TENANT_MULTITENANT_1)
+
+        result = calld.voicemails.list_voicemail_messages(voicemail_id=voicemail_id_2)
+        assert_that(
+            result,
+            has_entries(
+                items=contains_exactly(
+                    has_entries(id='1724436688-00000001'),
+                    has_entries(id='1724436755-00000002'),
+                    has_entries(id='1724436995-00000003'),
+                ),
+                total=3,
+            ),
+        )
+
+    def test_admin_list_messages_filter_user_uuid(self):
+        user_uuid = str(uuid.uuid4())
+        voicemail_id_1 = 111
+        voicemail_id_2 = 222
+        global_voicemail = MockVoicemail(
+            voicemail_id_1,
+            '8000',
+            'global-voicemail',
+            'default',
+            accesstype='global',
+            tenant_uuid=VALID_TENANT_MULTITENANT_1,
+        )
+        personal_voicemail = MockVoicemail(
+            voicemail_id_2,
+            '8001',
+            'personal-voicemail',
+            'default',
+            user_uuids=[user_uuid],
+            tenant_uuid=VALID_TENANT_MULTITENANT_1,
+        )
+        self.confd.set_user_voicemails({user_uuid: [personal_voicemail]})
+        self.confd.set_voicemails(global_voicemail, personal_voicemail)
+        calld = self.make_user_calld(user_uuid, tenant_uuid=VALID_TENANT_MULTITENANT_1)
+
+        result = calld.voicemails.list_voicemail_messages(user_uuid=user_uuid)
+        assert_that(
+            result,
+            has_entries(
+                items=has_items(
+                    has_entries(
+                        id='1724107750-00000001',
+                        voicemail=has_entry('accesstype', 'global'),
+                    ),
+                    has_entries(
+                        id='1724436688-00000001',
+                        voicemail=has_entry('accesstype', 'personal'),
+                    ),
+                ),
+                total=4,
+            ),
+        )
+
+    def test_admin_list_messages_pagination_ordering(self):
+        user_uuid = str(uuid.uuid4())
+        voicemail_id_1 = 111
+        voicemail_id_2 = 222
+        message_id_1 = '1724107750-00000001'
+        message_id_2 = '1724436688-00000001'
+        message_id_3 = '1724436755-00000002'
+        message_id_4 = '1724436995-00000003'
+        global_voicemail = MockVoicemail(
+            voicemail_id_1,
+            '8000',
+            'global-voicemail',
+            'default',
+            accesstype='global',
+            tenant_uuid=VALID_TENANT_MULTITENANT_1,
+        )
+        personal_voicemail = MockVoicemail(
+            voicemail_id_2,
+            '8001',
+            'personal-voicemail',
+            'default',
+            user_uuids=[user_uuid],
+            tenant_uuid=VALID_TENANT_MULTITENANT_1,
+        )
+        self.confd.set_user_voicemails({user_uuid: [personal_voicemail]})
+        self.confd.set_voicemails(global_voicemail, personal_voicemail)
+        calld = self.make_user_calld(user_uuid, tenant_uuid=VALID_TENANT_MULTITENANT_1)
+
+        # ascending order by timestamp
+        assert_that(
+            calld.voicemails.list_voicemail_messages(
+                direction='asc', order='timestamp'
+            ),
+            has_entries(
+                items=contains_exactly(
+                    has_entries(id=message_id_1),
+                    has_entries(id=message_id_2),
+                    has_entries(id=message_id_3),
+                    has_entries(id=message_id_4),
+                ),
+                total=4,
+            ),
+        )
+
+        # descending order
+        assert_that(
+            calld.voicemails.list_voicemail_messages(
+                direction='desc', order='timestamp'
+            ),
+            has_entries(
+                items=contains_exactly(
+                    has_entries(id=message_id_4),
+                    has_entries(id=message_id_3),
+                    has_entries(id=message_id_2),
+                    has_entries(id=message_id_1),
+                ),
+                total=4,
+            ),
+        )
+
+        # limit
+        assert_that(
+            calld.voicemails.list_voicemail_messages(limit=2),
+            has_entries(
+                items=contains_exactly(
+                    has_entries(id=message_id_1),
+                    has_entries(id=message_id_2),
+                ),
+                total=4,
+            ),
+        )
+
+        # limit + offset
+        assert_that(
+            calld.voicemails.list_voicemail_messages(limit=1, offset=2),
+            has_entries(
+                items=contains_exactly(
+                    has_entries(id=message_id_3),
+                ),
+                total=4,
+            ),
+        )
+
+    def test_admin_list_messages_filter_timestamp_range(self):
+        user_uuid = str(uuid.uuid4())
+        voicemail_id_1 = 111
+        voicemail_id_2 = 222
+        # ts 1724107750 = 2024-08-19T22:49:10
+        # ts 1724436688 = 2024-08-23T18:11:28
+        # ts 1724436755 = 2024-08-23T18:12:35
+        # ts 1724436995 = 2024-08-23T18:16:35
+        global_voicemail = MockVoicemail(
+            voicemail_id_1,
+            '8000',
+            'global-voicemail',
+            'default',
+            accesstype='global',
+            tenant_uuid=VALID_TENANT_MULTITENANT_1,
+        )
+        personal_voicemail = MockVoicemail(
+            voicemail_id_2,
+            '8001',
+            'personal-voicemail',
+            'default',
+            user_uuids=[user_uuid],
+            tenant_uuid=VALID_TENANT_MULTITENANT_1,
+        )
+        self.confd.set_user_voicemails({user_uuid: [personal_voicemail]})
+        self.confd.set_voicemails(global_voicemail, personal_voicemail)
+        calld = self.make_user_calld(user_uuid, tenant_uuid=VALID_TENANT_MULTITENANT_1)
+
+        # from inclusive, until exclusive
+        result = calld.voicemails.list_voicemail_messages(
+            **{
+                'from': '2024-08-23T18:11:28',
+                'until': '2024-08-23T18:16:35',
+            }
+        )
+        assert_that(
+            result,
+            has_entries(
+                items=contains_exactly(
+                    has_entries(id='1724436688-00000001'),
+                    has_entries(id='1724436755-00000002'),
+                ),
+                total=4,
+                filtered=2,
+            ),
+        )
+
+        # only from
+        result = calld.voicemails.list_voicemail_messages(
+            **{
+                'from': '2024-08-23T18:12:35',
+            }
+        )
+        assert_that(
+            result,
+            has_entries(
+                items=contains_exactly(
+                    has_entries(id='1724436755-00000002'),
+                    has_entries(id='1724436995-00000003'),
+                ),
+                total=4,
+                filtered=2,
+            ),
+        )
+
+    def test_admin_list_messages_timestamp_with_pagination(self):
+        user_uuid = str(uuid.uuid4())
+        voicemail_id_1 = 111
+        voicemail_id_2 = 222
+        global_voicemail = MockVoicemail(
+            voicemail_id_1,
+            '8000',
+            'global-voicemail',
+            'default',
+            accesstype='global',
+            tenant_uuid=VALID_TENANT_MULTITENANT_1,
+        )
+        personal_voicemail = MockVoicemail(
+            voicemail_id_2,
+            '8001',
+            'personal-voicemail',
+            'default',
+            user_uuids=[user_uuid],
+            tenant_uuid=VALID_TENANT_MULTITENANT_1,
+        )
+        self.confd.set_user_voicemails({user_uuid: [personal_voicemail]})
+        self.confd.set_voicemails(global_voicemail, personal_voicemail)
+        calld = self.make_user_calld(user_uuid, tenant_uuid=VALID_TENANT_MULTITENANT_1)
+
+        # 3 messages match from >= 2024-08-23T18:11:28, paginate with limit=1, offset=1
+        result = calld.voicemails.list_voicemail_messages(
+            **{
+                'from': '2024-08-23T18:11:28',
+                'limit': 1,
+                'offset': 1,
+            }
+        )
+        assert_that(
+            result,
+            has_entries(
+                items=contains_exactly(
+                    has_entries(id='1724436755-00000002'),
+                ),
+                total=4,
+                filtered=3,
+            ),
+        )

--- a/integration_tests/suite/test_voicemail_transcription.py
+++ b/integration_tests/suite/test_voicemail_transcription.py
@@ -5,6 +5,7 @@ import uuid
 
 from hamcrest import (
     assert_that,
+    contains_exactly,
     has_entries,
     has_item,
     has_items,
@@ -581,6 +582,87 @@ class TestVoicemailTranscriptionEnrichment(RealAsteriskIntegrationTest):
             ),
         )
         assert_that(msg['transcribed'], is_(False))
+
+    def test_list_admin_messages_filter_transcribed(self):
+        user_uuid = str(uuid.uuid4())
+        voicemail_id_1 = 111
+        voicemail_id_2 = 222
+        transcribed_msg = '1724107750-00000001'  # default/8000
+        non_transcribed_msg = '1724436688-00000001'  # default/8001
+        vm1 = MockVoicemail(
+            voicemail_id_1,
+            '8000',
+            'vm-transcribed',
+            'default',
+            tenant_uuid=VALID_TENANT,
+        )
+        vm2 = MockVoicemail(
+            voicemail_id_2,
+            '8001',
+            'vm-not-transcribed',
+            'default',
+            tenant_uuid=VALID_TENANT,
+        )
+        self.confd.set_voicemails(vm1, vm2)
+
+        self.call_logd.set_transcriptions(
+            [
+                {
+                    'message_id': transcribed_msg,
+                    'voicemail_id': voicemail_id_1,
+                    'tenant_uuid': VALID_TENANT,
+                    'transcription_text': 'Hello',
+                    'provider_id': 'openai/whisper-1',
+                    'language': 'en',
+                    'duration': 19.0,
+                },
+            ]
+        )
+
+        calld = self.make_user_calld(user_uuid, tenant_uuid=VALID_TENANT)
+        # default/8001 has 3 more messages, total = 4
+
+        # no filter: both transcribed and non-transcribed included
+        result = calld.voicemails.list_voicemail_messages()
+        assert_that(
+            result,
+            has_entries(
+                items=has_items(
+                    has_entries(id=transcribed_msg, transcribed=True),
+                    has_entries(id=non_transcribed_msg, transcribed=False),
+                ),
+                total=4,
+                filtered=4,
+            ),
+        )
+
+        # transcribed=True: only transcribed messages
+        result = calld.voicemails.list_voicemail_messages(transcribed=True)
+        assert_that(
+            result,
+            has_entries(
+                items=contains_exactly(
+                    has_entries(id=transcribed_msg, transcribed=True),
+                ),
+                total=4,
+                filtered=1,
+            ),
+        )
+
+        # transcribed=False: only non-transcribed messages
+        result = calld.voicemails.list_voicemail_messages(transcribed=False)
+        assert_that(
+            result,
+            has_entries(
+                items=contains_exactly(
+                    has_entries(id='1724436688-00000001', transcribed=False),
+                    has_entries(id='1724436755-00000002', transcribed=False),
+                    has_entries(id='1724436995-00000003', transcribed=False),
+                ),
+                total=4,
+                filtered=3,
+            ),
+        )
 
     def test_list_user_messages_transcription_fault_tolerance(self):
         """Verify that messages are still returned when call-logd is unavailable."""

--- a/integration_tests/suite/test_voicemail_transcription.py
+++ b/integration_tests/suite/test_voicemail_transcription.py
@@ -541,12 +541,12 @@ class TestVoicemailTranscriptionEnrichment(RealAsteriskIntegrationTest):
                 'duration',
                 'timestamp',
                 'empty',
-                'transcripted',
+                'transcribed',
                 'voicemail',
                 'folder',
             ),
         )
-        assert_that(msg['transcripted'], is_(True))
+        assert_that(msg['transcribed'], is_(True))
 
     def test_list_admin_messages_without_transcription(self):
         user_uuid = str(uuid.uuid4())
@@ -575,12 +575,12 @@ class TestVoicemailTranscriptionEnrichment(RealAsteriskIntegrationTest):
                 'duration',
                 'timestamp',
                 'empty',
-                'transcripted',
+                'transcribed',
                 'voicemail',
                 'folder',
             ),
         )
-        assert_that(msg['transcripted'], is_(False))
+        assert_that(msg['transcribed'], is_(False))
 
     def test_list_user_messages_transcription_fault_tolerance(self):
         """Verify that messages are still returned when call-logd is unavailable."""

--- a/integration_tests/suite/test_voicemail_transcription.py
+++ b/integration_tests/suite/test_voicemail_transcription.py
@@ -3,7 +3,15 @@
 
 import uuid
 
-from hamcrest import assert_that, has_entries, has_item, has_items, is_, none
+from hamcrest import (
+    assert_that,
+    has_entries,
+    has_item,
+    has_items,
+    is_,
+    none,
+    only_contains,
+)
 from wazo_test_helpers import until
 
 from .helpers.base import IntegrationTest
@@ -203,7 +211,6 @@ class TestVoicemailTranscriptionEnrichment(RealAsteriskIntegrationTest):
         )
         self.confd.set_user_voicemails({user_uuid: [voicemail]})
         self.confd.set_voicemails(voicemail)
-
         # No transcriptions set in call-logd
         calld = self.make_user_calld(user_uuid, tenant_uuid=VALID_TENANT)
         result = calld.voicemails.list_voicemail_messages_from_user(
@@ -523,19 +530,23 @@ class TestVoicemailTranscriptionEnrichment(RealAsteriskIntegrationTest):
         calld = self.make_user_calld(user_uuid, tenant_uuid=VALID_TENANT)
         result = calld.voicemails.list_voicemail_messages()
 
+        items = result['items']
+        msg = next(m for m in items if m['id'] == message_id)
         assert_that(
-            result,
-            has_entries(
-                items=has_item(
-                    has_entries(
-                        id=message_id,
-                        transcription=has_entries(
-                            text='Admin list transcription',
-                        ),
-                    ),
-                ),
+            msg.keys(),
+            only_contains(
+                'id',
+                'caller_id_name',
+                'caller_id_num',
+                'duration',
+                'timestamp',
+                'empty',
+                'transcripted',
+                'voicemail',
+                'folder',
             ),
         )
+        assert_that(msg['transcripted'], is_(True))
 
     def test_list_admin_messages_without_transcription(self):
         user_uuid = str(uuid.uuid4())
@@ -553,17 +564,23 @@ class TestVoicemailTranscriptionEnrichment(RealAsteriskIntegrationTest):
         calld = self.make_user_calld(user_uuid, tenant_uuid=VALID_TENANT)
         result = calld.voicemails.list_voicemail_messages()
 
+        items = result['items']
+        msg = next(m for m in items if m['id'] == message_id)
         assert_that(
-            result,
-            has_entries(
-                items=has_item(
-                    has_entries(
-                        id=message_id,
-                        transcription=is_(none()),
-                    ),
-                ),
+            msg.keys(),
+            only_contains(
+                'id',
+                'caller_id_name',
+                'caller_id_num',
+                'duration',
+                'timestamp',
+                'empty',
+                'transcripted',
+                'voicemail',
+                'folder',
             ),
         )
+        assert_that(msg['transcripted'], is_(False))
 
     def test_list_user_messages_transcription_fault_tolerance(self):
         """Verify that messages are still returned when call-logd is unavailable."""

--- a/integration_tests/suite/test_voicemail_transcription.py
+++ b/integration_tests/suite/test_voicemail_transcription.py
@@ -493,6 +493,78 @@ class TestVoicemailTranscriptionEnrichment(RealAsteriskIntegrationTest):
             ),
         )
 
+    def test_list_admin_messages_with_transcription(self):
+        user_uuid = str(uuid.uuid4())
+        voicemail_id = 111
+        message_id = '1724107750-00000001'  # Present in Docker volume
+        voicemail = MockVoicemail(
+            voicemail_id,
+            '8000',
+            'admin-voicemail',
+            'default',
+            tenant_uuid=VALID_TENANT,
+        )
+        self.confd.set_voicemails(voicemail)
+
+        self.call_logd.set_transcriptions(
+            [
+                {
+                    'message_id': message_id,
+                    'voicemail_id': voicemail_id,
+                    'tenant_uuid': VALID_TENANT,
+                    'transcription_text': 'Admin list transcription',
+                    'provider_id': 'openai/whisper-1',
+                    'language': 'en',
+                    'duration': 19.0,
+                },
+            ]
+        )
+
+        calld = self.make_user_calld(user_uuid, tenant_uuid=VALID_TENANT)
+        result = calld.voicemails.list_voicemail_messages()
+
+        assert_that(
+            result,
+            has_entries(
+                items=has_item(
+                    has_entries(
+                        id=message_id,
+                        transcription=has_entries(
+                            text='Admin list transcription',
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+    def test_list_admin_messages_without_transcription(self):
+        user_uuid = str(uuid.uuid4())
+        voicemail_id = 111
+        message_id = '1724107750-00000001'  # Present in Docker volume
+        voicemail = MockVoicemail(
+            voicemail_id,
+            '8000',
+            'admin-voicemail',
+            'default',
+            tenant_uuid=VALID_TENANT,
+        )
+        self.confd.set_voicemails(voicemail)
+
+        calld = self.make_user_calld(user_uuid, tenant_uuid=VALID_TENANT)
+        result = calld.voicemails.list_voicemail_messages()
+
+        assert_that(
+            result,
+            has_entries(
+                items=has_item(
+                    has_entries(
+                        id=message_id,
+                        transcription=is_(none()),
+                    ),
+                ),
+            ),
+        )
+
     def test_list_user_messages_transcription_fault_tolerance(self):
         """Verify that messages are still returned when call-logd is unavailable."""
         user_uuid = str(uuid.uuid4())

--- a/wazo_calld/plugin_helpers/confd.py
+++ b/wazo_calld/plugin_helpers/confd.py
@@ -240,29 +240,9 @@ def get_user_voicemail(user_uuid, confd_client):
     return voicemail
 
 
-def get_global_voicemails(
-    tenant_uuid, confd_client, recurse: bool = False
-) -> list[dict]:
+def get_all_voicemails(confd_client, **kwargs) -> list[dict]:
     try:
-        response = confd_client.voicemails.list(
-            tenant_uuid=tenant_uuid, accesstype='global', recurse=recurse
-        )
-        return response.get("items", [])
-    except HTTPError as e:
-        if not_found(e):
-            return []
-        raise
-    except RequestException as e:
-        raise WazoConfdUnreachable(confd_client, e)
-
-
-def get_all_voicemails(
-    tenant_uuid: str, confd_client, recurse: bool = False
-) -> list[dict]:
-    try:
-        response = confd_client.voicemails.list(
-            tenant_uuid=tenant_uuid, recurse=recurse
-        )
+        response = confd_client.voicemails.list(**kwargs)
         return response.get("items", [])
     except HTTPError as e:
         if not_found(e):

--- a/wazo_calld/plugin_helpers/confd.py
+++ b/wazo_calld/plugin_helpers/confd.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from requests import HTTPError, RequestException
@@ -244,6 +244,22 @@ def get_global_voicemails(tenant_uuid, confd_client) -> list[dict]:
     try:
         response = confd_client.voicemails.list(
             tenant_uuid=tenant_uuid, accesstype='global'
+        )
+        return response.get("items", [])
+    except HTTPError as e:
+        if not_found(e):
+            return []
+        raise
+    except RequestException as e:
+        raise WazoConfdUnreachable(confd_client, e)
+
+
+def get_all_voicemails(
+    tenant_uuid: str, confd_client, recurse: bool = False
+) -> list[dict]:
+    try:
+        response = confd_client.voicemails.list(
+            tenant_uuid=tenant_uuid, recurse=recurse
         )
         return response.get("items", [])
     except HTTPError as e:

--- a/wazo_calld/plugin_helpers/confd.py
+++ b/wazo_calld/plugin_helpers/confd.py
@@ -240,10 +240,12 @@ def get_user_voicemail(user_uuid, confd_client):
     return voicemail
 
 
-def get_global_voicemails(tenant_uuid, confd_client) -> list[dict]:
+def get_global_voicemails(
+    tenant_uuid, confd_client, recurse: bool = False
+) -> list[dict]:
     try:
         response = confd_client.voicemails.list(
-            tenant_uuid=tenant_uuid, accesstype='global'
+            tenant_uuid=tenant_uuid, accesstype='global', recurse=recurse
         )
         return response.get("items", [])
     except HTTPError as e:

--- a/wazo_calld/plugin_helpers/tests/test_confd.py
+++ b/wazo_calld/plugin_helpers/tests/test_confd.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
@@ -7,8 +7,8 @@ from unittest.mock import Mock
 import requests
 from hamcrest import assert_that, calling, equal_to, raises
 
-from ..confd import Line
-from ..exceptions import WazoConfdUnreachable
+from ..confd import Line, get_all_voicemails, get_voicemail
+from ..exceptions import NoSuchVoicemail, WazoConfdUnreachable
 
 
 class TestLine(TestCase):
@@ -35,4 +35,84 @@ class TestLine(TestCase):
         }
         assert_that(
             self.line.interface_autoanswer(), equal_to('sccp/abcdef/autoanswer')
+        )
+
+
+class TestGetVoicemail(TestCase):
+    def setUp(self):
+        self.confd_client = Mock()
+
+    def test_returns_voicemail(self):
+        vm = {'id': 1, 'name': 'vm', 'number': '100', 'context': 'default'}
+        self.confd_client.voicemails.get.return_value = vm
+
+        result = get_voicemail('tenant-1', 1, self.confd_client)
+
+        assert_that(result, equal_to(vm))
+        self.confd_client.voicemails.get.assert_called_once_with(
+            1, tenant_uuid='tenant-1'
+        )
+
+    def test_not_found_raises_no_such_voicemail(self):
+        response = Mock(status_code=404)
+        self.confd_client.voicemails.get.side_effect = requests.HTTPError(
+            response=response
+        )
+
+        assert_that(
+            calling(get_voicemail).with_args('tenant-1', 999, self.confd_client),
+            raises(NoSuchVoicemail),
+        )
+
+    def test_request_exception_raises_confd_unreachable(self):
+        self.confd_client.voicemails.get.side_effect = requests.RequestException
+
+        assert_that(
+            calling(get_voicemail).with_args('tenant-1', 1, self.confd_client),
+            raises(WazoConfdUnreachable),
+        )
+
+
+class TestGetAllVoicemails(TestCase):
+    def setUp(self):
+        self.confd_client = Mock()
+
+    def test_returns_items(self):
+        vms = [{'id': 1}, {'id': 2}]
+        self.confd_client.voicemails.list.return_value = {'items': vms, 'total': 2}
+
+        result = get_all_voicemails(
+            self.confd_client, tenant_uuid='tenant-1', recurse=False
+        )
+
+        assert_that(result, equal_to(vms))
+        self.confd_client.voicemails.list.assert_called_once_with(
+            tenant_uuid='tenant-1', recurse=False
+        )
+
+    def test_passes_accesstype_filter(self):
+        self.confd_client.voicemails.list.return_value = {'items': [], 'total': 0}
+
+        get_all_voicemails(self.confd_client, tenant_uuid='t', accesstype='global')
+
+        self.confd_client.voicemails.list.assert_called_once_with(
+            tenant_uuid='t', accesstype='global'
+        )
+
+    def test_not_found_returns_empty(self):
+        response = Mock(status_code=404)
+        self.confd_client.voicemails.list.side_effect = requests.HTTPError(
+            response=response
+        )
+
+        result = get_all_voicemails(self.confd_client, tenant_uuid='t')
+
+        assert_that(result, equal_to([]))
+
+    def test_request_exception_raises_confd_unreachable(self):
+        self.confd_client.voicemails.list.side_effect = requests.RequestException
+
+        assert_that(
+            calling(get_all_voicemails).with_args(self.confd_client, tenant_uuid='t'),
+            raises(WazoConfdUnreachable),
         )

--- a/wazo_calld/plugins/voicemails/api.yml
+++ b/wazo_calld/plugins/voicemails/api.yml
@@ -75,7 +75,7 @@ paths:
         '200':
           description: The voicemail messages in the tenant
           schema:
-            $ref: '#/definitions/VoicemailMessages'
+            $ref: '#/definitions/AdminVoicemailMessages'
         '400':
           $ref: '#/responses/InvalidRequest'
         '503':
@@ -698,13 +698,27 @@ definitions:
         type: integer
         description: The time the message was left as a Unix time value
         readOnly: true
-      transcription:
-        $ref: '#/definitions/VoicemailTranscription'
-        readOnly: true
-  VoicemailMessage:
+  VoicemailTranscriptedMessageBase:
     type: object
     allOf:
     - $ref: '#/definitions/VoicemailMessageBase'
+    - properties:
+        transcription:
+          $ref: '#/definitions/VoicemailTranscription'
+          readOnly: true
+  AdminVoicemailMessage:
+    type: object
+    allOf:
+    - $ref: '#/definitions/VoicemailMessageBase'
+    - properties:
+        transcripted:
+          type: boolean
+          description: True if a transcription exists for this message
+          readOnly: true
+  VoicemailMessage:
+    type: object
+    allOf:
+    - $ref: '#/definitions/VoicemailTranscriptedMessageBase'
     - properties:
         folder:
           $ref: '#/definitions/VoicemailFolderBase'
@@ -717,6 +731,24 @@ definitions:
         description: The folder's ID
     required:
     - folder_id
+  VoicemailMessageVoicemail:
+    type: object
+    properties:
+      id:
+        type: integer
+        description: The containing voicemail's ID
+        readOnly: true
+      name:
+        type: string
+        description: The containing voicemail's name
+        readOnly: true
+      accesstype:
+        type: string
+        description: The containing voicemail's type (either global or personal)
+        enum:
+        - global
+        - personal
+        readOnly: true
   VoicemailMessages:
     type: object
     properties:
@@ -729,25 +761,32 @@ definitions:
           - type: object
             properties:
               voicemail:
-                type: object
-                properties:
-                  id:
-                    type: integer
-                    description: The containing voicemail's ID
-                    readOnly: true
-                  name:
-                    type: string
-                    description: The containing voicemail's name
-                    readOnly: true
-                  accesstype:
-                    type: string
-                    description: The containing voicemail's type (either global or personal)
-                    enum:
-                    - global
-                    - personal
-                    readOnly: true
+                $ref: '#/definitions/VoicemailMessageVoicemail'
         readOnly: true
       total:
+        type: integer
+        readOnly: true
+  AdminVoicemailMessages:
+    type: object
+    properties:
+      items:
+        description: List of voicemail messages
+        type: array
+        items:
+          allOf:
+          - $ref: '#/definitions/AdminVoicemailMessage'
+          - type: object
+            properties:
+              folder:
+                $ref: '#/definitions/VoicemailFolderBase'
+                readOnly: true
+              voicemail:
+                $ref: '#/definitions/VoicemailMessageVoicemail'
+        readOnly: true
+      total:
+        type: integer
+        readOnly: true
+      filtered:
         type: integer
         readOnly: true
 parameters:

--- a/wazo_calld/plugins/voicemails/api.yml
+++ b/wazo_calld/plugins/voicemails/api.yml
@@ -711,7 +711,7 @@ definitions:
     allOf:
     - $ref: '#/definitions/VoicemailMessageBase'
     - properties:
-        transcripted:
+        transcribed:
           type: boolean
           description: True if a transcription exists for this message
           readOnly: true

--- a/wazo_calld/plugins/voicemails/api.yml
+++ b/wazo_calld/plugins/voicemails/api.yml
@@ -69,6 +69,11 @@ paths:
         type: boolean
         default: false
         required: false
+      - name: transcribed
+        in: query
+        description: Filter messages by transcription availability
+        type: boolean
+        required: false
       tags:
       - voicemails
       responses:

--- a/wazo_calld/plugins/voicemails/api.yml
+++ b/wazo_calld/plugins/voicemails/api.yml
@@ -5,35 +5,13 @@ paths:
       description: '**Required ACL:** `calld.voicemails.messages.read`'
       parameters:
       - $ref: '#/parameters/TenantUUID'
-      - name: direction
-        in: query
-        type: string
-        enum:
-        - asc
-        - desc
-        default: asc
-        required: false
-      - name: order
-        in: query
-        type: string
-        enum:
-        - id
-        - caller_id_name
-        - duration
-        - timestamp
-        default: timestamp
-        required: false
-      - name: limit
-        in: query
-        type: integer
-        required: false
-      - name: offset
-        in: query
-        type: integer
-        required: false
+      - $ref: '#/parameters/direction'
+      - $ref: '#/parameters/order'
+      - $ref: '#/parameters/limit'
+      - $ref: '#/parameters/offset'
       - name: voicemail_type
         in: query
-        description: Include or exclude messages from global mailboxes
+        description: Filter messages by voicemail accesstype
         type: string
         enum:
         - all

--- a/wazo_calld/plugins/voicemails/api.yml
+++ b/wazo_calld/plugins/voicemails/api.yml
@@ -1,4 +1,85 @@
 paths:
+  /voicemails/messages:
+    get:
+      summary: List all voicemail messages in a tenant
+      description: '**Required ACL:** `calld.voicemails.messages.read`'
+      parameters:
+      - $ref: '#/parameters/TenantUUID'
+      - name: direction
+        in: query
+        type: string
+        enum:
+        - asc
+        - desc
+        default: asc
+        required: false
+      - name: order
+        in: query
+        type: string
+        enum:
+        - id
+        - caller_id_name
+        - duration
+        - timestamp
+        default: timestamp
+        required: false
+      - name: limit
+        in: query
+        type: integer
+        required: false
+      - name: offset
+        in: query
+        type: integer
+        required: false
+      - name: voicemail_type
+        in: query
+        description: Include or exclude messages from global mailboxes
+        type: string
+        enum:
+        - all
+        - personal
+        - global
+        default: all
+        required: false
+      - name: user_uuid
+        in: query
+        description: Filter messages by user UUID (returns user's personal + global voicemails)
+        type: string
+        required: false
+      - name: voicemail_id
+        in: query
+        description: Filter messages by voicemail ID
+        type: integer
+        required: false
+      - name: from
+        in: query
+        description: Filter messages with timestamp >= this value (ISO 8601 datetime)
+        type: string
+        format: date-time
+        required: false
+      - name: until
+        in: query
+        description: Filter messages with timestamp < this value (ISO 8601 datetime)
+        type: string
+        format: date-time
+        required: false
+      - name: recurse
+        in: query
+        description: Include sub-tenants
+        type: boolean
+        default: false
+        required: false
+      tags:
+      - voicemails
+      responses:
+        '200':
+          description: The voicemail messages in the tenant
+          schema:
+            $ref: '#/definitions/VoicemailMessages'
+        '400':
+          $ref: '#/responses/InvalidRequest'
+        '503':
+          $ref: '#/responses/AnotherServiceUnavailable'
   /voicemails/{voicemail_id}:
     get:
       summary: Get details of a voicemail

--- a/wazo_calld/plugins/voicemails/http.py
+++ b/wazo_calld/plugins/voicemails/http.py
@@ -22,6 +22,7 @@ from .exceptions import (
 from .schemas import (
     VALID_GREETINGS,
     voicemail_admin_messages_get_schema,
+    voicemail_admin_messages_schema,
     voicemail_folder_schema,
     voicemail_greeting_copy_schema,
     voicemail_message_schema,
@@ -397,7 +398,7 @@ class VoicemailMessagesResource(AuthResource):
 
         messages = self._voicemails_service.list_messages(tenant.uuid, **params)
 
-        return voicemail_messages_schema.dump(
+        return voicemail_admin_messages_schema.dump(
             {"items": messages, "total": total, "filtered": filtered}
         )
 

--- a/wazo_calld/plugins/voicemails/http.py
+++ b/wazo_calld/plugins/voicemails/http.py
@@ -371,36 +371,9 @@ class VoicemailMessagesResource(AuthResource):
         params = voicemail_admin_messages_get_schema.load(request.args.to_dict())
         tenant = Tenant.autodetect()
 
-        voicemail_type = params.get('voicemail_type', 'all')
-        user_uuid = params.get('user_uuid')
-        voicemail_id = params.get('voicemail_id')
-        recurse = params.get('recurse', False)
-        from_ = params.get('from_')
-        until = params.get('until')
+        result = self._voicemails_service.get_tenant_messages(tenant.uuid, **params)
 
-        total = self._voicemails_service.count_messages(
-            tenant.uuid,
-            voicemail_type=voicemail_type,
-            user_uuid=user_uuid,
-            voicemail_id=voicemail_id,
-            recurse=recurse,
-        )
-
-        filtered = self._voicemails_service.count_filtered_messages(
-            tenant.uuid,
-            voicemail_type=voicemail_type,
-            user_uuid=user_uuid,
-            voicemail_id=voicemail_id,
-            from_=from_,
-            until=until,
-            recurse=recurse,
-        )
-
-        messages = self._voicemails_service.list_messages(tenant.uuid, **params)
-
-        return voicemail_admin_messages_schema.dump(
-            {"items": messages, "total": total, "filtered": filtered}
-        )
+        return voicemail_admin_messages_schema.dump(result)
 
 
 class UserVoicemailMessagesResource(AuthResource):

--- a/wazo_calld/plugins/voicemails/http.py
+++ b/wazo_calld/plugins/voicemails/http.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import re
@@ -21,6 +21,7 @@ from .exceptions import (
 )
 from .schemas import (
     VALID_GREETINGS,
+    voicemail_admin_messages_get_schema,
     voicemail_folder_schema,
     voicemail_greeting_copy_schema,
     voicemail_message_schema,
@@ -358,6 +359,47 @@ def _validate_greeting(greeting):
     if greeting in VALID_GREETINGS:
         return greeting
     raise NoSuchVoicemailGreeting(greeting)
+
+
+class VoicemailMessagesResource(AuthResource):
+    def __init__(self, voicemails_service):
+        self._voicemails_service = voicemails_service
+
+    @required_acl('calld.voicemails.messages.read')
+    def get(self):
+        params = voicemail_admin_messages_get_schema.load(request.args.to_dict())
+        tenant = Tenant.autodetect()
+
+        voicemail_type = params.get('voicemail_type', 'all')
+        user_uuid = params.get('user_uuid')
+        voicemail_id = params.get('voicemail_id')
+        recurse = params.get('recurse', False)
+        from_ = params.get('from_')
+        until = params.get('until')
+
+        total = self._voicemails_service.count_messages(
+            tenant.uuid,
+            voicemail_type=voicemail_type,
+            user_uuid=user_uuid,
+            voicemail_id=voicemail_id,
+            recurse=recurse,
+        )
+
+        filtered = self._voicemails_service.count_filtered_messages(
+            tenant.uuid,
+            voicemail_type=voicemail_type,
+            user_uuid=user_uuid,
+            voicemail_id=voicemail_id,
+            from_=from_,
+            until=until,
+            recurse=recurse,
+        )
+
+        messages = self._voicemails_service.list_messages(tenant.uuid, **params)
+
+        return voicemail_messages_schema.dump(
+            {"items": messages, "total": total, "filtered": filtered}
+        )
 
 
 class UserVoicemailMessagesResource(AuthResource):

--- a/wazo_calld/plugins/voicemails/plugin.py
+++ b/wazo_calld/plugins/voicemails/plugin.py
@@ -24,6 +24,7 @@ from .http import (
     VoicemailGreetingCopyResource,
     VoicemailGreetingResource,
     VoicemailMessageResource,
+    VoicemailMessagesResource,
     VoicemailRecordingResource,
     VoicemailResource,
 )
@@ -74,6 +75,11 @@ class Plugin:
 
         status_aggregator.add_provider(self._provide_status)
 
+        api.add_resource(
+            VoicemailMessagesResource,
+            '/voicemails/messages',
+            resource_class_args=[voicemails_service],
+        )
         api.add_resource(
             VoicemailResource,
             '/voicemails/<voicemail_id>',

--- a/wazo_calld/plugins/voicemails/schemas.py
+++ b/wazo_calld/plugins/voicemails/schemas.py
@@ -64,6 +64,7 @@ class UnifiedVoicemailMessageSchema(VoicemailMessageBaseSchema):
 class VoicemailMessagesSchema(Schema):
     items = fields.Nested(UnifiedVoicemailMessageSchema, many=True)
     total = fields.Integer()
+    filtered = fields.Integer(dump_default=None)
 
 
 class VoicemailMessagesGetSchema(Schema):
@@ -78,6 +79,14 @@ class VoicemailMessagesGetSchema(Schema):
     )
 
 
+class VoicemailAdminMessagesGetSchema(VoicemailMessagesGetSchema):
+    user_uuid = fields.String()
+    voicemail_id = fields.Integer()
+    from_ = fields.DateTime(data_key='from')
+    until = fields.DateTime()
+    recurse = fields.Boolean(load_default=False)
+
+
 voicemail_schema = VoicemailSchema()
 voicemail_folder_schema = VoicemailFolderSchema()
 voicemail_message_schema = VoicemailMessageSchema()
@@ -85,3 +94,4 @@ voicemail_message_update_schema = VoicemailMessageUpdateSchema()
 voicemail_greeting_copy_schema = VoicemailGreetingCopySchema()
 voicemail_messages_schema = VoicemailMessagesSchema()
 voicemail_messages_get_schema = VoicemailMessagesGetSchema()
+voicemail_admin_messages_get_schema = VoicemailAdminMessagesGetSchema()

--- a/wazo_calld/plugins/voicemails/schemas.py
+++ b/wazo_calld/plugins/voicemails/schemas.py
@@ -68,7 +68,7 @@ class VoicemailMessagesSchema(Schema):
 
 
 class VoicemailAdminMessagesSchema(VoicemailMessagesSchema):
-    filtered = fields.Integer(dump_default=None)
+    filtered = fields.Integer()
 
 
 class VoicemailMessagesGetSchema(Schema):

--- a/wazo_calld/plugins/voicemails/schemas.py
+++ b/wazo_calld/plugins/voicemails/schemas.py
@@ -107,6 +107,7 @@ class VoicemailAdminMessagesGetSchema(VoicemailMessagesGetSchema):
     from_ = AwareDateTime(data_key='from')
     until = AwareDateTime()
     recurse = fields.Boolean(load_default=False)
+    transcribed = fields.Boolean()
 
 
 voicemail_schema = VoicemailSchema()

--- a/wazo_calld/plugins/voicemails/schemas.py
+++ b/wazo_calld/plugins/voicemails/schemas.py
@@ -22,9 +22,20 @@ class VoicemailMessageBaseSchema(Schema):
     duration = fields.Integer()
     timestamp = fields.Integer()
     empty = fields.Boolean()
+
+
+class VoicemailTranscriptedMessageSchema(VoicemailMessageBaseSchema):
     transcription = fields.Nested(
         VoicemailTranscriptionSchema, allow_none=True, dump_default=None
     )
+
+
+class VoicemailTranscriptedHiddenMessageSchema(VoicemailMessageBaseSchema):
+    transcripted = fields.Method('_is_transcripted')
+
+    @staticmethod
+    def _is_transcripted(obj):
+        return obj.get('transcription') is not None
 
 
 class VoicemailFolderBaseSchema(Schema):
@@ -33,12 +44,12 @@ class VoicemailFolderBaseSchema(Schema):
     type = fields.String()
 
 
-class VoicemailMessageSchema(VoicemailMessageBaseSchema):
+class VoicemailMessageSchema(VoicemailTranscriptedMessageSchema):
     folder = fields.Nested(VoicemailFolderBaseSchema)
 
 
 class VoicemailFolderSchema(VoicemailFolderBaseSchema):
-    messages = fields.Nested(VoicemailMessageBaseSchema, many=True)
+    messages = fields.Nested(VoicemailTranscriptedMessageSchema, many=True)
 
 
 class VoicemailSchema(Schema):
@@ -57,7 +68,12 @@ class VoicemailGreetingCopySchema(Schema):
     dest_greeting = fields.String(validate=OneOf(VALID_GREETINGS))
 
 
-class UnifiedVoicemailMessageSchema(VoicemailMessageBaseSchema):
+class UnifiedVoicemailMessageSchema(VoicemailTranscriptedMessageSchema):
+    voicemail = fields.Nested(VoicemailSchema, only=("id", "name", "accesstype"))
+    folder = fields.Nested(VoicemailFolderBaseSchema)
+
+
+class UnifiedVoicemailAdminMessageSchema(VoicemailTranscriptedHiddenMessageSchema):
     voicemail = fields.Nested(VoicemailSchema, only=("id", "name", "accesstype"))
     folder = fields.Nested(VoicemailFolderBaseSchema)
 
@@ -67,7 +83,9 @@ class VoicemailMessagesSchema(Schema):
     total = fields.Integer()
 
 
-class VoicemailAdminMessagesSchema(VoicemailMessagesSchema):
+class VoicemailAdminMessagesSchema(Schema):
+    items = fields.Nested(UnifiedVoicemailAdminMessageSchema, many=True)
+    total = fields.Integer()
     filtered = fields.Integer()
 
 

--- a/wazo_calld/plugins/voicemails/schemas.py
+++ b/wazo_calld/plugins/voicemails/schemas.py
@@ -65,6 +65,9 @@ class UnifiedVoicemailMessageSchema(VoicemailMessageBaseSchema):
 class VoicemailMessagesSchema(Schema):
     items = fields.Nested(UnifiedVoicemailMessageSchema, many=True)
     total = fields.Integer()
+
+
+class VoicemailAdminMessagesSchema(VoicemailMessagesSchema):
     filtered = fields.Integer(dump_default=None)
 
 
@@ -94,5 +97,6 @@ voicemail_message_schema = VoicemailMessageSchema()
 voicemail_message_update_schema = VoicemailMessageUpdateSchema()
 voicemail_greeting_copy_schema = VoicemailGreetingCopySchema()
 voicemail_messages_schema = VoicemailMessagesSchema()
+voicemail_admin_messages_schema = VoicemailAdminMessagesSchema()
 voicemail_messages_get_schema = VoicemailMessagesGetSchema()
 voicemail_admin_messages_get_schema = VoicemailAdminMessagesGetSchema()

--- a/wazo_calld/plugins/voicemails/schemas.py
+++ b/wazo_calld/plugins/voicemails/schemas.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import Schema, fields
+from marshmallow.fields import AwareDateTime
 from xivo.mallow.validate import OneOf, Range
 
 VALID_GREETINGS = ["unavailable", "busy", "name"]
@@ -82,8 +83,8 @@ class VoicemailMessagesGetSchema(Schema):
 class VoicemailAdminMessagesGetSchema(VoicemailMessagesGetSchema):
     user_uuid = fields.String()
     voicemail_id = fields.Integer()
-    from_ = fields.DateTime(data_key='from')
-    until = fields.DateTime()
+    from_ = AwareDateTime(data_key='from')
+    until = AwareDateTime()
     recurse = fields.Boolean(load_default=False)
 
 

--- a/wazo_calld/plugins/voicemails/schemas.py
+++ b/wazo_calld/plugins/voicemails/schemas.py
@@ -31,10 +31,10 @@ class VoicemailTranscriptedMessageSchema(VoicemailMessageBaseSchema):
 
 
 class VoicemailTranscriptedHiddenMessageSchema(VoicemailMessageBaseSchema):
-    transcripted = fields.Method('_is_transcripted')
+    transcribed = fields.Method('_is_transcribed')
 
     @staticmethod
-    def _is_transcripted(obj):
+    def _is_transcribed(obj):
         return obj.get('transcription') is not None
 
 

--- a/wazo_calld/plugins/voicemails/services.py
+++ b/wazo_calld/plugins/voicemails/services.py
@@ -37,27 +37,45 @@ class VoicemailsService:
         user_uuid,
         voicemail_type: Literal["all", "global", "personal"] = "all",
     ):
-        vm_confs = self._get_voicemails_configs(tenant_uuid, user_uuid, voicemail_type)
+        vm_confs = self._get_voicemails_configs(
+            tenant_uuid, voicemail_type=voicemail_type, user_uuid=user_uuid
+        )
         if not vm_confs:
             return 0
         return self._storage.count_all_messages(*vm_confs)
 
     def _get_voicemails_configs(
-        self, tenant_uuid, user_uuid, voicemail_type: VoicemailTypes = "all"
-    ):
-        vm_confs = []
+        self,
+        tenant_uuid: str,
+        voicemail_type: VoicemailTypes = "all",
+        user_uuid: str | None = None,
+        voicemail_id: int | None = None,
+        recurse: bool = False,
+    ) -> list[dict]:
         client = self._confd_client
 
-        if voicemail_type in ("all", "personal"):
-            try:
-                vm_confs.append(confd.get_user_voicemail(user_uuid, client))
-            except NoSuchUserVoicemail:
-                pass
+        if voicemail_id is not None:
+            return [confd.get_voicemail(tenant_uuid, voicemail_id, client)]
 
-        if voicemail_type in ("all", "global"):
-            vm_confs.extend(confd.get_global_voicemails(tenant_uuid, client))
+        if user_uuid is not None:
+            vm_confs: list[dict] = []
+            if voicemail_type in ("all", "personal"):
+                try:
+                    vm_confs.append(confd.get_user_voicemail(user_uuid, client))
+                except NoSuchUserVoicemail:
+                    pass
+            if voicemail_type in ("all", "global"):
+                vm_confs.extend(
+                    confd.get_all_voicemails(
+                        client, tenant_uuid=tenant_uuid, accesstype='global'
+                    )
+                )
+            return vm_confs
 
-        return vm_confs
+        kwargs: dict = {'tenant_uuid': tenant_uuid, 'recurse': recurse}
+        if voicemail_type != "all":
+            kwargs['accesstype'] = voicemail_type
+        return confd.get_all_voicemails(client, **kwargs)
 
     def get_voicemail(self, tenant_uuid, voicemail_id):
         vm_conf = confd.get_voicemail(tenant_uuid, voicemail_id, self._confd_client)
@@ -92,7 +110,7 @@ class VoicemailsService:
         return message
 
     def get_user_message(self, tenant_uuid, user_uuid, message_id):
-        vm_confs = self._get_voicemails_configs(tenant_uuid, user_uuid, 'all')
+        vm_confs = self._get_voicemails_configs(tenant_uuid, user_uuid=user_uuid)
         message = self._storage.get_message_info(message_id, *vm_confs)
         voicemail_ids = {vm_conf['id'] for vm_conf in vm_confs if 'id' in vm_conf}
         self._enrich_messages_with_transcriptions([message], voicemail_ids)
@@ -103,7 +121,7 @@ class VoicemailsService:
         return self._get_message_recording(message_id, vm_conf)
 
     def get_user_message_recording(self, tenant_uuid, user_uuid, message_id):
-        vm_confs = self._get_voicemails_configs(tenant_uuid, user_uuid, 'all')
+        vm_confs = self._get_voicemails_configs(tenant_uuid, user_uuid=user_uuid)
         return self._get_message_recording(message_id, *vm_confs)
 
     def _get_message_recording(self, message_id, *vm_confs):
@@ -122,7 +140,9 @@ class VoicemailsService:
         direction: str | None = None,
         order: str | None = None,
     ):
-        vm_confs = self._get_voicemails_configs(tenant_uuid, user_uuid, voicemail_type)
+        vm_confs = self._get_voicemails_configs(
+            tenant_uuid, voicemail_type=voicemail_type, user_uuid=user_uuid
+        )
         if not vm_confs:
             return []
 
@@ -133,66 +153,7 @@ class VoicemailsService:
         self._enrich_messages_with_transcriptions(messages, voicemail_ids)
         return messages
 
-    def _get_tenant_voicemails_configs(
-        self,
-        tenant_uuid: str,
-        voicemail_type: VoicemailTypes = "all",
-        user_uuid: str | None = None,
-        voicemail_id: int | None = None,
-        recurse: bool = False,
-    ) -> list[dict]:
-        client = self._confd_client
-
-        if voicemail_id is not None:
-            return [confd.get_voicemail(tenant_uuid, voicemail_id, client)]
-
-        if user_uuid is not None:
-            return self._get_voicemails_configs(tenant_uuid, user_uuid, voicemail_type)
-
-        if voicemail_type == "global":
-            return confd.get_global_voicemails(tenant_uuid, client, recurse=recurse)
-        elif voicemail_type == "personal":
-            all_vms = confd.get_all_voicemails(tenant_uuid, client, recurse=recurse)
-            return [vm for vm in all_vms if vm.get('accesstype') != 'global']
-        else:
-            return confd.get_all_voicemails(tenant_uuid, client, recurse=recurse)
-
-    def count_messages(
-        self,
-        tenant_uuid: str,
-        voicemail_type: VoicemailTypes = "all",
-        user_uuid: str | None = None,
-        voicemail_id: int | None = None,
-        recurse: bool = False,
-    ) -> int:
-        vm_confs = self._get_tenant_voicemails_configs(
-            tenant_uuid, voicemail_type, user_uuid, voicemail_id, recurse
-        )
-        if not vm_confs:
-            return 0
-        return self._storage.count_all_messages(*vm_confs)
-
-    def count_filtered_messages(
-        self,
-        tenant_uuid: str,
-        voicemail_type: VoicemailTypes = "all",
-        user_uuid: str | None = None,
-        voicemail_id: int | None = None,
-        from_: datetime | None = None,
-        until: datetime | None = None,
-        recurse: bool = False,
-    ) -> int | None:
-        if from_ is None and until is None:
-            return None
-        vm_confs = self._get_tenant_voicemails_configs(
-            tenant_uuid, voicemail_type, user_uuid, voicemail_id, recurse
-        )
-        if not vm_confs:
-            return 0
-        messages = self._storage.list_messages_infos(*vm_confs)
-        return len(self._filter_by_timestamp(messages, from_, until))
-
-    def list_messages(
+    def get_tenant_messages(
         self,
         tenant_uuid: str,
         voicemail_type: VoicemailTypes = "all",
@@ -205,48 +166,42 @@ class VoicemailsService:
         from_: datetime | None = None,
         until: datetime | None = None,
         recurse: bool = False,
-    ) -> list[dict]:
-        vm_confs = self._get_tenant_voicemails_configs(
-            tenant_uuid, voicemail_type, user_uuid, voicemail_id, recurse
+    ) -> dict:
+        vm_confs = self._get_voicemails_configs(
+            tenant_uuid,
+            voicemail_type=voicemail_type,
+            user_uuid=user_uuid,
+            voicemail_id=voicemail_id,
+            recurse=recurse,
         )
         if not vm_confs:
-            return []
+            return {'items': [], 'total': 0, 'filtered': 0}
 
-        if from_ is not None or until is not None:
-            all_messages = self._storage.list_messages_infos(
-                *vm_confs, order=order, direction=direction
-            )
-            filtered = self._filter_by_timestamp(all_messages, from_, until)
-            start = offset or 0
-            end = (start + limit) if limit is not None else None
-            messages = filtered[start:end]
-        else:
-            messages = self._storage.list_messages_infos(
-                *vm_confs,
-                limit=limit,
-                offset=offset,
-                order=order,
-                direction=direction,
-            )
+        all_messages = self._storage.list_messages_infos(
+            *vm_confs, order=order, direction=direction
+        )
+        total = len(all_messages)
 
-        voicemail_ids = {vm_conf['id'] for vm_conf in vm_confs if 'id' in vm_conf}
-        self._enrich_messages_with_transcriptions(messages, voicemail_ids)
-        return messages
-
-    @staticmethod
-    def _filter_by_timestamp(
-        messages: list[dict],
-        from_: datetime | None,
-        until: datetime | None,
-    ) -> list[dict]:
-        result = messages
+        filtered_messages = all_messages
         if from_ is not None:
             from_ts = int(from_.timestamp())
-            result = [m for m in result if m.get('timestamp', 0) >= from_ts]
+            filtered_messages = [
+                m for m in filtered_messages if m.get('timestamp', 0) >= from_ts
+            ]
         if until is not None:
             until_ts = int(until.timestamp())
-            result = [m for m in result if m.get('timestamp', 0) < until_ts]
-        return result
+            filtered_messages = [
+                m for m in filtered_messages if m.get('timestamp', 0) < until_ts
+            ]
+        filtered = len(filtered_messages)
+
+        start = offset or 0
+        end = (start + limit) if limit is not None else None
+        items = filtered_messages[start:end]
+
+        voicemail_ids = {vm_conf['id'] for vm_conf in vm_confs if 'id' in vm_conf}
+        self._enrich_messages_with_transcriptions(items, voicemail_ids)
+        return {'items': items, 'total': total, 'filtered': filtered}
 
     def _enrich_messages_with_transcriptions(self, messages, voicemail_ids):
         if not messages or not voicemail_ids:
@@ -282,7 +237,7 @@ class VoicemailsService:
 
     def move_user_message(self, tenant_uuid, user_uuid, message_id, dest_folder_id):
         dest_folder = self._storage.get_folder_by_id(dest_folder_id)
-        for vm_conf in self._get_voicemails_configs(tenant_uuid, user_uuid, 'all'):
+        for vm_conf in self._get_voicemails_configs(tenant_uuid, user_uuid=user_uuid):
             try:
                 message_info = self._storage.get_message_info(message_id, vm_conf)
             except NoSuchVoicemailMessage:
@@ -307,7 +262,7 @@ class VoicemailsService:
         return self._delete_message(vm_conf, message_id)
 
     def delete_user_message(self, tenant_uuid, user_uuid, message_id):
-        for vm_conf in self._get_voicemails_configs(tenant_uuid, user_uuid, 'all'):
+        for vm_conf in self._get_voicemails_configs(tenant_uuid, user_uuid=user_uuid):
             try:
                 return self._delete_message(vm_conf, message_id)
             except NoSuchVoicemailMessage:

--- a/wazo_calld/plugins/voicemails/services.py
+++ b/wazo_calld/plugins/voicemails/services.py
@@ -3,6 +3,7 @@
 
 import base64
 import logging
+from datetime import datetime
 from typing import Literal
 
 import requests
@@ -131,6 +132,121 @@ class VoicemailsService:
         voicemail_ids = {vm_conf['id'] for vm_conf in vm_confs if 'id' in vm_conf}
         self._enrich_messages_with_transcriptions(messages, voicemail_ids)
         return messages
+
+    def _get_tenant_voicemails_configs(
+        self,
+        tenant_uuid: str,
+        voicemail_type: VoicemailTypes = "all",
+        user_uuid: str | None = None,
+        voicemail_id: int | None = None,
+        recurse: bool = False,
+    ) -> list[dict]:
+        client = self._confd_client
+
+        if voicemail_id is not None:
+            return [confd.get_voicemail(tenant_uuid, voicemail_id, client)]
+
+        if user_uuid is not None:
+            return self._get_voicemails_configs(tenant_uuid, user_uuid, voicemail_type)
+
+        if voicemail_type == "global":
+            return confd.get_global_voicemails(tenant_uuid, client)
+        elif voicemail_type == "personal":
+            all_vms = confd.get_all_voicemails(tenant_uuid, client, recurse=recurse)
+            return [vm for vm in all_vms if vm.get('accesstype') != 'global']
+        else:
+            return confd.get_all_voicemails(tenant_uuid, client, recurse=recurse)
+
+    def count_messages(
+        self,
+        tenant_uuid: str,
+        voicemail_type: VoicemailTypes = "all",
+        user_uuid: str | None = None,
+        voicemail_id: int | None = None,
+        recurse: bool = False,
+    ) -> int:
+        vm_confs = self._get_tenant_voicemails_configs(
+            tenant_uuid, voicemail_type, user_uuid, voicemail_id, recurse
+        )
+        if not vm_confs:
+            return 0
+        return self._storage.count_all_messages(*vm_confs)
+
+    def count_filtered_messages(
+        self,
+        tenant_uuid: str,
+        voicemail_type: VoicemailTypes = "all",
+        user_uuid: str | None = None,
+        voicemail_id: int | None = None,
+        from_: datetime | None = None,
+        until: datetime | None = None,
+        recurse: bool = False,
+    ) -> int | None:
+        if from_ is None and until is None:
+            return None
+        vm_confs = self._get_tenant_voicemails_configs(
+            tenant_uuid, voicemail_type, user_uuid, voicemail_id, recurse
+        )
+        if not vm_confs:
+            return 0
+        messages = self._storage.list_messages_infos(*vm_confs)
+        return len(self._filter_by_timestamp(messages, from_, until))
+
+    def list_messages(
+        self,
+        tenant_uuid: str,
+        voicemail_type: VoicemailTypes = "all",
+        user_uuid: str | None = None,
+        voicemail_id: int | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        direction: str | None = None,
+        order: str | None = None,
+        from_: datetime | None = None,
+        until: datetime | None = None,
+        recurse: bool = False,
+    ) -> list[dict]:
+        vm_confs = self._get_tenant_voicemails_configs(
+            tenant_uuid, voicemail_type, user_uuid, voicemail_id, recurse
+        )
+        if not vm_confs:
+            return []
+
+        if from_ is not None or until is not None:
+            all_messages = self._storage.list_messages_infos(
+                *vm_confs, order=order, direction=direction
+            )
+            filtered = self._filter_by_timestamp(all_messages, from_, until)
+            start = offset or 0
+            end = (start + limit) if limit is not None else None
+            messages = filtered[start:end]
+        else:
+            messages = self._storage.list_messages_infos(
+                *vm_confs,
+                limit=limit,
+                offset=offset,
+                order=order,
+                direction=direction,
+            )
+
+        voicemail_ids = {vm_conf['id'] for vm_conf in vm_confs if 'id' in vm_conf}
+        self._enrich_messages_with_transcriptions(messages, voicemail_ids)
+        return messages
+
+    @staticmethod
+    def _filter_by_timestamp(
+        messages: list[dict],
+        from_: datetime | None,
+        until: datetime | None,
+    ) -> list[dict]:
+        result = messages
+        if from_ is not None:
+            from_ts = int(from_.timestamp())
+            result = [m for m in result if m.get('timestamp', 0) >= from_ts]
+        if until is not None:
+            until_ts = int(until.timestamp())
+            result = [m for m in result if m.get('timestamp', 0) < until_ts]
+        return result
 
     def _enrich_messages_with_transcriptions(self, messages, voicemail_ids):
         if not messages or not voicemail_ids:

--- a/wazo_calld/plugins/voicemails/services.py
+++ b/wazo_calld/plugins/voicemails/services.py
@@ -150,7 +150,7 @@ class VoicemailsService:
             return self._get_voicemails_configs(tenant_uuid, user_uuid, voicemail_type)
 
         if voicemail_type == "global":
-            return confd.get_global_voicemails(tenant_uuid, client)
+            return confd.get_global_voicemails(tenant_uuid, client, recurse=recurse)
         elif voicemail_type == "personal":
             all_vms = confd.get_all_voicemails(tenant_uuid, client, recurse=recurse)
             return [vm for vm in all_vms if vm.get('accesstype') != 'global']

--- a/wazo_calld/plugins/voicemails/services.py
+++ b/wazo_calld/plugins/voicemails/services.py
@@ -10,7 +10,7 @@ import requests
 from ari.exceptions import ARIHTTPError
 
 from wazo_calld.plugin_helpers import confd
-from wazo_calld.plugin_helpers.exceptions import NoSuchUserVoicemail
+from wazo_calld.plugin_helpers.exceptions import NoSuchUserVoicemail, NoSuchVoicemail
 
 from .exceptions import (
     InvalidVoicemailGreeting,
@@ -55,7 +55,10 @@ class VoicemailsService:
         client = self._confd_client
 
         if voicemail_id is not None:
-            return [confd.get_voicemail(tenant_uuid, voicemail_id, client)]
+            try:
+                return [confd.get_voicemail(tenant_uuid, voicemail_id, client)]
+            except NoSuchVoicemail:
+                return []
 
         if user_uuid is not None:
             vm_confs: list[dict] = []

--- a/wazo_calld/plugins/voicemails/services.py
+++ b/wazo_calld/plugins/voicemails/services.py
@@ -166,6 +166,7 @@ class VoicemailsService:
         from_: datetime | None = None,
         until: datetime | None = None,
         recurse: bool = False,
+        transcribed: bool | None = None,
     ) -> dict:
         vm_confs = self._get_voicemails_configs(
             tenant_uuid,
@@ -193,14 +194,22 @@ class VoicemailsService:
             filtered_messages = [
                 m for m in filtered_messages if m.get('timestamp', 0) < until_ts
             ]
+
+        voicemail_ids = {vm_conf['id'] for vm_conf in vm_confs if 'id' in vm_conf}
+        self._enrich_messages_with_transcriptions(filtered_messages, voicemail_ids)
+
+        if transcribed is not None:
+            filtered_messages = [
+                m
+                for m in filtered_messages
+                if (m.get('transcription') is not None) == transcribed
+            ]
         filtered = len(filtered_messages)
 
         start = offset or 0
         end = (start + limit) if limit is not None else None
         items = filtered_messages[start:end]
 
-        voicemail_ids = {vm_conf['id'] for vm_conf in vm_confs if 'id' in vm_conf}
-        self._enrich_messages_with_transcriptions(items, voicemail_ids)
         return {'items': items, 'total': total, 'filtered': filtered}
 
     def _enrich_messages_with_transcriptions(self, messages, voicemail_ids):


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-calld-client/pull/72


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new tenant-wide admin listing endpoint and new filtering logic (timestamps, recursion, transcription presence) that could impact data exposure and performance if edge cases or ACL/tenant scoping are incorrect.
> 
> **Overview**
> Adds a new admin API `GET /1.0/voicemails/messages` (ACL `calld.voicemails.messages.read`) to list voicemail messages across a tenant, with query filters for voicemail scope (`voicemail_type`, `user_uuid`, `voicemail_id`), time range (`from`/`until` as timezone-aware datetimes), pagination/ordering, optional sub-tenant recursion, and transcription presence (`transcribed`).
> 
> Implements `VoicemailsService.get_tenant_messages()` plus new marshmallow schemas and OpenAPI definitions, including a new admin response shape that exposes a boolean `transcribed` flag (instead of returning the full `transcription` payload) while preserving transcription enrichment for existing message/folder/voicemail responses. Updates confd helpers to support listing voicemails via a generic `get_all_voicemails()` call, and adds extensive integration/unit tests covering tenant isolation and filtering behavior; integration test Docker builds now `--pull` call-logd images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb39be855bfc1c4f859ea7ac734ec651cad92974. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->