### PR TITLE
[ITEM-92] Get auto-recording value from shared variables

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       XIVO_UUID: 08c56466-8f29-45c7-9856-92bf1ba89b92
 
   rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:3
     ports:
       - 5672
     volumes:

--- a/integration_tests/suite/test_calls_recording.py
+++ b/integration_tests/suite/test_calls_recording.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
@@ -1331,18 +1331,5 @@ class TestCallRecord(RealAsteriskIntegrationTest):
             context='local',
             extension='dial-autoanswer',
             variables={'variables': variables},
-        )
-        # Seed the SHARED() datastore so is_(group|queue)_auto_recorded()
-        # reads '0' instead of hitting Asterisk's "Error With Function" 500
-        # response for an uninitialized SHARED variable.
-        self.ari.channels.setChannelVar(
-            channelId=call.id,
-            variable='SHARED(WAZO_RECORD_GROUP_CALLEE)',
-            value='0',
-        )
-        self.ari.channels.setChannelVar(
-            channelId=call.id,
-            variable='SHARED(WAZO_RECORD_QUEUE_CALLEE)',
-            value='0',
         )
         return call.id

--- a/integration_tests/suite/test_calls_recording.py
+++ b/integration_tests/suite/test_calls_recording.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
@@ -1331,5 +1331,18 @@ class TestCallRecord(RealAsteriskIntegrationTest):
             context='local',
             extension='dial-autoanswer',
             variables={'variables': variables},
+        )
+        # Seed the SHARED() datastore so is_(group|queue)_auto_recorded()
+        # reads '0' instead of hitting Asterisk's "Error With Function" 500
+        # response for an uninitialized SHARED variable.
+        self.ari.channels.setChannelVar(
+            channelId=call.id,
+            variable='SHARED(WAZO_RECORD_GROUP_CALLEE)',
+            value='0',
+        )
+        self.ari.channels.setChannelVar(
+            channelId=call.id,
+            variable='SHARED(WAZO_RECORD_QUEUE_CALLEE)',
+            value='0',
         )
         return call.id

--- a/wazo_calld/plugin_helpers/ari_.py
+++ b/wazo_calld/plugin_helpers/ari_.py
@@ -340,17 +340,29 @@ class Channel:
         except ARINotFound:
             return False
 
+    """
+    In the case of the Asterisk's shared variable area, if the shared store isn't initiated then the ARI will return a 500 error
+    """
+
     def is_group_auto_recorded(self):
         try:
             return self._get_var('SHARED(WAZO_RECORD_GROUP_CALLEE)') == '1'
-        except (ARINotFound, ARINotInStasis, ARIServerError):
+        except (ARINotFound, ARINotInStasis):
             return False
+        except ARIServerError as e:
+            if e.original_message == 'Unable to read provided function':
+                return False
+            raise
 
     def is_queue_auto_recorded(self):
         try:
             return self._get_var('SHARED(WAZO_RECORD_QUEUE_CALLEE)') == '1'
-        except (ARINotFound, ARINotInStasis, ARIServerError):
+        except (ARINotFound, ARINotInStasis):
             return False
+        except ARIServerError as e:
+            if e.original_message == 'Unable to read provided function':
+                return False
+            raise
 
     def sip_call_id(self):
         if not self.is_sip():

--- a/wazo_calld/plugin_helpers/ari_.py
+++ b/wazo_calld/plugin_helpers/ari_.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -337,6 +337,18 @@ class Channel:
         try:
             progress = self._get_var('WAZO_CALL_PROGRESS')
             return progress == '1'
+        except ARINotFound:
+            return False
+
+    def is_group_auto_recorded(self):
+        try:
+            return self._get_var('SHARED(WAZO_RECORD_GROUP_CALLEE)') == '1'
+        except ARINotFound:
+            return False
+
+    def is_queue_auto_recorded(self):
+        try:
+            return self._get_var('SHARED(WAZO_RECORD_QUEUE_CALLEE)') == '1'
         except ARINotFound:
             return False
 

