### PR TITLE
integration tests: remove legacy egg-info target

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -2,7 +2,7 @@ CHAN_TEST_DIR ?= ../../chan-test
 
 test-setup: build-calld build-ari build-call-logd
 
-build-calld: egg-info
+build-calld:
 	docker build -t wazoplatform/wazo-calld ..
 	docker build --no-cache -t wazo-calld-test -f docker/Dockerfile-calld-test ..
 
@@ -23,10 +23,7 @@ clean:
 	docker rmi -f call-logd-test
 	docker rmi -f call-logd-db-test
 
-egg-info:
-	cd .. && python setup.py egg_info
-
 test:
 	pytest
 
-.PHONY: test-setup build-calld build-ari build-call-logd egg-info test
+.PHONY: test-setup build-calld build-ari build-call-logd test


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the integration test Makefile by removing a deprecated Python packaging step; Docker build/test behavior should be unchanged aside from no longer generating egg metadata.
> 
> **Overview**
> Removes the legacy `egg-info` Makefile target from integration tests and stops `build-calld` from depending on it.
> 
> Updates `.PHONY` accordingly, leaving the Docker build and `pytest` targets otherwise unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09b5cdb8a5370b928280cc2be50b323b0a820d3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->