--- a/wazo_calld/plugin_helpers/ari_.py
+++ b/wazo_calld/plugin_helpers/ari_.py
@@ -8,7 +8,7 @@ import logging
 import time
 from typing import Protocol, TypeVar
 
-from ari.exceptions import ARINotFound, ARINotInStasis
+from ari.exceptions import ARINotFound, ARINotInStasis, ARIServerError
 
 from .exceptions import BridgeNotFound, NotEnoughChannels, TooManyChannels
 
@@ -343,13 +343,13 @@ class Channel:
     def is_group_auto_recorded(self):
         try:
             return self._get_var('SHARED(WAZO_RECORD_GROUP_CALLEE)') == '1'
-        except ARINotFound:
+        except (ARINotFound, ARINotInStasis, ARIServerError):
             return False
 
     def is_queue_auto_recorded(self):
         try:
             return self._get_var('SHARED(WAZO_RECORD_QUEUE_CALLEE)') == '1'
-        except ARINotFound:
+        except (ARINotFound, ARINotInStasis, ARIServerError):
             return False
 
     def sip_call_id(self):

--- a/wazo_calld/plugin_helpers/tests/test_ari_helpers.py
+++ b/wazo_calld/plugin_helpers/tests/test_ari_helpers.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 from unittest.mock import sentinel as s
 
 from ari.exceptions import ARINotFound
-from hamcrest import assert_that, equal_to
+from hamcrest import assert_that, equal_to, is_
 
 from ..ari_ import Channel
 
@@ -52,3 +52,49 @@ class TestChannelHelper(TestCase):
         result = channel.dialed_extension()
 
         assert_that(result, equal_to(s.exten))
+
+    def test_is_group_auto_recorded_returns_true_when_shared_var_is_1(self):
+        self.ari.channels.getChannelVar.return_value = {'value': '1'}
+
+        channel = Channel(s.channel_id, self.ari)
+        result = channel.is_group_auto_recorded()
+
+        assert_that(result, is_(True))
+        self.ari.channels.getChannelVar.assert_called_once_with(
+            channelId=s.channel_id,
+            variable='SHARED(WAZO_RECORD_GROUP_CALLEE)',
+        )
+
+    def test_is_group_auto_recorded_returns_false_when_not_set(self):
+        self.ari.channels.getChannelVar.side_effect = ARINotFound(
+            original_error='no var',
+            ari_client=self.ari,
+        )
+
+        channel = Channel(s.channel_id, self.ari)
+        result = channel.is_group_auto_recorded()
+
+        assert_that(result, is_(False))
+
+    def test_is_queue_auto_recorded_returns_true_when_shared_var_is_1(self):
+        self.ari.channels.getChannelVar.return_value = {'value': '1'}
+
+        channel = Channel(s.channel_id, self.ari)
+        result = channel.is_queue_auto_recorded()
+
+        assert_that(result, is_(True))
+        self.ari.channels.getChannelVar.assert_called_once_with(
+            channelId=s.channel_id,
+            variable='SHARED(WAZO_RECORD_QUEUE_CALLEE)',
+        )
+
+    def test_is_queue_auto_recorded_returns_false_when_not_set(self):
+        self.ari.channels.getChannelVar.side_effect = ARINotFound(
+            original_error='no var',
+            ari_client=self.ari,
+        )
+
+        channel = Channel(s.channel_id, self.ari)
+        result = channel.is_queue_auto_recorded()
+
+        assert_that(result, is_(False))

--- a/wazo_calld/plugins/calls/services.py
+++ b/wazo_calld/plugins/calls/services.py
@@ -618,10 +618,10 @@ class CallsService:
     def _find_channel_to_record(self, call_id):
         try:
             channel = self._ari.channels.get(channelId=call_id)
-            channel_helper = Channel(channel.id, self._ari)
         except ARINotFound:
             raise NoSuchCall(call_id)
 
+        channel_helper = Channel(channel.id, self._ari)
         channel_name = channel.json['name']
         is_side_1_of_local = channel_name.startswith(
             'Local/'

--- a/wazo_calld/plugins/calls/services.py
+++ b/wazo_calld/plugins/calls/services.py
@@ -678,19 +678,6 @@ class CallsService:
 
         return channel
 
-    def _is_automated_recording(self, channel_id):
-        try:
-            channel = self._ari.channels.get(channelId=channel_id)
-        except ARINotFound:
-            raise NoSuchCall(channel_id)
-
-        cv = channel.json['channelvars']
-
-        auto_group_record = cv['WAZO_RECORD_GROUP_CALLEE'] == '1'
-        auto_queue_record = cv['WAZO_RECORD_QUEUE_CALLEE'] == '1'
-
-        return auto_group_record or auto_queue_record
-
     def _toggle_record_allowed(self, channel):
         cv = channel.json['channelvars']
 
@@ -735,7 +722,10 @@ class CallsService:
         if channel_variables['WAZO_CALL_RECORD_ACTIVE'] == '1':
             return
 
-        if self._is_automated_recording(channel_id):
+        if (
+            channel_helper.is_queue_auto_recorded()
+            or channel_helper.is_group_auto_recorded()
+        ):
             logger.debug('bypassing configured toggle permissions for auto-recording')
         elif not self._toggle_record_allowed(channel):
             raise RecordingUnauthorized(call_id)

--- a/wazo_calld/plugins/calls/services.py
+++ b/wazo_calld/plugins/calls/services.py
@@ -618,6 +618,7 @@ class CallsService:
     def _find_channel_to_record(self, call_id):
         try:
             channel = self._ari.channels.get(channelId=call_id)
+            channel_helper = Channel(channel.id, self._ari)
         except ARINotFound:
             raise NoSuchCall(call_id)
 
@@ -628,21 +629,8 @@ class CallsService:
         if not is_side_1_of_local:
             return channel
 
-        try:
-            is_group_callee = (
-                channel.getChannelVar(variable='WAZO_RECORD_GROUP_CALLEE')['value']
-                == '1'
-            )
-        except ARINotFound:
-            is_group_callee = False
-
-        try:
-            is_queue_callee = (
-                channel.getChannelVar(variable='WAZO_RECORD_QUEUE_CALLEE')['value']
-                == '1'
-            )
-        except ARINotFound:
-            is_queue_callee = False
+        is_group_callee = channel_helper.is_group_auto_recorded()
+        is_queue_callee = channel_helper.is_queue_auto_recorded()
 
         is_agent_callback = 'agentcallback' in channel_name
 

--- a/wazo_calld/plugins/calls/tests/test_services.py
+++ b/wazo_calld/plugins/calls/tests/test_services.py
@@ -19,13 +19,6 @@ def _make_local_group_callee_channel(match_uuid):
             'WAZO_LOCAL_CHAN_MATCH_UUID': match_uuid,
         },
     }
-
-    def get_channel_var(variable):
-        if variable == 'WAZO_RECORD_GROUP_CALLEE':
-            return {'value': '1'}
-        return {'value': ''}
-
-    channel.getChannelVar.side_effect = get_channel_var
     return channel
 
 
@@ -272,12 +265,21 @@ def _make_channel_mock(
 class TestFindChannelToRecord(TestCase):
     def setUp(self) -> None:
         self.ari = Mock()
+        self.shared_vars: dict[str, str] = {}
+
+        def _ari_get_var(channelId, variable):
+            if variable in self.shared_vars:
+                return {'value': self.shared_vars[variable]}
+            raise ARINotFound(Mock(), Mock())
+
+        self.ari.channels.getChannelVar.side_effect = _ari_get_var
         self.services = CallsService(
             Mock(), Mock(), self.ari, Mock(), Mock(), Mock(), Mock()
         )
 
     def test_group_callee_returns_answered_channel(self):
         call_uuid = 'shared-group-call-uuid'
+        self.shared_vars['SHARED(WAZO_RECORD_GROUP_CALLEE)'] = '1'
         local_channel = _make_local_group_callee_channel(call_uuid)
         answered_pjsip = _make_pjsip_channel(
             'PJSIP/answered-001', call_uuid, state='Up'
@@ -292,6 +294,7 @@ class TestFindChannelToRecord(TestCase):
 
     def test_group_callee_skips_ringing_channels(self):
         call_uuid = 'shared-group-call-uuid'
+        self.shared_vars['SHARED(WAZO_RECORD_GROUP_CALLEE)'] = '1'
         local_channel = _make_local_group_callee_channel(call_uuid)
         ringing_pjsip = _make_pjsip_channel(
             'PJSIP/ringing-001', call_uuid, state='Ring'
@@ -309,6 +312,7 @@ class TestFindChannelToRecord(TestCase):
 
     def test_group_callee_falls_back_to_local_when_no_channel_is_up(self):
         call_uuid = 'shared-group-call-uuid'
+        self.shared_vars['SHARED(WAZO_RECORD_GROUP_CALLEE)'] = '1'
         local_channel = _make_local_group_callee_channel(call_uuid)
         ringing_pjsip_1 = _make_pjsip_channel(
             'PJSIP/ringing-001', call_uuid, state='Ring'
@@ -357,13 +361,11 @@ class TestFindChannelToRecord(TestCase):
         assert_that(result, is_(channel))
 
     def test_local_side_1_group_callee_returns_real_channel(self) -> None:
+        self.shared_vars['SHARED(WAZO_RECORD_GROUP_CALLEE)'] = '1'
         local_channel = _make_channel_mock(
             'local-1',
             'Local/s@group;1',
             channelvars={'WAZO_LOCAL_CHAN_MATCH_UUID': 'match-uuid'},
-            getvar_side_effect={
-                'WAZO_RECORD_GROUP_CALLEE': {'value': '1'},
-            },
         )
         real_channel = _make_channel_mock(
             'real-1',
@@ -381,14 +383,11 @@ class TestFindChannelToRecord(TestCase):
         assert_that(result, is_(real_channel))
 
     def test_local_side_1_queue_callee_returns_real_channel(self) -> None:
+        self.shared_vars['SHARED(WAZO_RECORD_QUEUE_CALLEE)'] = '1'
         local_channel = _make_channel_mock(
             'local-1',
             'Local/s@queue;1',
             channelvars={'WAZO_LOCAL_CHAN_MATCH_UUID': 'match-uuid'},
-            getvar_side_effect={
-                'WAZO_RECORD_GROUP_CALLEE': ARINotFound(Mock(), Mock()),
-                'WAZO_RECORD_QUEUE_CALLEE': {'value': '1'},
-            },
         )
         real_channel = _make_channel_mock(
             'real-1',
@@ -427,13 +426,11 @@ class TestFindChannelToRecord(TestCase):
         assert_that(result, is_(real_channel))
 
     def test_local_side_1_group_callee_no_match_uuid_returns_local(self) -> None:
+        self.shared_vars['SHARED(WAZO_RECORD_GROUP_CALLEE)'] = '1'
         local_channel = _make_channel_mock(
             'local-1',
             'Local/s@group;1',
             channelvars={'WAZO_LOCAL_CHAN_MATCH_UUID': ''},
-            getvar_side_effect={
-                'WAZO_RECORD_GROUP_CALLEE': {'value': '1'},
-            },
         )
         self.ari.channels.get.return_value = local_channel
 
@@ -442,13 +439,11 @@ class TestFindChannelToRecord(TestCase):
         assert_that(result, is_(local_channel))
 
     def test_local_side_1_group_callee_no_matching_channel_returns_local(self) -> None:
+        self.shared_vars['SHARED(WAZO_RECORD_GROUP_CALLEE)'] = '1'
         local_channel = _make_channel_mock(
             'local-1',
             'Local/s@group;1',
             channelvars={'WAZO_LOCAL_CHAN_MATCH_UUID': 'match-uuid'},
-            getvar_side_effect={
-                'WAZO_RECORD_GROUP_CALLEE': {'value': '1'},
-            },
         )
         unrelated_channel = _make_channel_mock(
             'other-1',
@@ -466,13 +461,11 @@ class TestFindChannelToRecord(TestCase):
         assert_that(result, is_(local_channel))
 
     def test_skips_local_channels_when_searching(self) -> None:
+        self.shared_vars['SHARED(WAZO_RECORD_GROUP_CALLEE)'] = '1'
         local_channel = _make_channel_mock(
             'local-1',
             'Local/s@group;1',
             channelvars={'WAZO_LOCAL_CHAN_MATCH_UUID': 'match-uuid'},
-            getvar_side_effect={
-                'WAZO_RECORD_GROUP_CALLEE': {'value': '1'},
-            },
         )
         other_local = _make_channel_mock(
             'local-2',
@@ -490,13 +483,11 @@ class TestFindChannelToRecord(TestCase):
         assert_that(result, is_(local_channel))
 
     def test_skips_caller_side_channels_when_searching(self) -> None:
+        self.shared_vars['SHARED(WAZO_RECORD_GROUP_CALLEE)'] = '1'
         local_channel = _make_channel_mock(
             'local-1',
             'Local/s@group;1',
             channelvars={'WAZO_LOCAL_CHAN_MATCH_UUID': 'match-uuid'},
-            getvar_side_effect={
-                'WAZO_RECORD_GROUP_CALLEE': {'value': '1'},
-            },
         )
         caller_channel = _make_channel_mock(
             'caller-1',
@@ -545,8 +536,6 @@ class TestRecordingUsesFoundChannel(TestCase):
                 'WAZO_QUEUE_DTMF_RECORD_TOGGLE_ENABLED': '0',
                 'WAZO_GROUP_DTMF_RECORD_TOGGLE_ENABLED': '0',
                 'WAZO_USER_DTMF_RECORD_TOGGLE_ENABLED': '1',
-                'WAZO_RECORD_GROUP_CALLEE': '0',
-                'WAZO_RECORD_QUEUE_CALLEE': '0',
             },
         )
 
@@ -566,6 +555,8 @@ class TestRecordingUsesFoundChannel(TestCase):
         )
         mock_channel_cls = tenant_patcher.start()
         mock_channel_cls.return_value.tenant_uuid.return_value = None
+        mock_channel_cls.return_value.is_group_auto_recorded.return_value = False
+        mock_channel_cls.return_value.is_queue_auto_recorded.return_value = False
         self.addCleanup(tenant_patcher.stop)
 
         # make_call_from_channel is used in stop/pause/resume


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-agid/pull/210


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes call recording channel selection and authorization bypass logic to rely on ARI `SHARED()` variables and handle additional ARI error cases; mistakes could cause recordings to start/stop on the wrong channel or be incorrectly authorized/blocked.
> 
> **Overview**
> Recording auto-detection for group/queue calls is switched to read from Asterisk shared variables (`SHARED(WAZO_RECORD_GROUP_CALLEE)` / `SHARED(WAZO_RECORD_QUEUE_CALLEE)`) via new `Channel.is_group_auto_recorded()` / `is_queue_auto_recorded()` helpers, including graceful handling of ARI 500s when the shared store is uninitialized.
> 
> `CallsService._find_channel_to_record()` and `record_start()` now use these helpers (and the shared-variable behavior) to decide when to record the “real” channel behind a `Local/...;1` leg and when to bypass DTMF toggle permissions; the old `_is_automated_recording` path is removed. Tests are updated/added accordingly, and the integration test `rabbitmq` image is pinned to `rabbitmq:3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 597f57aa35361b5ee91f5b8df54558b936ffc56c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->