### PR TITLE
TASK 242 mobile gsm fallback

### DIFF
--- a/integration_tests/assets/docker-compose.real_asterisk.override.yml
+++ b/integration_tests/assets/docker-compose.real_asterisk.override.yml
@@ -46,6 +46,7 @@ services:
   calld:
     volumes:
       - ./etc/wazo-calld/conf.d/20-real-asterisk.yml:/etc/wazo-calld/conf.d/20-real-asterisk.yml
+      - ./etc/wazo-calld/conf.d/30-dial-mobile.yml:/etc/wazo-calld/conf.d/30-dial-mobile.yml
       - asterisk-voicemail:/var/spool/asterisk/voicemail
 
   volume-init:

--- a/integration_tests/assets/etc/wazo-calld/conf.d/30-dial-mobile.yml
+++ b/integration_tests/assets/etc/wazo-calld/conf.d/30-dial-mobile.yml
@@ -1,0 +1,4 @@
+dial_mobile:
+  pstn_fallback:
+    min_timeout: 1.0
+    ring_timeout_factor: 0.05

--- a/integration_tests/suite/helpers/confd.py
+++ b/integration_tests/suite/helpers/confd.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -229,13 +229,20 @@ class MockMoh:
 
 class MockUser:
     def __init__(
-        self, uuid, line_ids=None, mobile=None, voicemail=None, tenant_uuid=None
+        self,
+        uuid,
+        line_ids=None,
+        mobile=None,
+        voicemail=None,
+        tenant_uuid=None,
+        mobile_fallback_enabled=False,
     ):
         self._uuid = uuid
         self._line_ids = line_ids or []
         self._mobile = mobile
         self._voicemail = voicemail
         self._tenant_uuid = tenant_uuid
+        self._mobile_fallback_enabled = mobile_fallback_enabled
 
     def uuid(self):
         return self._uuid
@@ -245,6 +252,7 @@ class MockUser:
             'uuid': self._uuid,
             'lines': [{'id': line_id} for line_id in self._line_ids],
             'mobile_phone_number': self._mobile,
+            'mobile_fallback_enabled': self._mobile_fallback_enabled,
             'voicemail': self._voicemail,
             'tenant_uuid': self._tenant_uuid,
         }

--- a/integration_tests/suite/test_dial_mobile.py
+++ b/integration_tests/suite/test_dial_mobile.py
@@ -1,9 +1,10 @@
-# Copyright 2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2024-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from uuid import uuid4
 
 from ari.exceptions import ARINotFound
+from hamcrest import assert_that, has_entries, has_item
 from wazo_test_helpers import until
 
 from .helpers.constants import ENDPOINT_AUTOANSWER
@@ -34,4 +35,99 @@ class TestDialMobile(RealAsteriskIntegrationTest):
             channel.id,
             timeout=10,
             message='Channel is stuck in stasis',
+        )
+
+    def test_caller_hangup_cancels_push_notification(self):
+        # Regression test: when caller hangs up while waiting for mobile to
+        # register, the pending push notification must be cancelled.
+        push_events = self.bus.accumulator(headers={'name': 'call_push_notification'})
+        cancel_events = self.bus.accumulator(
+            headers={'name': 'call_cancel_push_notification'}
+        )
+
+        # Originate a channel into dial_mobile 'dial' path; for a fresh
+        # ARI-originated channel CHANNEL(linkedid) == channel Uniqueid.
+        # StasisStart is processed before we publish to the bus, so
+        # dial_all_contacts will have run by the time we wait for the push event.
+        chan = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app='dial_mobile',
+            appArgs=['dial', 'nonexistent-aor'],
+        )
+
+        # Wait until the channel is in Stasis (Up state means autoanswer fired).
+        def channel_is_up():
+            ch = self.ari.channels.get(channelId=chan.id)
+            assert ch.json['state'] == 'Up'
+
+        until.assert_(
+            channel_is_up, timeout=5, message='Channel never reached Up state'
+        )
+
+        # Publish a Pushmobile event whose Linkedid matches the channel's
+        # linkedid (== chan.id for a fresh origination).
+        call_id = 'test-call-id-caller-hangup'
+        self.bus.publish(
+            {
+                'data': {
+                    'UserEvent': 'Pushmobile',
+                    'Uniqueid': call_id,
+                    'Linkedid': chan.id,
+                    'ChanVariable': {
+                        'WAZO_USERUUID': 'eaa18a7f-3f49-419a-9abb-b445b8ba2e03',
+                        'WAZO_TENANT_UUID': 'some-tenant-uuid',
+                        'WAZO_SIP_CALL_ID': 'de9eb39fb7585796',
+                        'XIVO_BASE_EXTEN': '8000',
+                        'WAZO_DEREFERENCED_USERUUID': '',
+                    },
+                    'CallerIDName': 'Alice',
+                    'CallerIDNum': '101',
+                    'Event': 'UserEvent',
+                    'WAZO_DST_UUID': 'fb27eb93-d21c-483f-8068-e685c90b07e1',
+                    'WAZO_RING_TIME': '200',
+                    'WAZO_VIDEO_ENABLED': '0',
+                    'WAZO_TIMESTAMP': '2026-01-01T00:00:00.000+00:00',
+                    'ConnectedLineName': '',
+                    'ConnectedLineNum': '',
+                    'Priority': '1',
+                    'ChannelStateDesc': 'Ring',
+                    'Language': 'en_US',
+                    'Exten': 's',
+                    'ChannelState': '4',
+                    'Channel': 'PJSIP/test-0000001',
+                    'Context': 'wazo-user-mobile-notification',
+                    'Privilege': 'user,all',
+                    'AccountCode': '',
+                }
+            },
+            headers={'name': 'UserEvent'},
+        )
+
+        # Confirm send_push_notification was called (push notification sent).
+        def push_notification_sent():
+            assert_that(
+                push_events.accumulate(),
+                has_item(has_entries(name='call_push_notification')),
+            )
+
+        until.assert_(
+            push_notification_sent,
+            timeout=5,
+            message='Push notification event never published',
+        )
+
+        # Caller hangs up before mobile registers — this is the bug scenario.
+        chan.hangup()
+
+        # The push notification must be cancelled.
+        def push_notification_cancelled():
+            assert_that(
+                cancel_events.accumulate(),
+                has_item(has_entries(name='call_cancel_push_notification')),
+            )
+
+        until.assert_(
+            push_notification_cancelled,
+            timeout=5,
+            message='Push notification was not cancelled after caller hangup',
         )

--- a/integration_tests/suite/test_dial_mobile.py
+++ b/integration_tests/suite/test_dial_mobile.py
@@ -292,11 +292,7 @@ class TestDialMobile(RealAsteriskIntegrationTest):
             message='PSTN fallback channel was not hung up after caller hangup',
         )
 
-    def test_pstn_fallback_preserves_push_when_ari_unavailable(self):
-        # Regression test for ARI-side failure during the fallback commit:
-        # if ARI is unreachable when the timer fires, _pstn_fallback must
-        # abort cleanly (push left active, state → Cancelled) rather than
-        # silently dropping the call or leaving the Timer thread stuck.
+    def test_pstn_fallback_preserves_push_when_confd_unavailable(self):
         line_id = 424242
         self.confd.set_users(
             MockUser(
@@ -316,19 +312,25 @@ class TestDialMobile(RealAsteriskIntegrationTest):
         cancel_events = self.bus.accumulator(
             headers={'name': 'call_cancel_push_notification'}
         )
-        self._publish_pushmobile(chan, f'test-pstn-ari-down-{uuid4()}', ring_time='20')
+        self._publish_pushmobile(
+            chan, f'test-pstn-confd-down-{uuid4()}', ring_time='20'
+        )
         self._wait_push_notification(push_events)
 
-        # Stop ARI before the timer fires at max(10, 0.5 * 20) = 10 s, so
-        # the fallback commit hits an ARI-side failure. Wait past the timer
-        # window inside the stop scope.
-        with self.ari_stopped():
+        # PSTN timer fires at max(10, 0.5 * 20) = 10 s. Bring confd down
+        # before then and wait past the timer window.
+        with self.confd_stopped():
             time.sleep(12)
             assert cancel_events.accumulate() == [], (
-                'cancel_push_notification was published despite ARI being '
+                'cancel_push_notification was published despite confd being '
                 'unavailable; the push should remain active when the fallback '
                 'cannot dispatch a PSTN leg'
             )
+            assert (
+                self._pstn_channels() == []
+            ), 'PSTN leg was originated despite confd being unavailable'
+
+        chan.hangup()
 
     def test_pstn_fallback_cancels_push_after_dispatch(self):
         line_id = 424242

--- a/integration_tests/suite/test_dial_mobile.py
+++ b/integration_tests/suite/test_dial_mobile.py
@@ -1,6 +1,7 @@
 # Copyright 2024-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import time
 from uuid import uuid4
 
 from ari.exceptions import ARINotFound
@@ -10,6 +11,9 @@ from wazo_test_helpers import until
 from .helpers.confd import MockLine, MockUser
 from .helpers.constants import ENDPOINT_AUTOANSWER
 from .helpers.real_asterisk import RealAsteriskIntegrationTest
+
+_TEST_USER_UUID = 'eaa18a7f-3f49-419a-9abb-b445b8ba2e03'
+_TEST_TENANT_UUID = 'some-tenant-uuid'
 
 
 class TestDialMobile(RealAsteriskIntegrationTest):
@@ -137,25 +141,8 @@ class TestDialMobile(RealAsteriskIntegrationTest):
             message='Push notification was not cancelled after caller hangup',
         )
 
-    def test_caller_hangup_cancels_active_pstn_fallback(self):
-        # Regression test: once the PSTN fallback has fired and a PSTN channel
-        # is ringing, hanging up the caller must also hang up the PSTN channel.
-        user_uuid = 'eaa18a7f-3f49-419a-9abb-b445b8ba2e03'
-        tenant_uuid = 'some-tenant-uuid'
-        line_id = 424242
-        self.confd.set_users(
-            MockUser(
-                uuid=user_uuid,
-                line_ids=[line_id],
-                mobile='ring',
-                mobile_fallback_enabled=True,
-                tenant_uuid=tenant_uuid,
-            )
-        )
-        self.confd.set_lines(
-            MockLine(id=line_id, context='local', tenant_uuid=tenant_uuid)
-        )
-
+    def _start_dial_mobile_dial(self):
+        """Originate a caller channel into dial_mobile dial mode and wait for Up."""
         chan = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app='dial_mobile',
@@ -169,9 +156,9 @@ class TestDialMobile(RealAsteriskIntegrationTest):
         until.assert_(
             channel_is_up, timeout=5, message='Channel never reached Up state'
         )
+        return chan
 
-        push_events = self.bus.accumulator(headers={'name': 'call_push_notification'})
-        call_id = f'test-pstn-hangup-{uuid4()}'
+    def _publish_pushmobile(self, chan, call_id, ring_time='20'):
         self.bus.publish(
             {
                 'data': {
@@ -179,8 +166,8 @@ class TestDialMobile(RealAsteriskIntegrationTest):
                     'Uniqueid': call_id,
                     'Linkedid': chan.id,
                     'ChanVariable': {
-                        'WAZO_USERUUID': user_uuid,
-                        'WAZO_TENANT_UUID': tenant_uuid,
+                        'WAZO_USERUUID': _TEST_USER_UUID,
+                        'WAZO_TENANT_UUID': _TEST_TENANT_UUID,
                         'WAZO_SIP_CALL_ID': 'de9eb39fb7585796',
                         'XIVO_BASE_EXTEN': '8000',
                         'WAZO_DEREFERENCED_USERUUID': '',
@@ -188,9 +175,8 @@ class TestDialMobile(RealAsteriskIntegrationTest):
                     'CallerIDName': 'Alice',
                     'CallerIDNum': '101',
                     'Event': 'UserEvent',
-                    # WAZO_DST_UUID is read as user_uuid by the push handler.
-                    'WAZO_DST_UUID': user_uuid,
-                    'WAZO_RING_TIME': '20',
+                    'WAZO_DST_UUID': _TEST_USER_UUID,
+                    'WAZO_RING_TIME': ring_time,
                     'WAZO_VIDEO_ENABLED': '0',
                     'WAZO_TIMESTAMP': '2026-01-01T00:00:00.000+00:00',
                     'ConnectedLineName': '',
@@ -209,6 +195,7 @@ class TestDialMobile(RealAsteriskIntegrationTest):
             headers={'name': 'UserEvent'},
         )
 
+    def _wait_push_notification(self, push_events):
         def push_notification_sent():
             assert_that(
                 push_events.accumulate(),
@@ -221,17 +208,70 @@ class TestDialMobile(RealAsteriskIntegrationTest):
             message='Push notification event never published',
         )
 
-        # The PSTN fallback timer is max(10, 0.5 * 20) = 10 s.
-        # Wait until Asterisk has originated the Local/ring@local PSTN leg.
-        def pstn_channel_originated():
-            channels = self.ari.channels.list()
-            pstn = [
-                c for c in channels if c.json['name'].startswith('Local/ring@local')
-            ]
-            return pstn[0] if pstn else None
+    def _pstn_channels(self):
+        return [
+            c
+            for c in self.ari.channels.list()
+            if c.json['name'].startswith('Local/ring@local')
+        ]
 
+    def test_pstn_fallback_skipped_when_disabled(self):
+        # Regression test: when the user has mobile_fallback_enabled=False,
+        # the PSTN fallback must NOT originate a PSTN call when the timer fires.
+        line_id = 424242
+        self.confd.set_users(
+            MockUser(
+                uuid=_TEST_USER_UUID,
+                line_ids=[line_id],
+                mobile='ring',
+                mobile_fallback_enabled=False,
+                tenant_uuid=_TEST_TENANT_UUID,
+            )
+        )
+        self.confd.set_lines(
+            MockLine(id=line_id, context='local', tenant_uuid=_TEST_TENANT_UUID)
+        )
+
+        chan = self._start_dial_mobile_dial()
+        push_events = self.bus.accumulator(headers={'name': 'call_push_notification'})
+        self._publish_pushmobile(chan, f'test-pstn-disabled-{uuid4()}', ring_time='20')
+        self._wait_push_notification(push_events)
+
+        # PSTN timer fires at max(10, 0.5 * 20) = 10 s. Wait beyond that and
+        # verify no PSTN channel was ever originated.
+        time.sleep(12)
+        assert (
+            self._pstn_channels() == []
+        ), 'PSTN fallback originated a call despite mobile_fallback_enabled=False'
+
+        chan.hangup()
+
+    def test_caller_hangup_cancels_active_pstn_fallback(self):
+        # Regression test: once the PSTN fallback has fired and a PSTN channel
+        # is ringing, hanging up the caller must also hang up the PSTN channel.
+        line_id = 424242
+        self.confd.set_users(
+            MockUser(
+                uuid=_TEST_USER_UUID,
+                line_ids=[line_id],
+                mobile='ring',
+                mobile_fallback_enabled=True,
+                tenant_uuid=_TEST_TENANT_UUID,
+            )
+        )
+        self.confd.set_lines(
+            MockLine(id=line_id, context='local', tenant_uuid=_TEST_TENANT_UUID)
+        )
+
+        chan = self._start_dial_mobile_dial()
+        push_events = self.bus.accumulator(headers={'name': 'call_push_notification'})
+        self._publish_pushmobile(chan, f'test-pstn-hangup-{uuid4()}', ring_time='20')
+        self._wait_push_notification(push_events)
+
+        # PSTN timer fires at max(10, 0.5 * 20) = 10 s. Wait until the
+        # Local/ring@local PSTN leg is originated.
         pstn_channel = until.true(
-            pstn_channel_originated,
+            lambda: next(iter(self._pstn_channels()), None),
             timeout=15,
             message='PSTN fallback channel was never originated',
         )

--- a/integration_tests/suite/test_dial_mobile.py
+++ b/integration_tests/suite/test_dial_mobile.py
@@ -237,9 +237,10 @@ class TestDialMobile(RealAsteriskIntegrationTest):
         self._publish_pushmobile(chan, f'test-pstn-disabled-{uuid4()}', ring_time='20')
         self._wait_push_notification(push_events)
 
-        # PSTN timer fires at max(10, 0.5 * 20) = 10 s. Wait beyond that and
+        # PSTN timer fires at max(1.0, 0.05 * 20) = 1 s (integration-test
+        # override in conf.d/30-dial-mobile.yml). Wait beyond that and
         # verify no PSTN channel was ever originated.
-        time.sleep(12)
+        time.sleep(3)
         assert (
             self._pstn_channels() == []
         ), 'PSTN fallback originated a call despite mobile_fallback_enabled=False'
@@ -268,11 +269,11 @@ class TestDialMobile(RealAsteriskIntegrationTest):
         self._publish_pushmobile(chan, f'test-pstn-hangup-{uuid4()}', ring_time='20')
         self._wait_push_notification(push_events)
 
-        # PSTN timer fires at max(10, 0.5 * 20) = 10 s. Wait until the
-        # Local/ring@local PSTN leg is originated.
+        # PSTN timer fires at max(1.0, 0.05 * 20) = 1 s (integration-test
+        # override). Wait until the Local/ring@local PSTN leg is originated.
         pstn_channel = until.true(
             lambda: next(iter(self._pstn_channels()), None),
-            timeout=15,
+            timeout=5,
             message='PSTN fallback channel was never originated',
         )
 
@@ -317,10 +318,10 @@ class TestDialMobile(RealAsteriskIntegrationTest):
         )
         self._wait_push_notification(push_events)
 
-        # PSTN timer fires at max(10, 0.5 * 20) = 10 s. Bring confd down
-        # before then and wait past the timer window.
+        # PSTN timer fires at max(1.0, 0.05 * 20) = 1 s (integration-test
+        # override). Bring confd down before then and wait past the timer.
         with self.confd_stopped():
-            time.sleep(12)
+            time.sleep(3)
             assert cancel_events.accumulate() == [], (
                 'cancel_push_notification was published despite confd being '
                 'unavailable; the push should remain active when the fallback '
@@ -360,7 +361,7 @@ class TestDialMobile(RealAsteriskIntegrationTest):
         # Wait for the PSTN leg to be originated first.
         until.true(
             lambda: next(iter(self._pstn_channels()), None),
-            timeout=15,
+            timeout=5,
             message='PSTN fallback channel was never originated',
         )
 

--- a/integration_tests/suite/test_dial_mobile.py
+++ b/integration_tests/suite/test_dial_mobile.py
@@ -292,6 +292,44 @@ class TestDialMobile(RealAsteriskIntegrationTest):
             message='PSTN fallback channel was not hung up after caller hangup',
         )
 
+    def test_pstn_fallback_preserves_push_when_ari_unavailable(self):
+        # Regression test for ARI-side failure during the fallback commit:
+        # if ARI is unreachable when the timer fires, _pstn_fallback must
+        # abort cleanly (push left active, state → Cancelled) rather than
+        # silently dropping the call or leaving the Timer thread stuck.
+        line_id = 424242
+        self.confd.set_users(
+            MockUser(
+                uuid=_TEST_USER_UUID,
+                line_ids=[line_id],
+                mobile='ring',
+                mobile_fallback_enabled=True,
+                tenant_uuid=_TEST_TENANT_UUID,
+            )
+        )
+        self.confd.set_lines(
+            MockLine(id=line_id, context='local', tenant_uuid=_TEST_TENANT_UUID)
+        )
+
+        chan = self._start_dial_mobile_dial()
+        push_events = self.bus.accumulator(headers={'name': 'call_push_notification'})
+        cancel_events = self.bus.accumulator(
+            headers={'name': 'call_cancel_push_notification'}
+        )
+        self._publish_pushmobile(chan, f'test-pstn-ari-down-{uuid4()}', ring_time='20')
+        self._wait_push_notification(push_events)
+
+        # Stop ARI before the timer fires at max(10, 0.5 * 20) = 10 s, so
+        # the fallback commit hits an ARI-side failure. Wait past the timer
+        # window inside the stop scope.
+        with self.ari_stopped():
+            time.sleep(12)
+            assert cancel_events.accumulate() == [], (
+                'cancel_push_notification was published despite ARI being '
+                'unavailable; the push should remain active when the fallback '
+                'cannot dispatch a PSTN leg'
+            )
+
     def test_pstn_fallback_cancels_push_after_dispatch(self):
         line_id = 424242
         self.confd.set_users(

--- a/integration_tests/suite/test_dial_mobile.py
+++ b/integration_tests/suite/test_dial_mobile.py
@@ -379,3 +379,86 @@ class TestDialMobile(RealAsteriskIntegrationTest):
         )
 
         chan.hangup()
+
+    def test_cancel_push_via_dial_end_uses_linkedid(self):
+        # Regression test for the linkedid-keyed state invariant: the bus
+        # consumer's DialEnd handler looks up push state by event['Linkedid'].
+        # Internal state is now keyed by Linkedid too, so the lookup must
+        # succeed even when the Pushmobile event's Uniqueid differs from its
+        # Linkedid (the common production case, where Pushmobile is emitted
+        # from a Local;2 leg of a Dial).
+        chan = self._start_dial_mobile_dial()
+        push_events = self.bus.accumulator(headers={'name': 'call_push_notification'})
+        cancel_events = self.bus.accumulator(
+            headers={'name': 'call_cancel_push_notification'}
+        )
+
+        push_uniqueid = f'test-push-uniqueid-{uuid4()}'
+        # _publish_pushmobile sets Uniqueid=push_uniqueid, Linkedid=chan.id —
+        # deliberately distinct values.
+        self._publish_pushmobile(chan, push_uniqueid, ring_time='200')
+        self._wait_push_notification(push_events)
+
+        # Fake a DialEnd for the wazo_wait_for_registration dial that didn't
+        # answer. The bus consumer only reads DestContext, DialStatus, and
+        # Linkedid; the rest of the payload is padding to satisfy AMI
+        # deserialization.
+        self.bus.publish(
+            {
+                'data': {
+                    'Event': 'DialEnd',
+                    'DialStatus': 'NOANSWER',
+                    'DestContext': 'wazo_wait_for_registration',
+                    'Linkedid': chan.id,
+                    'Uniqueid': chan.id,
+                    'Channel': 'PJSIP/test-00000001',
+                    'DestChannel': ('Local/test@wazo_wait_for_registration-00000001;1'),
+                    'DestLinkedid': chan.id,
+                    'DestUniqueid': 'fake-dest-uniqueid',
+                    'CallerIDNum': '101',
+                    'CallerIDName': 'Alice',
+                    'ConnectedLineNum': '<unknown>',
+                    'ConnectedLineName': '<unknown>',
+                    'Context': 'user',
+                    'Exten': 's',
+                    'Priority': '1',
+                    'Language': 'en_US',
+                    'DestExten': 's',
+                    'DestPriority': '1',
+                    'DestLanguage': 'en_US',
+                    'DestCallerIDNum': 's',
+                    'DestCallerIDName': '<unknown>',
+                    'DestConnectedLineNum': '<unknown>',
+                    'DestConnectedLineName': '<unknown>',
+                    'ChannelState': '6',
+                    'ChannelStateDesc': 'Up',
+                    'DestChannelState': '5',
+                    'DestChannelStateDesc': 'Ringing',
+                    'ChanVariable': {},
+                    'DestChanVariable': {},
+                    'AccountCode': '',
+                    'DestAccountCode': '',
+                    'Privilege': 'call,all',
+                }
+            },
+            headers={'name': 'DialEnd'},
+        )
+
+        # The cancel-push event must be published — proving the linkedid-keyed
+        # lookup succeeded despite the Pushmobile's Uniqueid being different.
+        def push_notification_cancelled():
+            assert_that(
+                cancel_events.accumulate(),
+                has_item(has_entries(name='call_cancel_push_notification')),
+            )
+
+        until.assert_(
+            push_notification_cancelled,
+            timeout=5,
+            message=(
+                'cancel_push_notification was not published despite DialEnd '
+                'carrying the matching Linkedid'
+            ),
+        )
+
+        chan.hangup()

--- a/integration_tests/suite/test_dial_mobile.py
+++ b/integration_tests/suite/test_dial_mobile.py
@@ -7,12 +7,17 @@ from ari.exceptions import ARINotFound
 from hamcrest import assert_that, has_entries, has_item
 from wazo_test_helpers import until
 
+from .helpers.confd import MockLine, MockUser
 from .helpers.constants import ENDPOINT_AUTOANSWER
 from .helpers.real_asterisk import RealAsteriskIntegrationTest
 
 
 class TestDialMobile(RealAsteriskIntegrationTest):
     asset = 'real_asterisk'
+
+    def setUp(self):
+        super().setUp()
+        self.confd.reset()
 
     def test_that_dial_mobile_join_with_no_bridge_does_not_block(self):
         unknown_bridge_id = str(uuid4())
@@ -130,4 +135,119 @@ class TestDialMobile(RealAsteriskIntegrationTest):
             push_notification_cancelled,
             timeout=5,
             message='Push notification was not cancelled after caller hangup',
+        )
+
+    def test_caller_hangup_cancels_active_pstn_fallback(self):
+        # Regression test: once the PSTN fallback has fired and a PSTN channel
+        # is ringing, hanging up the caller must also hang up the PSTN channel.
+        user_uuid = 'eaa18a7f-3f49-419a-9abb-b445b8ba2e03'
+        tenant_uuid = 'some-tenant-uuid'
+        line_id = 424242
+        self.confd.set_users(
+            MockUser(
+                uuid=user_uuid,
+                line_ids=[line_id],
+                mobile='ring',
+                mobile_fallback_enabled=True,
+                tenant_uuid=tenant_uuid,
+            )
+        )
+        self.confd.set_lines(
+            MockLine(id=line_id, context='local', tenant_uuid=tenant_uuid)
+        )
+
+        chan = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app='dial_mobile',
+            appArgs=['dial', 'nonexistent-aor'],
+        )
+
+        def channel_is_up():
+            ch = self.ari.channels.get(channelId=chan.id)
+            assert ch.json['state'] == 'Up'
+
+        until.assert_(
+            channel_is_up, timeout=5, message='Channel never reached Up state'
+        )
+
+        push_events = self.bus.accumulator(headers={'name': 'call_push_notification'})
+        call_id = f'test-pstn-hangup-{uuid4()}'
+        self.bus.publish(
+            {
+                'data': {
+                    'UserEvent': 'Pushmobile',
+                    'Uniqueid': call_id,
+                    'Linkedid': chan.id,
+                    'ChanVariable': {
+                        'WAZO_USERUUID': user_uuid,
+                        'WAZO_TENANT_UUID': tenant_uuid,
+                        'WAZO_SIP_CALL_ID': 'de9eb39fb7585796',
+                        'XIVO_BASE_EXTEN': '8000',
+                        'WAZO_DEREFERENCED_USERUUID': '',
+                    },
+                    'CallerIDName': 'Alice',
+                    'CallerIDNum': '101',
+                    'Event': 'UserEvent',
+                    # WAZO_DST_UUID is read as user_uuid by the push handler.
+                    'WAZO_DST_UUID': user_uuid,
+                    'WAZO_RING_TIME': '20',
+                    'WAZO_VIDEO_ENABLED': '0',
+                    'WAZO_TIMESTAMP': '2026-01-01T00:00:00.000+00:00',
+                    'ConnectedLineName': '',
+                    'ConnectedLineNum': '',
+                    'Priority': '1',
+                    'ChannelStateDesc': 'Ring',
+                    'Language': 'en_US',
+                    'Exten': 's',
+                    'ChannelState': '4',
+                    'Channel': 'PJSIP/test-0000001',
+                    'Context': 'wazo-user-mobile-notification',
+                    'Privilege': 'user,all',
+                    'AccountCode': '',
+                }
+            },
+            headers={'name': 'UserEvent'},
+        )
+
+        def push_notification_sent():
+            assert_that(
+                push_events.accumulate(),
+                has_item(has_entries(name='call_push_notification')),
+            )
+
+        until.assert_(
+            push_notification_sent,
+            timeout=5,
+            message='Push notification event never published',
+        )
+
+        # The PSTN fallback timer is max(10, 0.5 * 20) = 10 s.
+        # Wait until Asterisk has originated the Local/ring@local PSTN leg.
+        def pstn_channel_originated():
+            channels = self.ari.channels.list()
+            pstn = [
+                c for c in channels if c.json['name'].startswith('Local/ring@local')
+            ]
+            return pstn[0] if pstn else None
+
+        pstn_channel = until.true(
+            pstn_channel_originated,
+            timeout=15,
+            message='PSTN fallback channel was never originated',
+        )
+
+        # Caller hangs up after the PSTN has been originated.
+        chan.hangup()
+
+        def pstn_channel_gone():
+            try:
+                self.ari.channels.get(channelId=pstn_channel.id)
+                return False
+            except ARINotFound:
+                return True
+
+        until.true(
+            pstn_channel_gone,
+            timeout=5,
+            message='PSTN fallback channel was not hung up after caller hangup',
         )

--- a/integration_tests/suite/test_dial_mobile.py
+++ b/integration_tests/suite/test_dial_mobile.py
@@ -291,3 +291,51 @@ class TestDialMobile(RealAsteriskIntegrationTest):
             timeout=5,
             message='PSTN fallback channel was not hung up after caller hangup',
         )
+
+    def test_pstn_fallback_cancels_push_after_dispatch(self):
+        line_id = 424242
+        self.confd.set_users(
+            MockUser(
+                uuid=_TEST_USER_UUID,
+                line_ids=[line_id],
+                mobile='ring',
+                mobile_fallback_enabled=True,
+                tenant_uuid=_TEST_TENANT_UUID,
+            )
+        )
+        self.confd.set_lines(
+            MockLine(id=line_id, context='local', tenant_uuid=_TEST_TENANT_UUID)
+        )
+
+        chan = self._start_dial_mobile_dial()
+        push_events = self.bus.accumulator(headers={'name': 'call_push_notification'})
+        cancel_events = self.bus.accumulator(
+            headers={'name': 'call_cancel_push_notification'}
+        )
+        self._publish_pushmobile(
+            chan, f'test-pstn-cancels-push-{uuid4()}', ring_time='20'
+        )
+        self._wait_push_notification(push_events)
+
+        # Wait for the PSTN leg to be originated first.
+        until.true(
+            lambda: next(iter(self._pstn_channels()), None),
+            timeout=15,
+            message='PSTN fallback channel was never originated',
+        )
+
+        # Cancel-push must have been published as part of the successful
+        # PSTN dispatch.
+        def push_notification_cancelled():
+            assert_that(
+                cancel_events.accumulate(),
+                has_item(has_entries(name='call_cancel_push_notification')),
+            )
+
+        until.assert_(
+            push_notification_cancelled,
+            timeout=5,
+            message='Push notification was not cancelled after PSTN dispatch',
+        )
+
+        chan.hangup()

--- a/wazo_calld/plugins/dial_mobile/bus_consume.py
+++ b/wazo_calld/plugins/dial_mobile/bus_consume.py
@@ -106,4 +106,5 @@ class EventHandler:
         if event['DialStatus'] == 'ANSWER':
             return
 
-        self._service.cancel_push_mobile(event['Uniqueid'])
+        # Internal state is keyed by the call's Linkedid.
+        self._service.cancel_push_mobile(event['Linkedid'])

--- a/wazo_calld/plugins/dial_mobile/bus_consume.py
+++ b/wazo_calld/plugins/dial_mobile/bus_consume.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2022-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -93,7 +93,7 @@ class EventHandler:
             return self._service.cancel_push_mobile(linkedid)
 
         if has_a_registered_mobile_and_pending_push:
-            self._service.remove_pending_push_mobile(linkedid)
+            self._service.complete_pending_push_mobile(linkedid)
         else:
             self._service.cancel_push_mobile(linkedid)
 

--- a/wazo_calld/plugins/dial_mobile/plugin.py
+++ b/wazo_calld/plugins/dial_mobile/plugin.py
@@ -1,10 +1,11 @@
-# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
 from wazo_amid_client import Client as AmidClient
 from wazo_auth_client import Client as AuthClient
+from wazo_confd_client import Client as ConfdClient
 from xivo.pubsub import CallbackCollector
 
 from wazo_calld.types import PluginDependencies
@@ -30,8 +31,13 @@ class Plugin:
         auth_client = AuthClient(**config['auth'])
         token_changed_subscribe(auth_client.set_token)
 
+        confd_client = ConfdClient(**config['confd'])
+        token_changed_subscribe(confd_client.set_token)
+
         notifier = Notifier(bus_publisher)
-        service = DialMobileService(ari, notifier, amid_client, auth_client)
+        service = DialMobileService(
+            ari, notifier, amid_client, auth_client, confd_client
+        )
         stasis = DialMobileStasis(ari, service)
         event_handler = EventHandler(service)
 

--- a/wazo_calld/plugins/dial_mobile/plugin.py
+++ b/wazo_calld/plugins/dial_mobile/plugin.py
@@ -12,7 +12,11 @@ from wazo_calld.types import PluginDependencies
 
 from .bus_consume import EventHandler
 from .notifier import Notifier
-from .services import DialMobileService
+from .services import (
+    DEFAULT_PSTN_FALLBACK_MIN_TIMEOUT,
+    DEFAULT_PSTN_FALLBACK_RING_TIMEOUT_FACTOR,
+    DialMobileService,
+)
 from .stasis import DialMobileStasis
 
 
@@ -34,9 +38,20 @@ class Plugin:
         confd_client = ConfdClient(**config['confd'])
         token_changed_subscribe(confd_client.set_token)
 
+        pstn_fallback_config = config.get('dial_mobile', {}).get('pstn_fallback', {})
         notifier = Notifier(bus_publisher)
         service = DialMobileService(
-            ari, notifier, amid_client, auth_client, confd_client
+            ari,
+            notifier,
+            amid_client,
+            auth_client,
+            confd_client,
+            pstn_fallback_min_timeout=pstn_fallback_config.get(
+                'min_timeout', DEFAULT_PSTN_FALLBACK_MIN_TIMEOUT
+            ),
+            pstn_fallback_ring_timeout_factor=pstn_fallback_config.get(
+                'ring_timeout_factor', DEFAULT_PSTN_FALLBACK_RING_TIMEOUT_FACTOR
+            ),
         )
         stasis = DialMobileStasis(ari, service)
         event_handler = EventHandler(service)

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -440,9 +440,6 @@ class DialMobileService:
             )
             return
 
-        # TODO: check user['mobile_fallback_enabled'] once DB column + confd field exist
-        # Hardcoded True for E2E testing without DB migration
-
         try:
             user = self._confd_client.users.get(
                 pending.user_uuid, tenant_uuid=pending.tenant_uuid
@@ -450,6 +447,13 @@ class DialMobileService:
         except (HTTPError, RequestException) as e:
             logger.error(
                 'PSTN fallback: cannot fetch user %s: %s', pending.user_uuid, e
+            )
+            return
+
+        if not user.get('mobile_fallback_enabled'):
+            logger.info(
+                'PSTN fallback: user %s has mobile fallback disabled, skipping',
+                pending.user_uuid,
             )
             return
 

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -9,14 +9,19 @@ from collections import namedtuple
 
 import requests
 from ari.exceptions import ARINotFound
+from requests import HTTPError, RequestException
 
 from wazo_calld.plugin_helpers.ari_ import Bridge
 
 logger = logging.getLogger(__name__)
 
 PendingPushMobile = namedtuple(
-    'PendingPushMobile', ['call_id', 'tenant_uuid', 'user_uuid', 'payload']
+    'PendingPushMobile',
+    ['call_id', 'tenant_uuid', 'user_uuid', 'origin_call_id', 'payload'],
 )
+
+PSTN_FALLBACK_MAX_TIMEOUT = 10.0
+PSTN_FALLBACK_RING_TIMEOUT_FACTOR = 0.5
 
 
 class _NoSuchChannel(Exception):
@@ -182,15 +187,20 @@ class _PollingContactDialer:
 
 
 class DialMobileService:
-    def __init__(self, ari, notifier, amid_client, auth_client):
+    def __init__(self, ari, notifier, amid_client, auth_client, confd_client):
         self._ari = ari.client
         self._auth_client = auth_client
         self._amid_client = amid_client
+        self._confd_client = confd_client
         self._contact_dialers = {}
         self._outgoing_calls = {}
         self._call_ring_time = {}
         self._pending_push_mobile = {}
         self._notifier = notifier
+        self._pstn_fallback_timers: dict[str, threading.Timer] = {}
+        self._origin_call_id_by_bridge_uuid: dict[str, str] = {}
+        self._bridge_uuid_by_origin_call_id: dict[str, str] = {}
+        self._call_id_by_origin_call_id: dict[str, str] = {}
 
     def find_bridge_by_exten_context(self, exten, context):
         pickup_mark = f'{exten}%{context}'
@@ -223,10 +233,19 @@ class DialMobileService:
         )
         self._contact_dialers[future_bridge_uuid] = dialer
         self._outgoing_calls[future_bridge_uuid] = caller_channel_id
+        self._origin_call_id_by_bridge_uuid[future_bridge_uuid] = origin_channel_id
+        self._bridge_uuid_by_origin_call_id[origin_channel_id] = future_bridge_uuid
         dialer.start()
 
     def join_bridge(self, channel_id, future_bridge_uuid):
         logger.info('%s is joining bridge %s', channel_id, future_bridge_uuid)
+        # cancel pstn fallback timer
+        if origin_call_id := self._origin_call_id_by_bridge_uuid.get(
+            future_bridge_uuid
+        ):
+            if call_id := self._call_id_by_origin_call_id.get(origin_call_id):
+                if timer := self._pstn_fallback_timers.pop(call_id, None):
+                    timer.cancel()
         dialer = self._contact_dialers.pop(future_bridge_uuid, None)
         logger.debug('Removing dialer: %s', str(dialer))
         if not dialer:
@@ -363,14 +382,27 @@ class DialMobileService:
             call_id,
             tenant_uuid,
             user_uuid,
+            origin_call_id,
             payload,
         )
 
         self._call_ring_time[origin_call_id] = ring_timeout
+        self._call_id_by_origin_call_id[origin_call_id] = call_id
+
+        # setup timer to trigger PSTN fallback mechanism
+        fallback_timeout = max(
+            PSTN_FALLBACK_MAX_TIMEOUT,
+            PSTN_FALLBACK_RING_TIMEOUT_FACTOR * int(ring_timeout),
+        )
+        timer = threading.Timer(fallback_timeout, self._pstn_fallback, args=[call_id])
+        self._pstn_fallback_timers[call_id] = timer
+        timer.start()
 
         self._notifier.push_notification(payload, tenant_uuid, user_uuid)
 
     def cancel_push_mobile(self, call_id):
+        if timer := self._pstn_fallback_timers.pop(call_id, None):
+            timer.cancel()
         pending_push = self._pending_push_mobile.pop(call_id, None)
         if not pending_push:
             return
@@ -383,6 +415,86 @@ class DialMobileService:
 
     def remove_pending_push_mobile(self, call_id):
         self._pending_push_mobile.pop(call_id, None)
+
+    def _pstn_fallback(self, call_id: str) -> None:
+        # fallback call to user's mobile number over PSTN if mobile wake up push still pending
+        pending = self._pending_push_mobile.get(call_id)
+        if not pending:
+            logger.info(
+                "no pending push for call_id %s, aborting PSTN fallback", call_id
+            )
+            return
+
+        # TODO: check user['mobile_fallback_enabled'] once DB column + confd field exist
+        # Hardcoded True for E2E testing without DB migration
+
+        try:
+            user = self._confd_client.users.get(
+                pending.user_uuid, tenant_uuid=pending.tenant_uuid
+            )
+        except (HTTPError, RequestException) as e:
+            logger.error(
+                'PSTN fallback: cannot fetch user %s: %s', pending.user_uuid, e
+            )
+            return
+
+        mobile_phone_number = user.get('mobile_phone_number')
+        if not mobile_phone_number:
+            logger.info(
+                'PSTN fallback: user %s has no mobile_phone_number, skipping',
+                pending.user_uuid,
+            )
+            return
+
+        lines = user.get('lines', [])
+        if not lines:
+            logger.warning(
+                'PSTN fallback: user %s has no lines, skipping', pending.user_uuid
+            )
+            return
+
+        try:
+            line = self._confd_client.lines.get(
+                lines[0]['id'], tenant_uuid=pending.tenant_uuid
+            )
+        except (HTTPError, RequestException) as e:
+            logger.error(
+                'PSTN fallback: cannot fetch line for user %s: %s', pending.user_uuid, e
+            )
+            return
+
+        user_context = line['context']
+
+        future_bridge_uuid = self._bridge_uuid_by_origin_call_id.get(
+            pending.origin_call_id
+        )
+        if not future_bridge_uuid:
+            logger.warning(
+                'PSTN fallback: no bridge found for call %s, skipping', call_id
+            )
+            return
+
+        caller_channel_id = self._outgoing_calls.get(future_bridge_uuid)
+        caller_id = '"{name}" <{number}>'.format(
+            name=pending.payload['peer_caller_id_name'],
+            number=pending.payload['peer_caller_id_number'],
+        )
+
+        logger.info(
+            'PSTN fallback: originating Local/%s@%s for user %s (call %s)',
+            mobile_phone_number,
+            user_context,
+            pending.user_uuid,
+            call_id,
+        )
+        self.cancel_push_mobile(call_id)
+        self._ari.channels.originate(
+            endpoint=f'Local/{mobile_phone_number}@{user_context}',
+            app='dial_mobile',
+            appArgs=['join', future_bridge_uuid],
+            callerId=caller_id,
+            originator=caller_channel_id,
+        )
 
     def has_a_registered_mobile_and_pending_push(
         self, push_call_id, call_id, endpoint, user_uuid

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -297,6 +297,14 @@ class DialMobileService:
         bridge.addChannel(channel=channel_id, inhibitConnectedLineUpdates=True)
         bridge.addChannel(channel=outgoing_channel_id, inhibitConnectedLineUpdates=True)
 
+    def _call_id_for_bridge(self, bridge_uuid: str) -> str | None:
+        origin_call_id = self._origin_call_id_by_bridge_uuid.get(bridge_uuid)
+        return (
+            self._call_id_by_origin_call_id.get(origin_call_id)
+            if origin_call_id
+            else None
+        )
+
     def notify_channel_gone(self, channel_id):
         to_remove = set()
 
@@ -311,6 +319,8 @@ class DialMobileService:
         for key in to_remove:
             logger.debug('Removing dialer: %s', str(self._contact_dialers[key]))
             del self._contact_dialers[key]
+            if call_id := self._call_id_for_bridge(key):
+                self.cancel_push_mobile(call_id)
 
     def clean_bridge(self, bridge_id):
         bridge_helper = Bridge(bridge_id, self._ari)

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -8,7 +8,7 @@ import uuid
 from collections import namedtuple
 
 import requests
-from ari.exceptions import ARINotFound
+from ari.exceptions import ARINotFound, ARIServerError
 from requests import HTTPError, RequestException
 
 from wazo_calld.plugin_helpers.ari_ import Bridge
@@ -220,9 +220,14 @@ class DialMobileService:
             future_bridge_uuid,
         )
         ringing_time = self._call_ring_time.get(origin_channel_id, 30)
-        pickup_mark = self._ari.channels.getChannelVar(
-            channelId=caller_channel_id, variable=f'PJSIP_ENDPOINT({aor},PICKUPMARK)'
-        )['value']
+        try:
+            pickup_mark = self._ari.channels.getChannelVar(
+                channelId=caller_channel_id,
+                variable=f'PJSIP_ENDPOINT({aor},PICKUPMARK)',
+            )['value']
+        except ARIServerError as e:
+            logger.warning('PJSIP_ENDPOINT(%s,PICKUPMARK) lookup failed: %s', aor, e)
+            pickup_mark = ''
         dialer = _PollingContactDialer(
             self._ari,
             future_bridge_uuid,

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -5,6 +5,7 @@ import logging
 import threading
 import time
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import requests
@@ -81,7 +82,14 @@ class _NoSuchChannel(Exception):
 
 class _PollingContactDialer:
     def __init__(
-        self, ari, future_bridge_uuid, channel_id, aor, ringing_time, pickup_mark
+        self,
+        ari,
+        future_bridge_uuid,
+        channel_id,
+        aor,
+        ringing_time,
+        pickup_mark,
+        on_contact_dialed: Callable[[], None] | None = None,
     ):
         self._ari = ari
         self.future_bridge_uuid = future_bridge_uuid
@@ -91,12 +99,13 @@ class _PollingContactDialer:
             target=self._run_no_exception,
             args=(channel_id, aor),
         )
-        self._called_contacts = set()
+        self._called_contacts: set[str] = set()
         self.is_running = False
-        self._dialed_channels = set()
+        self._dialed_channels: set = set()
         self._caller_channel_id = channel_id
         self._ringing_time = ringing_time
         self.pickup_mark = pickup_mark
+        self._on_contact_dialed = on_contact_dialed
 
         dialer_id = str(self)
 
@@ -185,6 +194,8 @@ class _PollingContactDialer:
         self.logger.debug('Dialed channel %s', channel.id)
         self._called_contacts.add(contact)
         self._dialed_channels.add(channel)
+        if self._on_contact_dialed is not None:
+            self._on_contact_dialed()
 
     def _remove_unanswered_channels(self):
         for channel in self._dialed_channels:
@@ -249,6 +260,7 @@ class DialMobileService:
         self._incoming_calls: dict[str, IncomingCall] = {}
         self._notifier = notifier
         self._pstn_fallback_timers: dict[str, threading.Timer] = {}
+        self._pstn_fallback_channels: dict[str, str] = {}
         self._origin_call_id_by_bridge_uuid: dict[str, str] = {}
         self._bridge_uuid_by_origin_call_id: dict[str, str] = {}
         self._call_id_by_origin_call_id: dict[str, str] = {}
@@ -279,6 +291,17 @@ class DialMobileService:
         except ARIServerError as e:
             logger.warning('PJSIP_ENDPOINT(%s,PICKUPMARK) lookup failed: %s', aor, e)
             pickup_mark = ''
+
+        def _on_contact_dialed() -> None:
+            # The mobile has registered and the SIP INVITE has been sent;
+            # the PSTN fallback is no longer needed.
+            if call_id := self._call_id_for_bridge(future_bridge_uuid):
+                logger.debug(
+                    'mobile contact dialed for call %s: cancelling PSTN fallback',
+                    call_id,
+                )
+                self._cancel_pstn_fallback(call_id)
+
         dialer = _PollingContactDialer(
             self._ari,
             future_bridge_uuid,
@@ -286,6 +309,7 @@ class DialMobileService:
             aor,
             ringing_time,
             pickup_mark,
+            on_contact_dialed=_on_contact_dialed,
         )
         self._contact_dialers[future_bridge_uuid] = dialer
         self._outgoing_calls[future_bridge_uuid] = caller_channel_id
@@ -297,8 +321,19 @@ class DialMobileService:
         logger.info('%s is joining bridge %s', channel_id, future_bridge_uuid)
         call_id = self._call_id_for_bridge(future_bridge_uuid)
         if call_id:
-            logger.debug('cancelling pstn fallback timer for call %s', call_id)
-            self._cancel_pstn_timer(call_id)
+            pstn_channel_id = self._pstn_fallback_channels.get(call_id)
+            if pstn_channel_id == channel_id:
+                # The PSTN-fallback call is itself answering and joining the
+                # bridge — clear timer and tracking but keep the channel.
+                logger.debug(
+                    'pstn fallback call %s joining bridge',
+                    call_id,
+                )
+                self._pstn_fallback_channels.pop(call_id, None)
+            else:
+                logger.debug('cancelling pstn fallback for call %s', call_id)
+                self._cancel_pstn_fallback(call_id)
+
         dialer = self._contact_dialers.pop(future_bridge_uuid, None)
         logger.debug('Removing dialer: %s', str(dialer))
         if not dialer:
@@ -375,6 +410,14 @@ class DialMobileService:
         )
 
     def notify_channel_gone(self, channel_id):
+        # Drop tracking for PSTN-fallback channels that have torn down
+        # on their own.
+        for tracked_call_id, pstn_channel_id in list(
+            self._pstn_fallback_channels.items()
+        ):
+            if pstn_channel_id == channel_id:
+                self._pstn_fallback_channels.pop(tracked_call_id, None)
+
         to_remove: list[tuple[str, bool]] = []
 
         for key, dialer in self._contact_dialers.items():
@@ -392,16 +435,16 @@ class DialMobileService:
             if call_id := self._call_id_for_bridge(key):
                 if is_caller_gone:
                     logger.debug(
-                        'Caller channel gone for call %s: cancelling PSTN timer',
+                        'Caller channel gone for call %s: cancelling PSTN fallback',
                         call_id,
                     )
                 else:
                     logger.debug(
                         'Dialed mobile contact gone for call %s: '
-                        'mobile was reachable, cancelling PSTN timer',
+                        'mobile was reachable, cancelling PSTN fallback',
                         call_id,
                     )
-                self._cancel_pstn_timer(call_id)
+                self._cancel_pstn_fallback(call_id)
                 self.cancel_push_mobile(call_id)
 
     def clean_bridge(self, bridge_id):
@@ -502,6 +545,14 @@ class DialMobileService:
     def _cancel_pstn_timer(self, call_id: str) -> None:
         if timer := self._pstn_fallback_timers.pop(call_id, None):
             timer.cancel()
+
+    def _cancel_pstn_fallback(self, call_id: str) -> None:
+        self._cancel_pstn_timer(call_id)
+        if pstn_channel_id := self._pstn_fallback_channels.pop(call_id, None):
+            try:
+                self._ari.channels.hangup(channelId=pstn_channel_id)
+            except ARINotFound:
+                pass
 
     def cancel_push_mobile(self, call_id: str) -> None:
         incoming_call = self._incoming_calls.pop(call_id, None)
@@ -617,7 +668,6 @@ class DialMobileService:
                 call_id,
             )
             return
-
         caller_id = '"{name}" <{number}>'.format(
             name=pending.payload['peer_caller_id_name'],
             number=pending.payload['peer_caller_id_number'],
@@ -631,7 +681,7 @@ class DialMobileService:
             call_id,
         )
         self.cancel_push_mobile(call_id)
-        self._ari.channels.originate(
+        pstn_channel = self._ari.channels.originate(
             endpoint=f'Local/{mobile_phone_number}@{user_context}',
             app='dial_mobile',
             appArgs=['join', future_bridge_uuid],
@@ -639,6 +689,7 @@ class DialMobileService:
             originator=caller_channel_id,
             variables={'variables': {'_WAZO_TENANT_UUID': pending.tenant_uuid}},
         )
+        self._pstn_fallback_channels[call_id] = pstn_channel.id
 
     def has_a_registered_mobile_and_pending_push(
         self, push_call_id, call_id, endpoint, user_uuid

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -543,10 +543,14 @@ class DialMobileService:
     def notify_channel_gone(self, channel_id):
         # If a PSTN-fallback channel has torn down on its own, transition
         # its state to Cancelled so it isn't double-hung-up later.
-        for tracked_call_id, state in list(self._pstn_fallbacks.items()):
-            match state:
-                case PSTNFallbackDialing(channel_id=cid) if cid == channel_id:
-                    self._pstn_fallbacks[tracked_call_id] = state.cancelled()
+        # Re-read the state under the per-call lock so we don't race with
+        # the timer thread or another cancellation path.
+        for tracked_call_id in list(self._pstn_fallbacks):
+            with self._incoming_call_lock(tracked_call_id):
+                state = self._pstn_fallbacks.get(tracked_call_id)
+                match state:
+                    case PSTNFallbackDialing(channel_id=cid) if cid == channel_id:
+                        self._pstn_fallbacks[tracked_call_id] = state.cancelled()
 
         to_remove: list[tuple[str, bool]] = []
 
@@ -684,8 +688,16 @@ class DialMobileService:
                 self._pstn_fallbacks[call_id] = PSTNFallbackPending(
                     call_id=call_id, timer=timer
                 )
+                logger.info(
+                    'call %s: Arming PSTN fallback timer with timeout=%d',
+                    origin_call_id,
+                    fallback_timeout,
+                )
                 timer.start()
 
+            logger.info(
+                'call %s: Sending incoming call push notification', origin_call_id
+            )
             self._notifier.push_notification(payload, tenant_uuid, user_uuid)
             self._incoming_calls[call_id] = pending.notified()
 
@@ -713,13 +725,27 @@ class DialMobileService:
         if lock is None:
             return
         with lock:
+            logger.info('cancelling PSTN fallback for call %s', call_id)
             match self._pstn_fallbacks.get(call_id):
-                case None | PSTNFallbackCancelled() | PSTNFallbackDialAnswered():
+                case None | PSTNFallbackCancelled() | PSTNFallbackDialAnswered() as state:
+                    logger.debug(
+                        'cancelling PSTN fallback for call %s while in terminal state (%s)',
+                        call_id,
+                        state,
+                    )
                     return
                 case PSTNFallbackPending(timer=timer) as current:
+                    logger.debug(
+                        'cancelling PSTN fallback for call %s while in pending state',
+                        call_id,
+                    )
                     timer.cancel()
                     self._pstn_fallbacks[call_id] = current.cancelled()
                 case PSTNFallbackDialing(channel_id=channel_id) as current:
+                    logger.debug(
+                        'cancelling PSTN fallback for call %s while in dialing state',
+                        call_id,
+                    )
                     self._hangup_pstn_channel(channel_id)
                     self._pstn_fallbacks[call_id] = current.cancelled()
                 case PSTNFallbackTriggering() as current:
@@ -727,7 +753,7 @@ class DialMobileService:
                     # confd lookups and channel checks. Marking the state
                     # Cancelled tells the Phase 3 re-check to abort.
                     logger.debug(
-                        'cancelling PSTN fallback for call %s while in ' 'Triggering',
+                        'cancelling PSTN fallback for call %s while in triggering state',
                         call_id,
                     )
                     self._pstn_fallbacks[call_id] = current.cancelled()
@@ -740,6 +766,7 @@ class DialMobileService:
 
     def cancel_push_mobile(self, call_id: str) -> None:
         with self._incoming_call_lock(call_id):
+            logger.info('call %s: cancelling mobile push', call_id)
             incoming_call = self._incoming_calls.get(call_id)
             match incoming_call:
                 case IncomingCallReceived() | IncomingCallPushCancelled():
@@ -749,6 +776,10 @@ class DialMobileService:
                         type(incoming_call).__name__,
                     )
                 case IncomingCallNotified():
+                    logger.debug(
+                        'call %s: push notification in flight, sending out cancel notification',
+                        call_id,
+                    )
                     self._notifier.cancel_push_notification(
                         incoming_call.payload,
                         incoming_call.tenant_uuid,
@@ -758,7 +789,7 @@ class DialMobileService:
                 case IncomingCallPending():
                     # Push not yet sent (very tight race during send_push_notification);
                     # record the cancellation without dispatching one.
-                    logger.info(
+                    logger.debug(
                         'cancel_push_mobile: push not yet sent for call %s, '
                         'recording cancellation',
                         call_id,
@@ -766,7 +797,7 @@ class DialMobileService:
                     self._incoming_calls[call_id] = incoming_call.push_cancelled()
                 case None:
                     logger.warning(
-                        'cancel_push_mobile: no incoming call for call_id %s',
+                        'cancel_push_mobile: no mobile push state for call_id %s',
                         call_id,
                     )
 
@@ -822,12 +853,13 @@ class DialMobileService:
         # Phase 1: transition Pending → Triggering atomically. From here
         # on, observers (e.g. `_cancel_pstn_fallback`) see Triggering.
         with lock:
+            logger.info('Triggering PSTN fallback for call %s', call_id)
             match self._pstn_fallbacks.get(call_id):
                 case PSTNFallbackPending() as current:
                     self._pstn_fallbacks[call_id] = current.triggering()
                 case _ as state:
                     logger.debug(
-                        'PSTN fallback for call %s not in Pending (got %s); '
+                        'PSTN fallback for call %s not in Pending state (%s); '
                         'aborting',
                         call_id,
                         type(state).__name__,

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -1,6 +1,7 @@
 # Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import contextlib
 import logging
 import threading
 import uuid
@@ -665,27 +666,28 @@ class DialMobileService:
             origin_call_id=origin_call_id,
             payload=payload,
         )
-        self._incoming_calls[call_id] = pending
+        lock = self._call_locks.setdefault(call_id, threading.RLock())
+        with lock:
+            self._incoming_calls[call_id] = pending
 
-        self._call_ring_time[origin_call_id] = ring_timeout
-        self._call_id_by_origin_call_id[origin_call_id] = call_id
+            self._call_ring_time[origin_call_id] = ring_timeout
+            self._call_id_by_origin_call_id[origin_call_id] = call_id
 
-        if self._pstn_fallback_eligible(user_uuid, tenant_uuid):
-            fallback_timeout = max(
-                PSTN_FALLBACK_MIN_TIMEOUT,
-                PSTN_FALLBACK_RING_TIMEOUT_FACTOR * int(ring_timeout),
-            )
-            timer = threading.Timer(
-                fallback_timeout, self._pstn_fallback, args=[call_id]
-            )
-            self._call_locks[call_id] = threading.RLock()
-            self._pstn_fallbacks[call_id] = PSTNFallbackPending(
-                call_id=call_id, timer=timer
-            )
-            timer.start()
+            if self._pstn_fallback_eligible(user_uuid, tenant_uuid):
+                fallback_timeout = max(
+                    PSTN_FALLBACK_MIN_TIMEOUT,
+                    PSTN_FALLBACK_RING_TIMEOUT_FACTOR * int(ring_timeout),
+                )
+                timer = threading.Timer(
+                    fallback_timeout, self._pstn_fallback, args=[call_id]
+                )
+                self._pstn_fallbacks[call_id] = PSTNFallbackPending(
+                    call_id=call_id, timer=timer
+                )
+                timer.start()
 
-        self._notifier.push_notification(payload, tenant_uuid, user_uuid)
-        self._incoming_calls[call_id] = pending.notified()
+            self._notifier.push_notification(payload, tenant_uuid, user_uuid)
+            self._incoming_calls[call_id] = pending.notified()
 
     def _pstn_fallback_eligible(self, user_uuid: str, tenant_uuid: str) -> bool:
         # Check user config once at push time so we don't arm a timer that
@@ -737,59 +739,70 @@ class DialMobileService:
             pass
 
     def cancel_push_mobile(self, call_id: str) -> None:
-        incoming_call = self._incoming_calls.get(call_id)
-        match incoming_call:
-            case IncomingCallReceived() | IncomingCallPushCancelled():
-                logger.debug(
-                    'cancel_push_mobile: call %s already terminal (%s)',
-                    call_id,
-                    type(incoming_call).__name__,
-                )
-            case IncomingCallNotified():
-                self._notifier.cancel_push_notification(
-                    incoming_call.payload,
-                    incoming_call.tenant_uuid,
-                    incoming_call.user_uuid,
-                )
-                self._incoming_calls[call_id] = incoming_call.push_cancelled()
-            case IncomingCallPending():
-                # Push not yet sent (very tight race during send_push_notification);
-                # record the cancellation without dispatching one.
-                logger.info(
-                    'cancel_push_mobile: push not yet sent for call %s, '
-                    'recording cancellation',
-                    call_id,
-                )
-                self._incoming_calls[call_id] = incoming_call.push_cancelled()
-            case None:
-                logger.warning(
-                    'cancel_push_mobile: no incoming call for call_id %s', call_id
-                )
+        with self._incoming_call_lock(call_id):
+            incoming_call = self._incoming_calls.get(call_id)
+            match incoming_call:
+                case IncomingCallReceived() | IncomingCallPushCancelled():
+                    logger.debug(
+                        'cancel_push_mobile: call %s already terminal (%s)',
+                        call_id,
+                        type(incoming_call).__name__,
+                    )
+                case IncomingCallNotified():
+                    self._notifier.cancel_push_notification(
+                        incoming_call.payload,
+                        incoming_call.tenant_uuid,
+                        incoming_call.user_uuid,
+                    )
+                    self._incoming_calls[call_id] = incoming_call.push_cancelled()
+                case IncomingCallPending():
+                    # Push not yet sent (very tight race during send_push_notification);
+                    # record the cancellation without dispatching one.
+                    logger.info(
+                        'cancel_push_mobile: push not yet sent for call %s, '
+                        'recording cancellation',
+                        call_id,
+                    )
+                    self._incoming_calls[call_id] = incoming_call.push_cancelled()
+                case None:
+                    logger.warning(
+                        'cancel_push_mobile: no incoming call for call_id %s',
+                        call_id,
+                    )
 
     def complete_pending_push_mobile(self, call_id: str) -> None:
-        incoming_call = self._incoming_calls.get(call_id)
-        match incoming_call:
-            case IncomingCallReceived():
-                pass
-            case IncomingCallPushCancelled():
-                logger.warning(
-                    'complete_pending_push_mobile: call %s was already cancelled',
-                    call_id,
-                )
-            case IncomingCallNotified():
-                self._incoming_calls[call_id] = incoming_call.received()
-            case IncomingCallPending():
-                logger.warning(
-                    'complete_pending_push_mobile: completing before push was '
-                    'sent for call %s',
-                    call_id,
-                )
-                self._incoming_calls[call_id] = incoming_call.notified().received()
-            case None:
-                logger.warning(
-                    'complete_pending_push_mobile: no incoming call for call_id %s',
-                    call_id,
-                )
+        with self._incoming_call_lock(call_id):
+            incoming_call = self._incoming_calls.get(call_id)
+            match incoming_call:
+                case IncomingCallReceived():
+                    pass
+                case IncomingCallPushCancelled():
+                    logger.warning(
+                        'complete_pending_push_mobile: call %s was already cancelled',
+                        call_id,
+                    )
+                case IncomingCallNotified():
+                    self._incoming_calls[call_id] = incoming_call.received()
+                case IncomingCallPending():
+                    logger.warning(
+                        'complete_pending_push_mobile: completing before push was '
+                        'sent for call %s',
+                        call_id,
+                    )
+                    self._incoming_calls[call_id] = incoming_call.notified().received()
+                case None:
+                    logger.warning(
+                        'complete_pending_push_mobile: no incoming call for call_id %s',
+                        call_id,
+                    )
+
+    def _incoming_call_lock(self, call_id: str):
+        # Returns the per-call RLock for serializing IncomingCall transitions,
+        # or a no-op context manager if the call is unknown (no entry was
+        # created, or the call was already pruned). The lock is created in
+        # `send_push_notification` and reused by the PSTN state machine.
+        lock = self._call_locks.get(call_id)
+        return lock if lock is not None else contextlib.nullcontext()
 
     def _pstn_fallback(self, call_id: str) -> None:
         """Timer-fired callback. Drives the fallback through:

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -3,7 +3,6 @@
 
 import logging
 import threading
-import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -106,6 +105,7 @@ class _PollingContactDialer:
         self._ringing_time = ringing_time
         self.pickup_mark = pickup_mark
         self._on_contact_dialed = on_contact_dialed
+        self._wakeup = threading.Event()
 
         dialer_id = str(self)
 
@@ -128,8 +128,13 @@ class _PollingContactDialer:
 
         self.logger.debug('Stopping')
         self.should_stop.set()
+        self._wakeup.set()
         self._thread.join()
         self.logger.debug('Stopped')
+
+    def kick(self) -> None:
+        """Wake the run loop to re-check contacts."""
+        self._wakeup.set()
 
     def _run_no_exception(self, *args, **kwargs):
         try:
@@ -141,15 +146,15 @@ class _PollingContactDialer:
         channel = self._ari.channels.get(channelId=channel_id)
         caller_id = '"{name}" <{number}>'.format(**channel.json['caller'])
 
-        while True:
-            contacts = self._get_contacts(channel_id, aor)
-            for contact in contacts:
-                if self.should_stop.is_set():
-                    break
+        # Initial check: contact may already be registered when the call lands.
+        self._dial_current_contacts(channel_id, aor, caller_id)
 
-                self._send_contact_to_current_call(
-                    contact, self.future_bridge_uuid, caller_id
-                )
+        while not self.should_stop.is_set():
+            self._wakeup.wait()
+            self._wakeup.clear()
+
+            if self.should_stop.is_set():
+                break
 
             if not self._channel_is_up(channel_id):
                 self.logger.debug(
@@ -157,15 +162,19 @@ class _PollingContactDialer:
                     channel_id,
                     self._thread.name,
                 )
-                self.should_stop.set()
                 break
 
-            if self.should_stop.is_set():
-                break
-
-            time.sleep(0.25)
+            self._dial_current_contacts(channel_id, aor, caller_id)
 
         self._remove_unanswered_channels()
+
+    def _dial_current_contacts(self, channel_id, aor, caller_id):
+        for contact in self._get_contacts(channel_id, aor):
+            if self.should_stop.is_set():
+                break
+            self._send_contact_to_current_call(
+                contact, self.future_bridge_uuid, caller_id
+            )
 
     def _channel_is_up(self, channel_id):
         try:
@@ -255,6 +264,7 @@ class DialMobileService:
         self._amid_client = amid_client
         self._confd_client = confd_client
         self._contact_dialers = {}
+        self._dialers_by_aor: dict[str, set[_PollingContactDialer]] = {}
         self._outgoing_calls = {}
         self._call_ring_time = {}
         self._incoming_calls: dict[str, IncomingCall] = {}
@@ -312,10 +322,21 @@ class DialMobileService:
             on_contact_dialed=_on_contact_dialed,
         )
         self._contact_dialers[future_bridge_uuid] = dialer
+        self._dialers_by_aor.setdefault(aor, set()).add(dialer)
         self._outgoing_calls[future_bridge_uuid] = caller_channel_id
         self._origin_call_id_by_bridge_uuid[future_bridge_uuid] = origin_channel_id
         self._bridge_uuid_by_origin_call_id[origin_channel_id] = future_bridge_uuid
         dialer.start()
+
+    def notify_contact_available(self, aor: str) -> None:
+        for dialer in self._dialers_by_aor.get(aor, set()):
+            dialer.kick()
+
+    def _unregister_dialer_by_aor(self, dialer: _PollingContactDialer) -> None:
+        for aor, dialers in list(self._dialers_by_aor.items()):
+            dialers.discard(dialer)
+            if not dialers:
+                self._dialers_by_aor.pop(aor, None)
 
     def join_bridge(self, channel_id, future_bridge_uuid):
         logger.info('%s is joining bridge %s', channel_id, future_bridge_uuid)
@@ -335,6 +356,8 @@ class DialMobileService:
                 self._cancel_pstn_fallback(call_id)
 
         dialer = self._contact_dialers.pop(future_bridge_uuid, None)
+        if dialer is not None:
+            self._unregister_dialer_by_aor(dialer)
         logger.debug('Removing dialer: %s', str(dialer))
         if not dialer:
             # No active dialer means the call was already cancelled or answered;
@@ -430,8 +453,10 @@ class DialMobileService:
                 to_remove.append((key, is_caller_gone))
 
         for key, is_caller_gone in to_remove:
-            logger.debug('Removing dialer: %s', str(self._contact_dialers[key]))
+            dialer = self._contact_dialers[key]
+            logger.debug('Removing dialer: %s', str(dialer))
             del self._contact_dialers[key]
+            self._unregister_dialer_by_aor(dialer)
             if call_id := self._call_id_for_bridge(key):
                 if is_caller_gone:
                     logger.debug(

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -889,6 +889,13 @@ class DialMobileService:
                     call_id,
                 )
                 raise _PSTNFallbackAbort from e
+            except (ARIServerError, HTTPError, RequestException) as e:
+                logger.exception(
+                    'PSTN fallback: caller channel lookup failed for call %s; '
+                    'leaving push active and fallback Cancelled',
+                    call_id,
+                )
+                raise _PSTNFallbackAbort from e
 
             caller_id = '"{name}" <{number}>'.format(
                 name=pending.payload['peer_caller_id_name'],

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -895,9 +895,7 @@ class DialMobileService:
                 number=pending.payload['peer_caller_id_number'],
             )
 
-            # Phase 3: commit (cancel-push + originate). Re-check the
-            # state under the lock — a racing cancel may have transitioned
-            # us to Cancelled during phase 2.
+            # Phase 3: commit (originate, then cancel push on success).
             with lock:
                 match self._pstn_fallbacks.get(call_id):
                     case PSTNFallbackTriggering() as triggering:
@@ -909,7 +907,6 @@ class DialMobileService:
                             pending.user_uuid,
                             call_id,
                         )
-                        self.cancel_push_mobile(call_id)
                         try:
                             pstn_channel = self._ari.channels.originate(
                                 endpoint=(
@@ -932,10 +929,11 @@ class DialMobileService:
                         ) as e:
                             logger.exception(
                                 'PSTN fallback: originate failed for call %s; '
-                                'leaving fallback Cancelled',
+                                'leaving push active and fallback Cancelled',
                                 call_id,
                             )
                             raise _PSTNFallbackAbort from e
+                        self.cancel_push_mobile(call_id)
                         self._pstn_fallbacks[call_id] = triggering.dialing(
                             pstn_channel.id
                         )

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -302,10 +302,31 @@ class DialMobileService:
         dialer = self._contact_dialers.pop(future_bridge_uuid, None)
         logger.debug('Removing dialer: %s', str(dialer))
         if not dialer:
+            # No active dialer means the call was already cancelled or answered;
+            # this channel arrived late and has no bridge to join — hang it up.
+            if call_id:
+                incoming = self._incoming_calls.get(call_id)
+                if incoming is not None:
+                    logger.warning(
+                        'join_bridge(channel_id=%s, future_bridge_uuid=%s): call %s: '
+                        'bridge has no dialer but push state is %s; '
+                        'hanging up late channel',
+                        channel_id,
+                        future_bridge_uuid,
+                        call_id,
+                        type(incoming).__name__,
+                    )
+                else:
+                    logger.debug(
+                        'join_bridge: bridge %s has no dialer, call %s already'
+                        ' cleaned up; hanging up late channel %s',
+                        future_bridge_uuid,
+                        call_id,
+                        channel_id,
+                    )
             try:
                 self._ari.channels.hangup(channelId=channel_id)
             except ARINotFound:
-                # If its already gone do nothing
                 pass
             return
 

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -7,6 +7,7 @@ import threading
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
 import requests
 from ari.exceptions import ARINotFound, ARIServerError
@@ -190,12 +191,12 @@ class _NoSuchChannel(Exception):
 class _ContactDialer:
     def __init__(
         self,
-        ari,
-        future_bridge_uuid,
-        channel_id,
-        aor,
-        ringing_time,
-        pickup_mark,
+        ari: Any,
+        future_bridge_uuid: str,
+        channel_id: str,
+        aor: str,
+        ringing_time: int,
+        pickup_mark: str,
         on_contact_dialed: Callable[[], None] | None = None,
     ):
         self._ari = ari

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -361,7 +361,6 @@ class DialMobileService:
         self._call_locks: dict[str, threading.RLock] = {}
         self._origin_call_id_by_bridge_uuid: dict[str, str] = {}
         self._bridge_uuid_by_origin_call_id: dict[str, str] = {}
-        self._call_id_by_origin_call_id: dict[str, str] = {}
 
     def find_bridge_by_exten_context(self, exten, context):
         pickup_mark = f'{exten}%{context}'
@@ -517,12 +516,7 @@ class DialMobileService:
             self._prune_call_state(future_bridge_uuid)
 
     def _call_id_for_bridge(self, bridge_uuid: str) -> str | None:
-        origin_call_id = self._origin_call_id_by_bridge_uuid.get(bridge_uuid)
-        return (
-            self._call_id_by_origin_call_id.get(origin_call_id)
-            if origin_call_id
-            else None
-        )
+        return self._origin_call_id_by_bridge_uuid.get(bridge_uuid)
 
     def _prune_call_state(self, future_bridge_uuid: str) -> None:
         # Tear down per-call indirection so the maps don't grow unbounded
@@ -532,12 +526,10 @@ class DialMobileService:
         )
         if origin_call_id is not None:
             self._bridge_uuid_by_origin_call_id.pop(origin_call_id, None)
-            call_id = self._call_id_by_origin_call_id.pop(origin_call_id, None)
             self._call_ring_time.pop(origin_call_id, None)
-            if call_id is not None:
-                self._pstn_fallbacks.pop(call_id, None)
-                self._call_locks.pop(call_id, None)
-                self._incoming_calls.pop(call_id, None)
+            self._pstn_fallbacks.pop(origin_call_id, None)
+            self._call_locks.pop(origin_call_id, None)
+            self._incoming_calls.pop(origin_call_id, None)
         self._caller_channel_leg_by_bridge.pop(future_bridge_uuid, None)
 
     def notify_channel_gone(self, channel_id):
@@ -670,12 +662,17 @@ class DialMobileService:
             origin_call_id=origin_call_id,
             payload=payload,
         )
-        lock = self._call_locks.setdefault(call_id, threading.RLock())
+        # Internal state is keyed by the call's linkedid (origin_call_id),
+        # not the Pushmobile-emitting channel's Uniqueid (call_id) — that
+        # way bus consumer paths that only know the linkedid (BridgeEnter,
+        # DialEnd) find the state they need to mutate. call_id is kept on
+        # the dataclass and in the payload because the mobile client uses
+        # it as the call identifier.
+        lock = self._call_locks.setdefault(origin_call_id, threading.RLock())
         with lock:
-            self._incoming_calls[call_id] = pending
+            self._incoming_calls[origin_call_id] = pending
 
             self._call_ring_time[origin_call_id] = ring_timeout
-            self._call_id_by_origin_call_id[origin_call_id] = call_id
 
             if self._pstn_fallback_eligible(user_uuid, tenant_uuid):
                 fallback_timeout = max(
@@ -683,10 +680,10 @@ class DialMobileService:
                     PSTN_FALLBACK_RING_TIMEOUT_FACTOR * int(ring_timeout),
                 )
                 timer = threading.Timer(
-                    fallback_timeout, self._pstn_fallback, args=[call_id]
+                    fallback_timeout, self._pstn_fallback, args=[origin_call_id]
                 )
-                self._pstn_fallbacks[call_id] = PSTNFallbackPending(
-                    call_id=call_id, timer=timer
+                self._pstn_fallbacks[origin_call_id] = PSTNFallbackPending(
+                    call_id=origin_call_id, timer=timer
                 )
                 logger.info(
                     'call %s: Arming PSTN fallback timer with timeout=%d',
@@ -699,7 +696,7 @@ class DialMobileService:
                 'call %s: Sending incoming call push notification', origin_call_id
             )
             self._notifier.push_notification(payload, tenant_uuid, user_uuid)
-            self._incoming_calls[call_id] = pending.notified()
+            self._incoming_calls[origin_call_id] = pending.notified()
 
     def _pstn_fallback_eligible(self, user_uuid: str, tenant_uuid: str) -> bool:
         # Check user config once at push time so we don't arm a timer that
@@ -803,6 +800,7 @@ class DialMobileService:
 
     def complete_pending_push_mobile(self, call_id: str) -> None:
         with self._incoming_call_lock(call_id):
+            logger.info('Completing mobile push flow for call %s', call_id)
             incoming_call = self._incoming_calls.get(call_id)
             match incoming_call:
                 case IncomingCallReceived():

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -106,7 +106,7 @@ class PSTNFallbackTriggering:
 
 @dataclass(eq=False)
 class PSTNFallbackDialing:
-    """PSTN leg has been originated; cancellation must hang it up."""
+    """PSTN leg has been originated, pending answer from destination"""
 
     call_id: str
     channel_id: str
@@ -123,8 +123,7 @@ class PSTNFallbackDialing:
 @dataclass(eq=False)
 class PSTNFallbackDialAnswered:
     """Terminal — the PSTN leg answered and joined the bridge with the
-    caller. Unlike `Cancelled`, this is a success path: the call is
-    live."""
+    caller."""
 
     call_id: str
     channel_id: str
@@ -135,6 +134,12 @@ class PSTNFallbackCancelled:
     """Terminal — fallback was cancelled or completed without dialing."""
 
     call_id: str
+
+
+class _PSTNFallbackAbort(Exception):
+    """Internal control-flow signal: raised inside `_pstn_fallback` for
+    any early exit from the slow path so the surrounding `except`
+    transitions Triggering → Cancelled."""
 
 
 PSTNFallback = (
@@ -716,13 +721,11 @@ class DialMobileService:
                     self._hangup_pstn_channel(channel_id)
                     self._pstn_fallbacks[call_id] = current.cancelled()
                 case PSTNFallbackTriggering() as current:
-                    # `_pstn_fallback` always exits its lock-held section
-                    # in either `Dialing` (success) or `Cancelled`
-                    # (originate raised) — never `Triggering`. If we see
-                    # this, the commit-path invariant has been broken.
-                    logger.error(
-                        'PSTN fallback for call %s observed in Triggering '
-                        'state at cancellation; forcing Cancelled.',
+                    # `_pstn_fallback` is in its (lock-free) Phase 2 —
+                    # confd lookups and channel checks. Marking the state
+                    # Cancelled tells the Phase 3 re-check to abort.
+                    logger.debug(
+                        'cancelling PSTN fallback for call %s while in ' 'Triggering',
                         call_id,
                     )
                     self._pstn_fallbacks[call_id] = current.cancelled()
@@ -775,148 +778,189 @@ class DialMobileService:
         self.complete_pending_push_mobile(call_id)
 
     def _pstn_fallback(self, call_id: str) -> None:
-        """Timer-fired callback. Drives the fallback through its state
-        machine: Pending → Triggering → Dialing (or → Cancelled if a
-        racing cancel arrives before the lock is acquired)."""
-        match self._pstn_fallbacks.get(call_id):
-            case PSTNFallbackPending():
-                pass
-            case _ as state:
-                # Already cancelled, or the entry was never armed.
-                logger.warning(
-                    'pstn fallback triggered while not in pending state (%s), aborting',
-                    state,
-                )
-                return
+        """Timer-fired callback. Drives the fallback through:
+        Pending → Triggering (early) → Dialing on success, or
+        → Cancelled on any preliminary failure / originate failure /
+        racing cancel.
+        """
         lock = self._call_locks.get(call_id)
         if lock is None:
-            logger.warning('pstn fallback triggered but lock not available, aborting')
-            return
-
-        pending = self._incoming_calls.get(call_id)
-        if not pending:
-            logger.info(
-                "no pending push for call_id %s, aborting PSTN fallback", call_id
-            )
-            return
-
-        try:
-            user = self._confd_client.users.get(
-                pending.user_uuid, tenant_uuid=pending.tenant_uuid
-            )
-        except (HTTPError, RequestException) as e:
-            logger.error(
-                'PSTN fallback: cannot fetch user %s: %s', pending.user_uuid, e
-            )
-            return
-
-        if not user.get('mobile_fallback_enabled'):
-            logger.info(
-                'PSTN fallback: user %s has mobile fallback disabled, skipping',
-                pending.user_uuid,
-            )
-            return
-
-        mobile_phone_number = user.get('mobile_phone_number')
-        if not mobile_phone_number:
-            logger.info(
-                'PSTN fallback: user %s has no mobile_phone_number, skipping',
-                pending.user_uuid,
-            )
-            return
-
-        lines = user.get('lines', [])
-        if not lines:
             logger.warning(
-                'PSTN fallback: user %s has no lines, skipping',
-                pending.user_uuid,
-            )
-            return
-
-        try:
-            line = self._confd_client.lines.get(
-                lines[0]['id'], tenant_uuid=pending.tenant_uuid
-            )
-        except (HTTPError, RequestException) as e:
-            logger.error(
-                'PSTN fallback: cannot fetch line for user %s: %s',
-                pending.user_uuid,
-                e,
-            )
-            return
-
-        user_context = line['context']
-
-        future_bridge_uuid = self._bridge_uuid_by_origin_call_id.get(
-            pending.origin_call_id
-        )
-        if not future_bridge_uuid:
-            logger.warning(
-                'PSTN fallback: no bridge found for call %s, skipping', call_id
-            )
-            return
-
-        caller_channel_id = self._caller_channel_leg_by_bridge.get(future_bridge_uuid)
-        try:
-            self._ari.channels.get(channelId=caller_channel_id)
-        except ARINotFound:
-            logger.info(
-                'PSTN fallback: caller channel %s already gone for call %s, '
-                'skipping',
-                caller_channel_id,
+                'PSTN fallback timer fired for call %s but no lock available, '
+                'aborting',
                 call_id,
             )
             return
 
-        caller_id = '"{name}" <{number}>'.format(
-            name=pending.payload['peer_caller_id_name'],
-            number=pending.payload['peer_caller_id_number'],
-        )
-
-        # Commit step. The per-call lock serialises against
-        # `_cancel_pstn_fallback`. Inside the lock we re-read the state:
-        # a racing cancellation may have transitioned us to Cancelled.
-        # The commit always lands on `Dialing` (success) or `Cancelled`
-        # (originate failed) before the lock is released — so no observer
-        # ever sees a lingering `Triggering`.
+        # Phase 1: transition Pending → Triggering atomically. From here
+        # on, observers (e.g. `_cancel_pstn_fallback`) see Triggering.
         with lock:
             match self._pstn_fallbacks.get(call_id):
                 case PSTNFallbackPending() as current:
-                    triggering = current.triggering()
-                    self._pstn_fallbacks[call_id] = triggering
-                case _:
+                    self._pstn_fallbacks[call_id] = current.triggering()
+                case _ as state:
                     logger.debug(
-                        'PSTN fallback cancelled for call %s; not originating',
+                        'PSTN fallback for call %s not in Pending (got %s); '
+                        'aborting',
                         call_id,
+                        type(state).__name__,
                     )
                     return
 
-            logger.info(
-                'PSTN fallback: originating Local/%s@%s for user %s (call %s)',
-                mobile_phone_number,
-                user_context,
-                pending.user_uuid,
-                call_id,
-            )
-            self.cancel_push_mobile(call_id)
-            try:
-                pstn_channel = self._ari.channels.originate(
-                    endpoint=f'Local/{mobile_phone_number}@{user_context}',
-                    app='dial_mobile',
-                    appArgs=['join', future_bridge_uuid],
-                    callerId=caller_id,
-                    originator=caller_channel_id,
-                    variables={'variables': {'_WAZO_TENANT_UUID': pending.tenant_uuid}},
-                )
-            except (ARIServerError, HTTPError, RequestException):
-                logger.exception(
-                    'PSTN fallback: originate failed for call %s; '
-                    'leaving fallback Cancelled',
+        # Phase 2: slow path (confd lookups, channel checks). No lock
+        # held; state is observably Triggering. Any early exit raises
+        # `_PSTNFallbackAbort`, which the handler turns into a
+        # Triggering → Cancelled transition.
+        try:
+            pending = self._incoming_calls.get(call_id)
+            if not pending:
+                logger.info(
+                    "no pending push for call_id %s, aborting PSTN fallback",
                     call_id,
                 )
-                self._pstn_fallbacks[call_id] = triggering.cancelled()
-                return
-            self._pstn_fallbacks[call_id] = triggering.dialing(pstn_channel.id)
+                raise _PSTNFallbackAbort
+
+            try:
+                user = self._confd_client.users.get(
+                    pending.user_uuid, tenant_uuid=pending.tenant_uuid
+                )
+            except (HTTPError, RequestException) as e:
+                logger.error(
+                    'PSTN fallback: cannot fetch user %s: %s',
+                    pending.user_uuid,
+                    e,
+                )
+                raise _PSTNFallbackAbort from e
+
+            if not user.get('mobile_fallback_enabled'):
+                logger.info(
+                    'PSTN fallback: user %s has mobile fallback disabled, skipping',
+                    pending.user_uuid,
+                )
+                raise _PSTNFallbackAbort
+
+            mobile_phone_number = user.get('mobile_phone_number')
+            if not mobile_phone_number:
+                logger.info(
+                    'PSTN fallback: user %s has no mobile_phone_number, skipping',
+                    pending.user_uuid,
+                )
+                raise _PSTNFallbackAbort
+
+            lines = user.get('lines', [])
+            if not lines:
+                logger.warning(
+                    'PSTN fallback: user %s has no lines, skipping',
+                    pending.user_uuid,
+                )
+                raise _PSTNFallbackAbort
+
+            try:
+                line = self._confd_client.lines.get(
+                    lines[0]['id'], tenant_uuid=pending.tenant_uuid
+                )
+            except (HTTPError, RequestException) as e:
+                logger.error(
+                    'PSTN fallback: cannot fetch line for user %s: %s',
+                    pending.user_uuid,
+                    e,
+                )
+                raise _PSTNFallbackAbort from e
+
+            user_context = line['context']
+
+            future_bridge_uuid = self._bridge_uuid_by_origin_call_id.get(
+                pending.origin_call_id
+            )
+            if not future_bridge_uuid:
+                logger.warning(
+                    'PSTN fallback: no bridge found for call %s, skipping',
+                    call_id,
+                )
+                raise _PSTNFallbackAbort
+
+            caller_channel_id = self._caller_channel_leg_by_bridge.get(
+                future_bridge_uuid
+            )
+            try:
+                self._ari.channels.get(channelId=caller_channel_id)
+            except ARINotFound as e:
+                logger.info(
+                    'PSTN fallback: caller channel %s already gone for call %s, '
+                    'skipping',
+                    caller_channel_id,
+                    call_id,
+                )
+                raise _PSTNFallbackAbort from e
+
+            caller_id = '"{name}" <{number}>'.format(
+                name=pending.payload['peer_caller_id_name'],
+                number=pending.payload['peer_caller_id_number'],
+            )
+
+            # Phase 3: commit (cancel-push + originate). Re-check the
+            # state under the lock — a racing cancel may have transitioned
+            # us to Cancelled during phase 2.
+            with lock:
+                match self._pstn_fallbacks.get(call_id):
+                    case PSTNFallbackTriggering() as triggering:
+                        logger.info(
+                            'PSTN fallback: originating Local/%s@%s for user %s '
+                            '(call %s)',
+                            mobile_phone_number,
+                            user_context,
+                            pending.user_uuid,
+                            call_id,
+                        )
+                        self.cancel_push_mobile(call_id)
+                        try:
+                            pstn_channel = self._ari.channels.originate(
+                                endpoint=(
+                                    f'Local/{mobile_phone_number}@{user_context}'
+                                ),
+                                app='dial_mobile',
+                                appArgs=['join', future_bridge_uuid],
+                                callerId=caller_id,
+                                originator=caller_channel_id,
+                                variables={
+                                    'variables': {
+                                        '_WAZO_TENANT_UUID': pending.tenant_uuid
+                                    }
+                                },
+                            )
+                        except (
+                            ARIServerError,
+                            HTTPError,
+                            RequestException,
+                        ) as e:
+                            logger.exception(
+                                'PSTN fallback: originate failed for call %s; '
+                                'leaving fallback Cancelled',
+                                call_id,
+                            )
+                            raise _PSTNFallbackAbort from e
+                        self._pstn_fallbacks[call_id] = triggering.dialing(
+                            pstn_channel.id
+                        )
+                    case _ as state:
+                        logger.debug(
+                            'PSTN fallback for call %s no longer in Triggering '
+                            '(got %s); not originating',
+                            call_id,
+                            type(state).__name__,
+                        )
+        except _PSTNFallbackAbort:
+            # Transition Triggering → Cancelled if we still own that state.
+            with lock:
+                match self._pstn_fallbacks.get(call_id):
+                    case PSTNFallbackTriggering() as triggering:
+                        self._pstn_fallbacks[call_id] = triggering.cancelled()
+                    case _ as state:
+                        # already cancelled
+                        logger.debug(
+                            'PSTN fallback aborted but state already %s', state
+                        )
+                        return
 
     def has_a_registered_mobile_and_pending_push(
         self, push_call_id, call_id, endpoint, user_uuid

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -47,8 +47,14 @@ class IncomingCallPending:
 
 
 @dataclass
-class IncomingCallNotified(IncomingCallPending):
+class IncomingCallNotified:
     """Push sent; waiting for mobile app to register and answer"""
+
+    call_id: str
+    tenant_uuid: str
+    user_uuid: str
+    origin_call_id: str
+    payload: dict
 
     def received(self) -> 'IncomingCallReceived':
         return IncomingCallReceived(
@@ -59,15 +65,36 @@ class IncomingCallNotified(IncomingCallPending):
             payload=self.payload,
         )
 
+    def push_cancelled(self) -> 'IncomingCallPushCancelled':
+        return IncomingCallPushCancelled(
+            call_id=self.call_id,
+            tenant_uuid=self.tenant_uuid,
+            user_uuid=self.user_uuid,
+            origin_call_id=self.origin_call_id,
+            payload=self.payload,
+        )
+
 
 @dataclass
-class IncomingCallReceived(IncomingCallNotified):
+class IncomingCallReceived:
     """Mobile answered the call — terminal, no push cancellation sent"""
 
+    call_id: str
+    tenant_uuid: str
+    user_uuid: str
+    origin_call_id: str
+    payload: dict
+
 
 @dataclass
-class IncomingCallPushCancelled(IncomingCallPending):
+class IncomingCallPushCancelled:
     """Terminal: the mobile push attempt has been abandoned"""
+
+    call_id: str
+    tenant_uuid: str
+    user_uuid: str
+    origin_call_id: str
+    payload: dict
 
 
 IncomingCall = (
@@ -662,19 +689,30 @@ class DialMobileService:
             origin_call_id=origin_call_id,
             payload=payload,
         )
-        # Internal state is keyed by the call's linkedid (origin_call_id),
-        # not the Pushmobile-emitting channel's Uniqueid (call_id) — that
-        # way bus consumer paths that only know the linkedid (BridgeEnter,
-        # DialEnd) find the state they need to mutate. call_id is kept on
-        # the dataclass and in the payload because the mobile client uses
-        # it as the call identifier.
         lock = self._call_locks.setdefault(origin_call_id, threading.RLock())
         with lock:
             self._incoming_calls[origin_call_id] = pending
 
             self._call_ring_time[origin_call_id] = ring_timeout
 
-            if self._pstn_fallback_eligible(user_uuid, tenant_uuid):
+        pstn_fallback_enabled = self._pstn_fallback_eligible(user_uuid, tenant_uuid)
+        with lock:
+            match self._incoming_calls.get(origin_call_id):
+                case IncomingCallPending():
+                    logger.info(
+                        'call %s: Sending incoming call push notification',
+                        origin_call_id,
+                    )
+                    self._notifier.push_notification(payload, tenant_uuid, user_uuid)
+                    self._incoming_calls[origin_call_id] = pending.notified()
+                case _:
+                    logger.info(
+                        'call %s cancelled before sending out push notification, aborting',
+                        origin_call_id,
+                    )
+                    return
+
+            if pstn_fallback_enabled:
                 fallback_timeout = max(
                     PSTN_FALLBACK_MIN_TIMEOUT,
                     PSTN_FALLBACK_RING_TIMEOUT_FACTOR * int(ring_timeout),
@@ -691,12 +729,6 @@ class DialMobileService:
                     fallback_timeout,
                 )
                 timer.start()
-
-            logger.info(
-                'call %s: Sending incoming call push notification', origin_call_id
-            )
-            self._notifier.push_notification(payload, tenant_uuid, user_uuid)
-            self._incoming_calls[origin_call_id] = pending.notified()
 
     def _pstn_fallback_eligible(self, user_uuid: str, tenant_uuid: str) -> bool:
         # Check user config once at push time so we don't arm a timer that

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -244,13 +244,9 @@ class DialMobileService:
 
     def join_bridge(self, channel_id, future_bridge_uuid):
         logger.info('%s is joining bridge %s', channel_id, future_bridge_uuid)
-        # cancel pstn fallback timer
-        if origin_call_id := self._origin_call_id_by_bridge_uuid.get(
-            future_bridge_uuid
-        ):
-            if call_id := self._call_id_by_origin_call_id.get(origin_call_id):
-                if timer := self._pstn_fallback_timers.pop(call_id, None):
-                    timer.cancel()
+        call_id = self._call_id_for_bridge(future_bridge_uuid)
+        if call_id:
+            self._cancel_pstn_timer(call_id)
         dialer = self._contact_dialers.pop(future_bridge_uuid, None)
         logger.debug('Removing dialer: %s', str(dialer))
         if not dialer:
@@ -259,7 +255,8 @@ class DialMobileService:
             except ARINotFound:
                 # If its already gone do nothing
                 pass
-            self.cancel_push_mobile(channel_id)
+            if call_id:
+                self.cancel_push_mobile(call_id)
             return
 
         dialer.stop()
@@ -276,7 +273,8 @@ class DialMobileService:
             except ARINotFound:
                 # If its already gone do nothing
                 pass
-            self.cancel_push_mobile(channel_id)
+            if call_id:
+                self.cancel_push_mobile(call_id)
             return
 
         try:
@@ -306,7 +304,7 @@ class DialMobileService:
         )
 
     def notify_channel_gone(self, channel_id):
-        to_remove = set()
+        to_remove: list[tuple[str, bool]] = []
 
         for key, dialer in self._contact_dialers.items():
             try:
@@ -314,12 +312,25 @@ class DialMobileService:
             except _NoSuchChannel:
                 continue
             else:
-                to_remove.add(key)
+                is_caller_gone = channel_id == dialer._caller_channel_id
+                to_remove.append((key, is_caller_gone))
 
-        for key in to_remove:
+        for key, is_caller_gone in to_remove:
             logger.debug('Removing dialer: %s', str(self._contact_dialers[key]))
             del self._contact_dialers[key]
             if call_id := self._call_id_for_bridge(key):
+                if is_caller_gone:
+                    logger.debug(
+                        'Caller channel gone for call %s: cancelling PSTN timer',
+                        call_id,
+                    )
+                else:
+                    logger.debug(
+                        'Dialed mobile contact gone for call %s: '
+                        'mobile was reachable, cancelling PSTN timer',
+                        call_id,
+                    )
+                self._cancel_pstn_timer(call_id)
                 self.cancel_push_mobile(call_id)
 
     def clean_bridge(self, bridge_id):
@@ -415,9 +426,11 @@ class DialMobileService:
 
         self._notifier.push_notification(payload, tenant_uuid, user_uuid)
 
-    def cancel_push_mobile(self, call_id):
+    def _cancel_pstn_timer(self, call_id: str) -> None:
         if timer := self._pstn_fallback_timers.pop(call_id, None):
             timer.cancel()
+
+    def cancel_push_mobile(self, call_id: str) -> None:
         pending_push = self._pending_push_mobile.pop(call_id, None)
         if not pending_push:
             return
@@ -433,6 +446,7 @@ class DialMobileService:
 
     def _pstn_fallback(self, call_id: str) -> None:
         # fallback call to user's mobile number over PSTN if mobile wake up push still pending
+        self._pstn_fallback_timers.pop(call_id, None)  # timer fired; remove stale ref
         pending = self._pending_push_mobile.get(call_id)
         if not pending:
             logger.info(

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -164,8 +164,10 @@ class _PollingContactDialer:
                 )
                 break
 
+            self.logger.debug('woke up for new contacts')
             self._dial_current_contacts(channel_id, aor, caller_id)
 
+        self.logger.debug('Interrupted run loop')
         self._remove_unanswered_channels()
 
     def _dial_current_contacts(self, channel_id, aor, caller_id):
@@ -329,6 +331,7 @@ class DialMobileService:
         dialer.start()
 
     def notify_contact_available(self, aor: str) -> None:
+        logger.debug('new contact available for monitored aor %s', aor)
         for dialer in self._dialers_by_aor.get(aor, set()):
             dialer.kick()
 

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -440,10 +440,11 @@ class DialMobileService:
                     self._cancel_pstn_fallback(call_id)
 
         dialer = self._contact_dialers.pop(future_bridge_uuid, None)
-        if dialer is not None:
+        if dialer:
+            logger.debug('Removing dialer: %s', str(dialer))
             self._unregister_dialer_by_aor(dialer)
-        logger.debug('Removing dialer: %s', str(dialer))
-        if not dialer:
+            dialer.stop()
+        else:
             # No active dialer means the call was already cancelled or answered;
             # this channel arrived late and has no bridge to join — hang it up.
             if call_id:
@@ -472,7 +473,6 @@ class DialMobileService:
                 pass
             return
 
-        dialer.stop()
         outgoing_channel_id = self._outgoing_calls.get(future_bridge_uuid)
         try:
             try:

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -71,6 +71,89 @@ class IncomingCallCancelled(IncomingCallNotified):
 
 IncomingCall = IncomingCallPending | IncomingCallNotified
 
+
+@dataclass(eq=False)
+class PSTNFallbackPending:
+    """Timer armed; PSTN fallback may fire when it expires."""
+
+    call_id: str
+    timer: threading.Timer
+    lock: threading.Lock
+
+    def triggering(self) -> 'PSTNFallbackTriggering':
+        return PSTNFallbackTriggering(call_id=self.call_id, lock=self.lock)
+
+    def cancelled(self) -> 'PSTNFallbackCancelled':
+        return PSTNFallbackCancelled(call_id=self.call_id)
+
+
+@dataclass(eq=False)
+class PSTNFallbackTriggering:
+    """Timer fired; commit (cancel-push + originate) in flight.
+
+    The lock is held by `_pstn_fallback` during this state, so external
+    observers (`_cancel_pstn_fallback`) block until commit completes.
+    """
+
+    call_id: str
+    lock: threading.Lock
+
+    def dialing(self, channel_id: str) -> 'PSTNFallbackDialing':
+        return PSTNFallbackDialing(
+            call_id=self.call_id, channel_id=channel_id, lock=self.lock
+        )
+
+    def cancelled(self) -> 'PSTNFallbackCancelled':
+        return PSTNFallbackCancelled(call_id=self.call_id)
+
+
+@dataclass(eq=False)
+class PSTNFallbackDialing:
+    """PSTN leg has been originated; cancellation must hang it up.
+
+    Still carries the per-call state lock so `_cancel_pstn_fallback`
+    can acquire the same lock for any non-terminal state.
+    """
+
+    call_id: str
+    channel_id: str
+    lock: threading.Lock
+
+    def answered(self) -> 'PSTNFallbackDialAnswered':
+        return PSTNFallbackDialAnswered(
+            call_id=self.call_id, channel_id=self.channel_id
+        )
+
+    def cancelled(self) -> 'PSTNFallbackCancelled':
+        return PSTNFallbackCancelled(call_id=self.call_id)
+
+
+@dataclass(eq=False)
+class PSTNFallbackDialAnswered:
+    """Terminal — the PSTN leg answered and joined the bridge with the
+    caller. Unlike `Cancelled`, this is a success path: the call is
+    live."""
+
+    call_id: str
+    channel_id: str
+
+
+@dataclass(eq=False)
+class PSTNFallbackCancelled:
+    """Terminal — fallback was cancelled or completed without dialing."""
+
+    call_id: str
+
+
+PSTNFallback = (
+    PSTNFallbackPending
+    | PSTNFallbackTriggering
+    | PSTNFallbackDialing
+    | PSTNFallbackDialAnswered
+    | PSTNFallbackCancelled
+)
+
+
 PSTN_FALLBACK_MIN_TIMEOUT = 10.0
 PSTN_FALLBACK_RING_TIMEOUT_FACTOR = 0.5
 
@@ -271,12 +354,7 @@ class DialMobileService:
         self._call_ring_time = {}
         self._incoming_calls: dict[str, IncomingCall] = {}
         self._notifier = notifier
-        self._pstn_fallback_timers: dict[str, threading.Timer] = {}
-        self._pstn_fallback_channels: dict[str, str] = {}
-        # call_ids cancelled while their _pstn_fallback timer-callback may
-        # still be running. _pstn_fallback consults this on each side of its
-        # IO to abort and hang up an in-flight originate if needed.
-        self._pstn_fallback_cancelled: set[str] = set()
+        self._pstn_fallbacks: dict[str, PSTNFallback] = {}
         self._origin_call_id_by_bridge_uuid: dict[str, str] = {}
         self._bridge_uuid_by_origin_call_id: dict[str, str] = {}
         self._call_id_by_origin_call_id: dict[str, str] = {}
@@ -349,18 +427,17 @@ class DialMobileService:
         logger.info('%s is joining bridge %s', channel_id, future_bridge_uuid)
         call_id = self._call_id_for_bridge(future_bridge_uuid)
         if call_id:
-            pstn_channel_id = self._pstn_fallback_channels.get(call_id)
-            if pstn_channel_id == channel_id:
-                # The PSTN-fallback call is itself answering and joining the
-                # bridge — clear timer and tracking but keep the channel.
-                logger.debug(
-                    'pstn fallback call %s joining bridge',
-                    call_id,
-                )
-                self._pstn_fallback_channels.pop(call_id, None)
-            else:
-                logger.debug('cancelling pstn fallback for call %s', call_id)
-                self._cancel_pstn_fallback(call_id)
+            match self._pstn_fallbacks.get(call_id):
+                case PSTNFallbackDialing(channel_id=cid) as fallback_state if (
+                    cid == channel_id
+                ):
+                    # The PSTN-fallback call is itself answering and joining
+                    # the bridge — success path, not a cancellation.
+                    logger.debug('pstn fallback call %s joining bridge', call_id)
+                    self._pstn_fallbacks[call_id] = fallback_state.answered()
+                case _:
+                    logger.debug('cancelling pstn fallback for call %s', call_id)
+                    self._cancel_pstn_fallback(call_id)
 
         dialer = self._contact_dialers.pop(future_bridge_uuid, None)
         if dialer is not None:
@@ -453,18 +530,19 @@ class DialMobileService:
         )
         if origin_call_id is not None:
             self._bridge_uuid_by_origin_call_id.pop(origin_call_id, None)
-            self._call_id_by_origin_call_id.pop(origin_call_id, None)
+            call_id = self._call_id_by_origin_call_id.pop(origin_call_id, None)
             self._call_ring_time.pop(origin_call_id, None)
+            if call_id is not None:
+                self._pstn_fallbacks.pop(call_id, None)
         self._outgoing_calls.pop(future_bridge_uuid, None)
 
     def notify_channel_gone(self, channel_id):
-        # Drop tracking for PSTN-fallback channels that have torn down
-        # on their own.
-        for tracked_call_id, pstn_channel_id in list(
-            self._pstn_fallback_channels.items()
-        ):
-            if pstn_channel_id == channel_id:
-                self._pstn_fallback_channels.pop(tracked_call_id, None)
+        # If a PSTN-fallback channel has torn down on its own, transition
+        # its state to Cancelled so it isn't double-hung-up later.
+        for tracked_call_id, state in list(self._pstn_fallbacks.items()):
+            match state:
+                case PSTNFallbackDialing(channel_id=cid) if cid == channel_id:
+                    self._pstn_fallbacks[tracked_call_id] = state.cancelled()
 
         to_remove: list[tuple[str, bool]] = []
 
@@ -521,9 +599,11 @@ class DialMobileService:
         # Cancel any armed PSTN fallback timers so the (non-daemon) Timer
         # threads do not block process exit, and the callback doesn't run
         # against half-torn-down clients.
-        for timer in self._pstn_fallback_timers.values():
-            timer.cancel()
-        self._pstn_fallback_timers.clear()
+        for state in self._pstn_fallbacks.values():
+            match state:
+                case PSTNFallbackPending(timer=timer):
+                    timer.cancel()
+        self._pstn_fallbacks.clear()
 
     def _set_user_hint(self, user_uuid, has_mobile_sessions):
         self._amid_client.action(
@@ -595,7 +675,9 @@ class DialMobileService:
             timer = threading.Timer(
                 fallback_timeout, self._pstn_fallback, args=[call_id]
             )
-            self._pstn_fallback_timers[call_id] = timer
+            self._pstn_fallbacks[call_id] = PSTNFallbackPending(
+                call_id=call_id, timer=timer, lock=threading.Lock()
+            )
             timer.start()
 
         self._notifier.push_notification(payload, tenant_uuid, user_uuid)
@@ -620,21 +702,41 @@ class DialMobileService:
             user.get('mobile_fallback_enabled') and user.get('mobile_phone_number')
         )
 
-    def _cancel_pstn_timer(self, call_id: str) -> None:
-        if timer := self._pstn_fallback_timers.pop(call_id, None):
-            timer.cancel()
-
     def _cancel_pstn_fallback(self, call_id: str) -> None:
-        # Mark first: if `_pstn_fallback` is concurrently running in the
-        # timer thread, this flag is what makes it abort before originating
-        # (or hang up an already-originated channel).
-        self._pstn_fallback_cancelled.add(call_id)
-        self._cancel_pstn_timer(call_id)
-        if pstn_channel_id := self._pstn_fallback_channels.pop(call_id, None):
-            try:
-                self._ari.channels.hangup(channelId=pstn_channel_id)
-            except ARINotFound:
-                pass
+        # Every non-terminal fallback state carries the same per-call lock
+        state = self._pstn_fallbacks.get(call_id)
+        if state is None or isinstance(
+            state, (PSTNFallbackCancelled, PSTNFallbackDialAnswered)
+        ):
+            return
+
+        with state.lock:
+            match self._pstn_fallbacks.get(call_id):
+                case None | PSTNFallbackCancelled() | PSTNFallbackDialAnswered():
+                    return
+                case PSTNFallbackPending(timer=timer) as current:
+                    timer.cancel()
+                    self._pstn_fallbacks[call_id] = current.cancelled()
+                case PSTNFallbackDialing(channel_id=channel_id) as current:
+                    self._hangup_pstn_channel(channel_id)
+                    self._pstn_fallbacks[call_id] = current.cancelled()
+                case PSTNFallbackTriggering() as current:
+                    # `_pstn_fallback` always exits its lock-held section
+                    # in either `Dialing` (success) or `Cancelled`
+                    # (originate raised) — never `Triggering`. If we see
+                    # this, the commit-path invariant has been broken.
+                    logger.error(
+                        'PSTN fallback for call %s observed in Triggering '
+                        'state at cancellation; forcing Cancelled.',
+                        call_id,
+                    )
+                    self._pstn_fallbacks[call_id] = current.cancelled()
+
+    def _hangup_pstn_channel(self, channel_id: str) -> None:
+        try:
+            self._ari.channels.hangup(channelId=channel_id)
+        except ARINotFound:
+            pass
 
     def cancel_push_mobile(self, call_id: str) -> None:
         incoming_call = self._incoming_calls.pop(call_id, None)
@@ -678,111 +780,113 @@ class DialMobileService:
         self.complete_pending_push_mobile(call_id)
 
     def _pstn_fallback(self, call_id: str) -> None:
-        # fallback call to user's mobile number over PSTN if mobile wake up push still pending
-        self._pstn_fallback_timers.pop(call_id, None)  # timer fired; remove stale ref
+        """Timer-fired callback. Drives the fallback through its state
+        machine: Pending → Triggering → Dialing (or → Cancelled if a
+        racing cancel arrives before the lock is acquired)."""
+        match self._pstn_fallbacks.get(call_id):
+            case PSTNFallbackPending() as state:
+                pass
+            case _:
+                # Already cancelled, or the entry was never armed.
+                return
+
+        pending = self._incoming_calls.get(call_id)
+        if not pending:
+            logger.info(
+                "no pending push for call_id %s, aborting PSTN fallback", call_id
+            )
+            return
+
         try:
-            if call_id in self._pstn_fallback_cancelled:
-                logger.debug(
-                    'PSTN fallback aborted before run for call %s (cancelled)',
-                    call_id,
-                )
-                return
-
-            pending = self._incoming_calls.get(call_id)
-            if not pending:
-                logger.info(
-                    "no pending push for call_id %s, aborting PSTN fallback", call_id
-                )
-                return
-
-            try:
-                user = self._confd_client.users.get(
-                    pending.user_uuid, tenant_uuid=pending.tenant_uuid
-                )
-            except (HTTPError, RequestException) as e:
-                logger.error(
-                    'PSTN fallback: cannot fetch user %s: %s', pending.user_uuid, e
-                )
-                return
-
-            if call_id in self._pstn_fallback_cancelled:
-                logger.debug(
-                    'PSTN fallback cancelled during user fetch for call %s', call_id
-                )
-                return
-
-            if not user.get('mobile_fallback_enabled'):
-                logger.info(
-                    'PSTN fallback: user %s has mobile fallback disabled, skipping',
-                    pending.user_uuid,
-                )
-                return
-
-            mobile_phone_number = user.get('mobile_phone_number')
-            if not mobile_phone_number:
-                logger.info(
-                    'PSTN fallback: user %s has no mobile_phone_number, skipping',
-                    pending.user_uuid,
-                )
-                return
-
-            lines = user.get('lines', [])
-            if not lines:
-                logger.warning(
-                    'PSTN fallback: user %s has no lines, skipping',
-                    pending.user_uuid,
-                )
-                return
-
-            try:
-                line = self._confd_client.lines.get(
-                    lines[0]['id'], tenant_uuid=pending.tenant_uuid
-                )
-            except (HTTPError, RequestException) as e:
-                logger.error(
-                    'PSTN fallback: cannot fetch line for user %s: %s',
-                    pending.user_uuid,
-                    e,
-                )
-                return
-
-            user_context = line['context']
-
-            future_bridge_uuid = self._bridge_uuid_by_origin_call_id.get(
-                pending.origin_call_id
+            user = self._confd_client.users.get(
+                pending.user_uuid, tenant_uuid=pending.tenant_uuid
             )
-            if not future_bridge_uuid:
-                logger.warning(
-                    'PSTN fallback: no bridge found for call %s, skipping', call_id
-                )
-                return
-
-            caller_channel_id = self._outgoing_calls.get(future_bridge_uuid)
-            try:
-                self._ari.channels.get(channelId=caller_channel_id)
-            except ARINotFound:
-                logger.info(
-                    'PSTN fallback: caller channel %s already gone for call %s, '
-                    'skipping',
-                    caller_channel_id,
-                    call_id,
-                )
-                return
-
-            # Last opportunity to bail out before we side-effect the world
-            # (cancel push, originate). If the mobile registered while we
-            # were doing the slow confd lookups, abort now.
-            if call_id in self._pstn_fallback_cancelled:
-                logger.debug(
-                    'PSTN fallback cancelled during confd lookups for call %s',
-                    call_id,
-                )
-                return
-
-            caller_id = '"{name}" <{number}>'.format(
-                name=pending.payload['peer_caller_id_name'],
-                number=pending.payload['peer_caller_id_number'],
+        except (HTTPError, RequestException) as e:
+            logger.error(
+                'PSTN fallback: cannot fetch user %s: %s', pending.user_uuid, e
             )
+            return
+
+        if not user.get('mobile_fallback_enabled'):
+            logger.info(
+                'PSTN fallback: user %s has mobile fallback disabled, skipping',
+                pending.user_uuid,
+            )
+            return
+
+        mobile_phone_number = user.get('mobile_phone_number')
+        if not mobile_phone_number:
+            logger.info(
+                'PSTN fallback: user %s has no mobile_phone_number, skipping',
+                pending.user_uuid,
+            )
+            return
+
+        lines = user.get('lines', [])
+        if not lines:
+            logger.warning(
+                'PSTN fallback: user %s has no lines, skipping',
+                pending.user_uuid,
+            )
+            return
+
+        try:
+            line = self._confd_client.lines.get(
+                lines[0]['id'], tenant_uuid=pending.tenant_uuid
+            )
+        except (HTTPError, RequestException) as e:
+            logger.error(
+                'PSTN fallback: cannot fetch line for user %s: %s',
+                pending.user_uuid,
+                e,
+            )
+            return
+
+        user_context = line['context']
+
+        future_bridge_uuid = self._bridge_uuid_by_origin_call_id.get(
+            pending.origin_call_id
+        )
+        if not future_bridge_uuid:
+            logger.warning(
+                'PSTN fallback: no bridge found for call %s, skipping', call_id
+            )
+            return
+
+        caller_channel_id = self._outgoing_calls.get(future_bridge_uuid)
+        try:
+            self._ari.channels.get(channelId=caller_channel_id)
+        except ARINotFound:
+            logger.info(
+                'PSTN fallback: caller channel %s already gone for call %s, '
+                'skipping',
+                caller_channel_id,
+                call_id,
+            )
+            return
+
+        caller_id = '"{name}" <{number}>'.format(
+            name=pending.payload['peer_caller_id_name'],
+            number=pending.payload['peer_caller_id_number'],
+        )
+
+        # Commit step. The per-call lock serialises against
+        # `_cancel_pstn_fallback`. Inside the lock we re-read the state:
+        # a racing cancellation may have transitioned us to Cancelled.
+        # The commit always lands on `Dialing` (success) or `Cancelled`
+        # (originate failed) before the lock is released — so no observer
+        # ever sees a lingering `Triggering`.
+        with state.lock:
+            match self._pstn_fallbacks.get(call_id):
+                case PSTNFallbackPending() as current:
+                    triggering = current.triggering()
+                    self._pstn_fallbacks[call_id] = triggering
+                case _:
+                    logger.debug(
+                        'PSTN fallback cancelled for call %s; not originating',
+                        call_id,
+                    )
+                    return
 
             logger.info(
                 'PSTN fallback: originating Local/%s@%s for user %s (call %s)',
@@ -792,31 +896,24 @@ class DialMobileService:
                 call_id,
             )
             self.cancel_push_mobile(call_id)
-            pstn_channel = self._ari.channels.originate(
-                endpoint=f'Local/{mobile_phone_number}@{user_context}',
-                app='dial_mobile',
-                appArgs=['join', future_bridge_uuid],
-                callerId=caller_id,
-                originator=caller_channel_id,
-                variables={'variables': {'_WAZO_TENANT_UUID': pending.tenant_uuid}},
-            )
-            if call_id in self._pstn_fallback_cancelled:
-                # Cancellation arrived during originate; hang up the just-
-                # created channel and don't record it.
-                logger.debug(
-                    'PSTN fallback cancelled during originate for call %s; '
-                    'hanging up %s',
-                    call_id,
-                    pstn_channel.id,
+            try:
+                pstn_channel = self._ari.channels.originate(
+                    endpoint=f'Local/{mobile_phone_number}@{user_context}',
+                    app='dial_mobile',
+                    appArgs=['join', future_bridge_uuid],
+                    callerId=caller_id,
+                    originator=caller_channel_id,
+                    variables={'variables': {'_WAZO_TENANT_UUID': pending.tenant_uuid}},
                 )
-                try:
-                    self._ari.channels.hangup(channelId=pstn_channel.id)
-                except ARINotFound:
-                    pass
+            except (ARIServerError, HTTPError, RequestException):
+                logger.exception(
+                    'PSTN fallback: originate failed for call %s; '
+                    'leaving fallback Cancelled',
+                    call_id,
+                )
+                self._pstn_fallbacks[call_id] = triggering.cancelled()
                 return
-            self._pstn_fallback_channels[call_id] = pstn_channel.id
-        finally:
-            self._pstn_fallback_cancelled.discard(call_id)
+            self._pstn_fallbacks[call_id] = triggering.dialing(pstn_channel.id)
 
     def has_a_registered_mobile_and_pending_push(
         self, push_call_id, call_id, endpoint, user_uuid

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -71,7 +71,7 @@ class IncomingCallCancelled(IncomingCallNotified):
 
 IncomingCall = IncomingCallPending | IncomingCallNotified
 
-PSTN_FALLBACK_MAX_TIMEOUT = 10.0
+PSTN_FALLBACK_MIN_TIMEOUT = 10.0
 PSTN_FALLBACK_RING_TIMEOUT_FACTOR = 0.5
 
 
@@ -589,7 +589,7 @@ class DialMobileService:
 
         if self._pstn_fallback_eligible(user_uuid, tenant_uuid):
             fallback_timeout = max(
-                PSTN_FALLBACK_MAX_TIMEOUT,
+                PSTN_FALLBACK_MIN_TIMEOUT,
                 PSTN_FALLBACK_RING_TIMEOUT_FACTOR * int(ring_timeout),
             )
             timer = threading.Timer(

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -494,6 +494,16 @@ class DialMobileService:
             return
 
         caller_channel_id = self._outgoing_calls.get(future_bridge_uuid)
+        try:
+            self._ari.channels.get(channelId=caller_channel_id)
+        except ARINotFound:
+            logger.info(
+                'PSTN fallback: caller channel %s already gone for call %s, skipping',
+                caller_channel_id,
+                call_id,
+            )
+            return
+
         caller_id = '"{name}" <{number}>'.format(
             name=pending.payload['peer_caller_id_name'],
             number=pending.payload['peer_caller_id_number'],

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class IncomingCallPending:
-    """Push notification not yet sent — initial state."""
+    """Push notification not yet sent — initial state"""
 
     call_id: str
     tenant_uuid: str
@@ -35,10 +35,19 @@ class IncomingCallPending:
             payload=self.payload,
         )
 
+    def push_cancelled(self) -> 'IncomingCallPushCancelled':
+        return IncomingCallPushCancelled(
+            call_id=self.call_id,
+            tenant_uuid=self.tenant_uuid,
+            user_uuid=self.user_uuid,
+            origin_call_id=self.origin_call_id,
+            payload=self.payload,
+        )
+
 
 @dataclass
 class IncomingCallNotified(IncomingCallPending):
-    """Push sent; waiting for mobile app to register and answer."""
+    """Push sent; waiting for mobile app to register and answer"""
 
     def received(self) -> 'IncomingCallReceived':
         return IncomingCallReceived(
@@ -49,32 +58,28 @@ class IncomingCallNotified(IncomingCallPending):
             payload=self.payload,
         )
 
-    def cancelled(self) -> 'IncomingCallCancelled':
-        return IncomingCallCancelled(
-            call_id=self.call_id,
-            tenant_uuid=self.tenant_uuid,
-            user_uuid=self.user_uuid,
-            origin_call_id=self.origin_call_id,
-            payload=self.payload,
-        )
-
 
 @dataclass
 class IncomingCallReceived(IncomingCallNotified):
-    """Mobile answered the call — terminal, no push cancellation sent."""
+    """Mobile answered the call — terminal, no push cancellation sent"""
 
 
 @dataclass
-class IncomingCallCancelled(IncomingCallNotified):
-    """Caller hung up or PSTN fallback committed — terminal, push cancellation sent."""
+class IncomingCallPushCancelled(IncomingCallPending):
+    """Terminal: the mobile push attempt has been abandoned"""
 
 
-IncomingCall = IncomingCallPending | IncomingCallNotified
+IncomingCall = (
+    IncomingCallPending
+    | IncomingCallNotified
+    | IncomingCallReceived
+    | IncomingCallPushCancelled
+)
 
 
 @dataclass(eq=False)
 class PSTNFallbackPending:
-    """Timer armed; PSTN fallback may fire when it expires."""
+    """Timer armed; PSTN fallback may fire when it expires"""
 
     call_id: str
     timer: threading.Timer
@@ -447,28 +452,22 @@ class DialMobileService:
             self._unregister_dialer_by_aor(dialer)
             dialer.stop()
         else:
-            # No active dialer means the call was already cancelled or answered;
-            # this channel arrived late and has no bridge to join — hang it up.
-            if call_id:
-                incoming = self._incoming_calls.get(call_id)
-                if incoming is not None:
-                    logger.warning(
-                        'join_bridge(channel_id=%s, future_bridge_uuid=%s): call %s: '
-                        'bridge has no dialer but push state is %s; '
-                        'hanging up late channel',
-                        channel_id,
-                        future_bridge_uuid,
-                        call_id,
-                        type(incoming).__name__,
-                    )
-                else:
-                    logger.debug(
-                        'join_bridge: bridge %s has no dialer, call %s already'
-                        ' cleaned up; hanging up late channel %s',
-                        future_bridge_uuid,
-                        call_id,
-                        channel_id,
-                    )
+            # no dialer can mean  bridge is untracked, or call state already torn down
+            # (cancelled or already answered)
+            logger.warning(
+                'join_bridge(channel=%s, bridge=%s): Channel is late, hanging up',
+                channel_id,
+                future_bridge_uuid,
+            )
+            if call_id and (incoming := self._incoming_calls.get(call_id)):
+                logger.warning(
+                    'join_bridge(channel=%s, bridge=%s): call %s has no dialer '
+                    'but call push state is %s',
+                    channel_id,
+                    future_bridge_uuid,
+                    call_id,
+                    str(incoming),
+                )
             try:
                 self._ari.channels.hangup(channelId=channel_id)
             except ARINotFound:
@@ -537,6 +536,7 @@ class DialMobileService:
             if call_id is not None:
                 self._pstn_fallbacks.pop(call_id, None)
                 self._call_locks.pop(call_id, None)
+                self._incoming_calls.pop(call_id, None)
         self._caller_channel_leg_by_bridge.pop(future_bridge_uuid, None)
 
     def notify_channel_gone(self, channel_id):
@@ -737,39 +737,57 @@ class DialMobileService:
             pass
 
     def cancel_push_mobile(self, call_id: str) -> None:
-        incoming_call = self._incoming_calls.pop(call_id, None)
+        incoming_call = self._incoming_calls.get(call_id)
         match incoming_call:
+            case IncomingCallReceived() | IncomingCallPushCancelled():
+                logger.debug(
+                    'cancel_push_mobile: call %s already terminal (%s)',
+                    call_id,
+                    type(incoming_call).__name__,
+                )
             case IncomingCallNotified():
                 self._notifier.cancel_push_notification(
                     incoming_call.payload,
                     incoming_call.tenant_uuid,
                     incoming_call.user_uuid,
                 )
+                self._incoming_calls[call_id] = incoming_call.push_cancelled()
+            case IncomingCallPending():
+                # Push not yet sent (very tight race during send_push_notification);
+                # record the cancellation without dispatching one.
+                logger.info(
+                    'cancel_push_mobile: push not yet sent for call %s, '
+                    'recording cancellation',
+                    call_id,
+                )
+                self._incoming_calls[call_id] = incoming_call.push_cancelled()
             case None:
                 logger.warning(
                     'cancel_push_mobile: no incoming call for call_id %s', call_id
                 )
-            case _:
-                logger.warning(
-                    'cancel_push_mobile: unexpected state %s for call_id %s',
-                    type(incoming_call).__name__,
-                    call_id,
-                )
 
     def complete_pending_push_mobile(self, call_id: str) -> None:
-        incoming_call = self._incoming_calls.pop(call_id, None)
+        incoming_call = self._incoming_calls.get(call_id)
         match incoming_call:
-            case IncomingCallNotified():
+            case IncomingCallReceived():
                 pass
+            case IncomingCallPushCancelled():
+                logger.warning(
+                    'complete_pending_push_mobile: call %s was already cancelled',
+                    call_id,
+                )
+            case IncomingCallNotified():
+                self._incoming_calls[call_id] = incoming_call.received()
+            case IncomingCallPending():
+                logger.warning(
+                    'complete_pending_push_mobile: completing before push was '
+                    'sent for call %s',
+                    call_id,
+                )
+                self._incoming_calls[call_id] = incoming_call.notified().received()
             case None:
                 logger.warning(
                     'complete_pending_push_mobile: no incoming call for call_id %s',
-                    call_id,
-                )
-            case _:
-                logger.warning(
-                    'complete_pending_push_mobile: unexpected state %s for call_id %s',
-                    type(incoming_call).__name__,
                     call_id,
                 )
 
@@ -809,12 +827,15 @@ class DialMobileService:
         # Triggering → Cancelled transition.
         try:
             pending = self._incoming_calls.get(call_id)
-            if not pending:
-                logger.info(
-                    "no pending push for call_id %s, aborting PSTN fallback",
-                    call_id,
-                )
-                raise _PSTNFallbackAbort
+            match pending:
+                case None | IncomingCallReceived() | IncomingCallPushCancelled():
+                    logger.info(
+                        "no actionable push for call_id %s (state=%s); "
+                        "aborting PSTN fallback",
+                        call_id,
+                        type(pending).__name__ if pending else None,
+                    )
+                    raise _PSTNFallbackAbort
 
             try:
                 user = self._confd_client.users.get(
@@ -968,8 +989,9 @@ class DialMobileService:
         self, push_call_id, call_id, endpoint, user_uuid
     ):
         pending_push = self._incoming_calls.get(push_call_id)
-        if not pending_push:
-            return False
+        match pending_push:
+            case None | IncomingCallReceived() | IncomingCallPushCancelled():
+                return False
 
         if user_uuid != pending_push.user_uuid:
             return False

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -187,7 +187,7 @@ class _NoSuchChannel(Exception):
     pass
 
 
-class _PollingContactDialer:
+class _ContactDialer:
     def __init__(
         self,
         ari,
@@ -202,7 +202,7 @@ class _PollingContactDialer:
         self.future_bridge_uuid = future_bridge_uuid
         self.should_stop = threading.Event()
         self._thread = threading.Thread(
-            name='PollingContactDialer',
+            name='ContactDialer',
             target=self._run_no_exception,
             args=(channel_id, aor),
         )
@@ -374,7 +374,7 @@ class DialMobileService:
         self._amid_client = amid_client
         self._confd_client = confd_client
         self._contact_dialers = {}
-        self._dialers_by_aor: dict[str, set[_PollingContactDialer]] = {}
+        self._dialers_by_aor: dict[str, set[_ContactDialer]] = {}
         self._caller_channel_leg_by_bridge = {}
         self._call_ring_time = {}
         self._incoming_calls: dict[str, IncomingCall] = {}
@@ -421,7 +421,7 @@ class DialMobileService:
                 )
                 self._cancel_pstn_fallback(call_id)
 
-        dialer = _PollingContactDialer(
+        dialer = _ContactDialer(
             self._ari,
             future_bridge_uuid,
             caller_channel_id,
@@ -442,7 +442,7 @@ class DialMobileService:
         for dialer in self._dialers_by_aor.get(aor, set()):
             dialer.kick()
 
-    def _unregister_dialer_by_aor(self, dialer: _PollingContactDialer) -> None:
+    def _unregister_dialer_by_aor(self, dialer: _ContactDialer) -> None:
         for aor, dialers in list(self._dialers_by_aor.items()):
             dialers.discard(dialer)
             if not dialers:
@@ -848,9 +848,7 @@ class DialMobileService:
                         call_id,
                     )
 
-    def _incoming_call_lock(
-        self, call_id: str
-    ) -> threading.RLock | contextlib.nullcontext:
+    def _incoming_call_lock(self, call_id: str) -> contextlib.AbstractContextManager:
         lock = self._call_locks.get(call_id)
         # handle missing lock as a no-op context manager
         return lock if lock is not None else contextlib.nullcontext()

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -78,10 +78,9 @@ class PSTNFallbackPending:
 
     call_id: str
     timer: threading.Timer
-    lock: threading.Lock
 
     def triggering(self) -> 'PSTNFallbackTriggering':
-        return PSTNFallbackTriggering(call_id=self.call_id, lock=self.lock)
+        return PSTNFallbackTriggering(call_id=self.call_id)
 
     def cancelled(self) -> 'PSTNFallbackCancelled':
         return PSTNFallbackCancelled(call_id=self.call_id)
@@ -91,17 +90,15 @@ class PSTNFallbackPending:
 class PSTNFallbackTriggering:
     """Timer fired; commit (cancel-push + originate) in flight.
 
-    The lock is held by `_pstn_fallback` during this state, so external
-    observers (`_cancel_pstn_fallback`) block until commit completes.
+    Observable phase marker between `Pending` and `Dialing`. The
+    transition into and out of this state is serialised by the
+    per-call lock held by `_pstn_fallback`.
     """
 
     call_id: str
-    lock: threading.Lock
 
     def dialing(self, channel_id: str) -> 'PSTNFallbackDialing':
-        return PSTNFallbackDialing(
-            call_id=self.call_id, channel_id=channel_id, lock=self.lock
-        )
+        return PSTNFallbackDialing(call_id=self.call_id, channel_id=channel_id)
 
     def cancelled(self) -> 'PSTNFallbackCancelled':
         return PSTNFallbackCancelled(call_id=self.call_id)
@@ -109,15 +106,10 @@ class PSTNFallbackTriggering:
 
 @dataclass(eq=False)
 class PSTNFallbackDialing:
-    """PSTN leg has been originated; cancellation must hang it up.
-
-    Still carries the per-call state lock so `_cancel_pstn_fallback`
-    can acquire the same lock for any non-terminal state.
-    """
+    """PSTN leg has been originated; cancellation must hang it up."""
 
     call_id: str
     channel_id: str
-    lock: threading.Lock
 
     def answered(self) -> 'PSTNFallbackDialAnswered':
         return PSTNFallbackDialAnswered(
@@ -355,6 +347,7 @@ class DialMobileService:
         self._incoming_calls: dict[str, IncomingCall] = {}
         self._notifier = notifier
         self._pstn_fallbacks: dict[str, PSTNFallback] = {}
+        self._call_locks: dict[str, threading.RLock] = {}
         self._origin_call_id_by_bridge_uuid: dict[str, str] = {}
         self._bridge_uuid_by_origin_call_id: dict[str, str] = {}
         self._call_id_by_origin_call_id: dict[str, str] = {}
@@ -426,18 +419,22 @@ class DialMobileService:
     def join_bridge(self, channel_id, future_bridge_uuid):
         logger.info('%s is joining bridge %s', channel_id, future_bridge_uuid)
         call_id = self._call_id_for_bridge(future_bridge_uuid)
-        if call_id:
-            match self._pstn_fallbacks.get(call_id):
-                case PSTNFallbackDialing(channel_id=cid) as fallback_state if (
-                    cid == channel_id
-                ):
-                    # The PSTN-fallback call is itself answering and joining
-                    # the bridge — success path, not a cancellation.
-                    logger.debug('pstn fallback call %s joining bridge', call_id)
-                    self._pstn_fallbacks[call_id] = fallback_state.answered()
-                case _:
-                    logger.debug('cancelling pstn fallback for call %s', call_id)
-                    self._cancel_pstn_fallback(call_id)
+        if call_id and (lock := self._call_locks.get(call_id)):
+            with lock:
+                match self._pstn_fallbacks.get(call_id):
+                    case PSTNFallbackDialing(channel_id=cid) as current if (
+                        cid == channel_id
+                    ):
+                        # PSTN leg itself answering — success.
+                        logger.debug('pstn fallback call %s joining bridge', call_id)
+                        self._pstn_fallbacks[call_id] = current.answered()
+                    case None | PSTNFallbackCancelled() | (PSTNFallbackDialAnswered()):
+                        # Terminal: nothing to do.
+                        pass
+                    case _:
+                        # Different channel / non-Dialing state — cancel.
+                        logger.debug('cancelling pstn fallback for call %s', call_id)
+                        self._cancel_pstn_fallback(call_id)
 
         dialer = self._contact_dialers.pop(future_bridge_uuid, None)
         if dialer:
@@ -534,6 +531,7 @@ class DialMobileService:
             self._call_ring_time.pop(origin_call_id, None)
             if call_id is not None:
                 self._pstn_fallbacks.pop(call_id, None)
+                self._call_locks.pop(call_id, None)
         self._caller_channel_leg_by_bridge.pop(future_bridge_uuid, None)
 
     def notify_channel_gone(self, channel_id):
@@ -675,8 +673,9 @@ class DialMobileService:
             timer = threading.Timer(
                 fallback_timeout, self._pstn_fallback, args=[call_id]
             )
+            self._call_locks[call_id] = threading.RLock()
             self._pstn_fallbacks[call_id] = PSTNFallbackPending(
-                call_id=call_id, timer=timer, lock=threading.Lock()
+                call_id=call_id, timer=timer
             )
             timer.start()
 
@@ -703,14 +702,10 @@ class DialMobileService:
         )
 
     def _cancel_pstn_fallback(self, call_id: str) -> None:
-        # Every non-terminal fallback state carries the same per-call lock
-        state = self._pstn_fallbacks.get(call_id)
-        if state is None or isinstance(
-            state, (PSTNFallbackCancelled, PSTNFallbackDialAnswered)
-        ):
+        lock = self._call_locks.get(call_id)
+        if lock is None:
             return
-
-        with state.lock:
+        with lock:
             match self._pstn_fallbacks.get(call_id):
                 case None | PSTNFallbackCancelled() | PSTNFallbackDialAnswered():
                     return
@@ -784,11 +779,19 @@ class DialMobileService:
         machine: Pending → Triggering → Dialing (or → Cancelled if a
         racing cancel arrives before the lock is acquired)."""
         match self._pstn_fallbacks.get(call_id):
-            case PSTNFallbackPending() as state:
+            case PSTNFallbackPending():
                 pass
-            case _:
+            case _ as state:
                 # Already cancelled, or the entry was never armed.
+                logger.warning(
+                    'pstn fallback triggered while not in pending state (%s), aborting',
+                    state,
+                )
                 return
+        lock = self._call_locks.get(call_id)
+        if lock is None:
+            logger.warning('pstn fallback triggered but lock not available, aborting')
+            return
 
         pending = self._incoming_calls.get(call_id)
         if not pending:
@@ -876,7 +879,7 @@ class DialMobileService:
         # The commit always lands on `Dialing` (success) or `Cancelled`
         # (originate failed) before the lock is released — so no observer
         # ever sees a lingering `Triggering`.
-        with state.lock:
+        with lock:
             match self._pstn_fallbacks.get(call_id):
                 case PSTNFallbackPending() as current:
                     triggering = current.triggering()

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -297,6 +297,7 @@ class DialMobileService:
         logger.info('%s is joining bridge %s', channel_id, future_bridge_uuid)
         call_id = self._call_id_for_bridge(future_bridge_uuid)
         if call_id:
+            logger.debug('cancelling pstn fallback timer for call %s', call_id)
             self._cancel_pstn_timer(call_id)
         dialer = self._contact_dialers.pop(future_bridge_uuid, None)
         logger.debug('Removing dialer: %s', str(dialer))
@@ -306,8 +307,6 @@ class DialMobileService:
             except ARINotFound:
                 # If its already gone do nothing
                 pass
-            if call_id:
-                self.cancel_push_mobile(call_id)
             return
 
         dialer.stop()

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -350,7 +350,7 @@ class DialMobileService:
         self._confd_client = confd_client
         self._contact_dialers = {}
         self._dialers_by_aor: dict[str, set[_PollingContactDialer]] = {}
-        self._outgoing_calls = {}
+        self._caller_channel_leg_by_bridge = {}
         self._call_ring_time = {}
         self._incoming_calls: dict[str, IncomingCall] = {}
         self._notifier = notifier
@@ -407,7 +407,7 @@ class DialMobileService:
         )
         self._contact_dialers[future_bridge_uuid] = dialer
         self._dialers_by_aor.setdefault(aor, set()).add(dialer)
-        self._outgoing_calls[future_bridge_uuid] = caller_channel_id
+        self._caller_channel_leg_by_bridge[future_bridge_uuid] = caller_channel_id
         self._origin_call_id_by_bridge_uuid[future_bridge_uuid] = origin_channel_id
         self._bridge_uuid_by_origin_call_id[origin_channel_id] = future_bridge_uuid
         dialer.start()
@@ -473,7 +473,7 @@ class DialMobileService:
                 pass
             return
 
-        outgoing_channel_id = self._outgoing_calls.get(future_bridge_uuid)
+        outgoing_channel_id = self._caller_channel_leg_by_bridge.get(future_bridge_uuid)
         try:
             try:
                 self._ari.channels.answer(channelId=outgoing_channel_id)
@@ -534,7 +534,7 @@ class DialMobileService:
             self._call_ring_time.pop(origin_call_id, None)
             if call_id is not None:
                 self._pstn_fallbacks.pop(call_id, None)
-        self._outgoing_calls.pop(future_bridge_uuid, None)
+        self._caller_channel_leg_by_bridge.pop(future_bridge_uuid, None)
 
     def notify_channel_gone(self, channel_id):
         # If a PSTN-fallback channel has torn down on its own, transition
@@ -853,7 +853,7 @@ class DialMobileService:
             )
             return
 
-        caller_channel_id = self._outgoing_calls.get(future_bridge_uuid)
+        caller_channel_id = self._caller_channel_leg_by_bridge.get(future_bridge_uuid)
         try:
             self._ari.channels.get(channelId=caller_channel_id)
         except ARINotFound:

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -513,6 +513,7 @@ class DialMobileService:
             appArgs=['join', future_bridge_uuid],
             callerId=caller_id,
             originator=caller_channel_id,
+            variables={'variables': {'_WAZO_TENANT_UUID': pending.tenant_uuid}},
         )
 
     def has_a_registered_mobile_and_pending_push(

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -273,6 +273,10 @@ class DialMobileService:
         self._notifier = notifier
         self._pstn_fallback_timers: dict[str, threading.Timer] = {}
         self._pstn_fallback_channels: dict[str, str] = {}
+        # call_ids cancelled while their _pstn_fallback timer-callback may
+        # still be running. _pstn_fallback consults this on each side of its
+        # IO to abort and hang up an in-flight originate if needed.
+        self._pstn_fallback_cancelled: set[str] = set()
         self._origin_call_id_by_bridge_uuid: dict[str, str] = {}
         self._bridge_uuid_by_origin_call_id: dict[str, str] = {}
         self._call_id_by_origin_call_id: dict[str, str] = {}
@@ -392,40 +396,46 @@ class DialMobileService:
             return
 
         dialer.stop()
-        outgoing_channel_id = self._outgoing_calls[future_bridge_uuid]
+        outgoing_channel_id = self._outgoing_calls.get(future_bridge_uuid)
         try:
-            self._ari.channels.answer(channelId=outgoing_channel_id)
-        except ARINotFound:
-            logger.info(
-                'the caller (%s) left the call before being bridged',
-                outgoing_channel_id,
-            )
             try:
-                self._ari.channels.hangup(channelId=channel_id)
+                self._ari.channels.answer(channelId=outgoing_channel_id)
             except ARINotFound:
-                # If its already gone do nothing
-                pass
-            if call_id:
-                self.cancel_push_mobile(call_id)
-            return
+                logger.info(
+                    'the caller (%s) left the call before being bridged',
+                    outgoing_channel_id,
+                )
+                try:
+                    self._ari.channels.hangup(channelId=channel_id)
+                except ARINotFound:
+                    # If its already gone do nothing
+                    pass
+                if call_id:
+                    self.cancel_push_mobile(call_id)
+                return
 
-        try:
-            self._ari.channels.answer(channelId=channel_id)
-        except ARINotFound:
-            logger.info(
-                'the answered (%s) left the call before being bridged', channel_id
+            try:
+                self._ari.channels.answer(channelId=channel_id)
+            except ARINotFound:
+                logger.info(
+                    'the answered (%s) left the call before being bridged',
+                    channel_id,
+                )
+                return
+
+            bridge = self._ari.bridges.createWithId(
+                type='mixing',
+                bridgeId=f'wazo-dial-mobile-{future_bridge_uuid}',
             )
-            return
-
-        bridge = self._ari.bridges.createWithId(
-            type='mixing',
-            bridgeId=f'wazo-dial-mobile-{future_bridge_uuid}',
-        )
-        # Without the inhibitConnectedLineUpdates everyone in the bridge will receive a new
-        # connected line update with the caller ID of the caller when PAI is trusted, including
-        # the caller...
-        bridge.addChannel(channel=channel_id, inhibitConnectedLineUpdates=True)
-        bridge.addChannel(channel=outgoing_channel_id, inhibitConnectedLineUpdates=True)
+            # Without the inhibitConnectedLineUpdates everyone in the bridge will receive a new
+            # connected line update with the caller ID of the caller when PAI is trusted, including
+            # the caller...
+            bridge.addChannel(channel=channel_id, inhibitConnectedLineUpdates=True)
+            bridge.addChannel(
+                channel=outgoing_channel_id, inhibitConnectedLineUpdates=True
+            )
+        finally:
+            self._prune_call_state(future_bridge_uuid)
 
     def _call_id_for_bridge(self, bridge_uuid: str) -> str | None:
         origin_call_id = self._origin_call_id_by_bridge_uuid.get(bridge_uuid)
@@ -434,6 +444,18 @@ class DialMobileService:
             if origin_call_id
             else None
         )
+
+    def _prune_call_state(self, future_bridge_uuid: str) -> None:
+        # Tear down per-call indirection so the maps don't grow unbounded
+        # across the lifetime of the service.
+        origin_call_id = self._origin_call_id_by_bridge_uuid.pop(
+            future_bridge_uuid, None
+        )
+        if origin_call_id is not None:
+            self._bridge_uuid_by_origin_call_id.pop(origin_call_id, None)
+            self._call_id_by_origin_call_id.pop(origin_call_id, None)
+            self._call_ring_time.pop(origin_call_id, None)
+        self._outgoing_calls.pop(future_bridge_uuid, None)
 
     def notify_channel_gone(self, channel_id):
         # Drop tracking for PSTN-fallback channels that have torn down
@@ -474,6 +496,7 @@ class DialMobileService:
                     )
                 self._cancel_pstn_fallback(call_id)
                 self.cancel_push_mobile(call_id)
+            self._prune_call_state(key)
 
     def clean_bridge(self, bridge_id):
         bridge_helper = Bridge(bridge_id, self._ari)
@@ -495,6 +518,12 @@ class DialMobileService:
     def on_calld_stopping(self):
         for dialer in self._contact_dialers.values():
             dialer.stop()
+        # Cancel any armed PSTN fallback timers so the (non-daemon) Timer
+        # threads do not block process exit, and the callback doesn't run
+        # against half-torn-down clients.
+        for timer in self._pstn_fallback_timers.values():
+            timer.cancel()
+        self._pstn_fallback_timers.clear()
 
     def _set_user_hint(self, user_uuid, has_mobile_sessions):
         self._amid_client.action(
@@ -558,23 +587,48 @@ class DialMobileService:
         self._call_ring_time[origin_call_id] = ring_timeout
         self._call_id_by_origin_call_id[origin_call_id] = call_id
 
-        # setup timer to trigger PSTN fallback mechanism
-        fallback_timeout = max(
-            PSTN_FALLBACK_MAX_TIMEOUT,
-            PSTN_FALLBACK_RING_TIMEOUT_FACTOR * int(ring_timeout),
-        )
-        timer = threading.Timer(fallback_timeout, self._pstn_fallback, args=[call_id])
-        self._pstn_fallback_timers[call_id] = timer
-        timer.start()
+        if self._pstn_fallback_eligible(user_uuid, tenant_uuid):
+            fallback_timeout = max(
+                PSTN_FALLBACK_MAX_TIMEOUT,
+                PSTN_FALLBACK_RING_TIMEOUT_FACTOR * int(ring_timeout),
+            )
+            timer = threading.Timer(
+                fallback_timeout, self._pstn_fallback, args=[call_id]
+            )
+            self._pstn_fallback_timers[call_id] = timer
+            timer.start()
 
         self._notifier.push_notification(payload, tenant_uuid, user_uuid)
         self._incoming_calls[call_id] = pending.notified()
+
+    def _pstn_fallback_eligible(self, user_uuid: str, tenant_uuid: str) -> bool:
+        # Check user config once at push time so we don't arm a timer that
+        # would no-op when it fires.  On confd errors we err on the safe side
+        # and arm the timer anyway so the existing in-`_pstn_fallback` checks
+        # can re-evaluate when the timer fires.
+        try:
+            user = self._confd_client.users.get(user_uuid, tenant_uuid=tenant_uuid)
+        except (HTTPError, RequestException) as e:
+            logger.warning(
+                'PSTN fallback eligibility lookup failed for user %s: %s; '
+                'arming fallback timer optimistically',
+                user_uuid,
+                e,
+            )
+            return True
+        return bool(
+            user.get('mobile_fallback_enabled') and user.get('mobile_phone_number')
+        )
 
     def _cancel_pstn_timer(self, call_id: str) -> None:
         if timer := self._pstn_fallback_timers.pop(call_id, None):
             timer.cancel()
 
     def _cancel_pstn_fallback(self, call_id: str) -> None:
+        # Mark first: if `_pstn_fallback` is concurrently running in the
+        # timer thread, this flag is what makes it abort before originating
+        # (or hang up an already-originated channel).
+        self._pstn_fallback_cancelled.add(call_id)
         self._cancel_pstn_timer(call_id)
         if pstn_channel_id := self._pstn_fallback_channels.pop(call_id, None):
             try:
@@ -626,98 +680,143 @@ class DialMobileService:
     def _pstn_fallback(self, call_id: str) -> None:
         # fallback call to user's mobile number over PSTN if mobile wake up push still pending
         self._pstn_fallback_timers.pop(call_id, None)  # timer fired; remove stale ref
-        pending = self._incoming_calls.get(call_id)
-        if not pending:
-            logger.info(
-                "no pending push for call_id %s, aborting PSTN fallback", call_id
-            )
-            return
-
         try:
-            user = self._confd_client.users.get(
-                pending.user_uuid, tenant_uuid=pending.tenant_uuid
-            )
-        except (HTTPError, RequestException) as e:
-            logger.error(
-                'PSTN fallback: cannot fetch user %s: %s', pending.user_uuid, e
-            )
-            return
+            if call_id in self._pstn_fallback_cancelled:
+                logger.debug(
+                    'PSTN fallback aborted before run for call %s (cancelled)',
+                    call_id,
+                )
+                return
 
-        if not user.get('mobile_fallback_enabled'):
+            pending = self._incoming_calls.get(call_id)
+            if not pending:
+                logger.info(
+                    "no pending push for call_id %s, aborting PSTN fallback", call_id
+                )
+                return
+
+            try:
+                user = self._confd_client.users.get(
+                    pending.user_uuid, tenant_uuid=pending.tenant_uuid
+                )
+            except (HTTPError, RequestException) as e:
+                logger.error(
+                    'PSTN fallback: cannot fetch user %s: %s', pending.user_uuid, e
+                )
+                return
+
+            if call_id in self._pstn_fallback_cancelled:
+                logger.debug(
+                    'PSTN fallback cancelled during user fetch for call %s', call_id
+                )
+                return
+
+            if not user.get('mobile_fallback_enabled'):
+                logger.info(
+                    'PSTN fallback: user %s has mobile fallback disabled, skipping',
+                    pending.user_uuid,
+                )
+                return
+
+            mobile_phone_number = user.get('mobile_phone_number')
+            if not mobile_phone_number:
+                logger.info(
+                    'PSTN fallback: user %s has no mobile_phone_number, skipping',
+                    pending.user_uuid,
+                )
+                return
+
+            lines = user.get('lines', [])
+            if not lines:
+                logger.warning(
+                    'PSTN fallback: user %s has no lines, skipping',
+                    pending.user_uuid,
+                )
+                return
+
+            try:
+                line = self._confd_client.lines.get(
+                    lines[0]['id'], tenant_uuid=pending.tenant_uuid
+                )
+            except (HTTPError, RequestException) as e:
+                logger.error(
+                    'PSTN fallback: cannot fetch line for user %s: %s',
+                    pending.user_uuid,
+                    e,
+                )
+                return
+
+            user_context = line['context']
+
+            future_bridge_uuid = self._bridge_uuid_by_origin_call_id.get(
+                pending.origin_call_id
+            )
+            if not future_bridge_uuid:
+                logger.warning(
+                    'PSTN fallback: no bridge found for call %s, skipping', call_id
+                )
+                return
+
+            caller_channel_id = self._outgoing_calls.get(future_bridge_uuid)
+            try:
+                self._ari.channels.get(channelId=caller_channel_id)
+            except ARINotFound:
+                logger.info(
+                    'PSTN fallback: caller channel %s already gone for call %s, '
+                    'skipping',
+                    caller_channel_id,
+                    call_id,
+                )
+                return
+
+            # Last opportunity to bail out before we side-effect the world
+            # (cancel push, originate). If the mobile registered while we
+            # were doing the slow confd lookups, abort now.
+            if call_id in self._pstn_fallback_cancelled:
+                logger.debug(
+                    'PSTN fallback cancelled during confd lookups for call %s',
+                    call_id,
+                )
+                return
+
+            caller_id = '"{name}" <{number}>'.format(
+                name=pending.payload['peer_caller_id_name'],
+                number=pending.payload['peer_caller_id_number'],
+            )
+
             logger.info(
-                'PSTN fallback: user %s has mobile fallback disabled, skipping',
+                'PSTN fallback: originating Local/%s@%s for user %s (call %s)',
+                mobile_phone_number,
+                user_context,
                 pending.user_uuid,
-            )
-            return
-
-        mobile_phone_number = user.get('mobile_phone_number')
-        if not mobile_phone_number:
-            logger.info(
-                'PSTN fallback: user %s has no mobile_phone_number, skipping',
-                pending.user_uuid,
-            )
-            return
-
-        lines = user.get('lines', [])
-        if not lines:
-            logger.warning(
-                'PSTN fallback: user %s has no lines, skipping', pending.user_uuid
-            )
-            return
-
-        try:
-            line = self._confd_client.lines.get(
-                lines[0]['id'], tenant_uuid=pending.tenant_uuid
-            )
-        except (HTTPError, RequestException) as e:
-            logger.error(
-                'PSTN fallback: cannot fetch line for user %s: %s', pending.user_uuid, e
-            )
-            return
-
-        user_context = line['context']
-
-        future_bridge_uuid = self._bridge_uuid_by_origin_call_id.get(
-            pending.origin_call_id
-        )
-        if not future_bridge_uuid:
-            logger.warning(
-                'PSTN fallback: no bridge found for call %s, skipping', call_id
-            )
-            return
-
-        caller_channel_id = self._outgoing_calls.get(future_bridge_uuid)
-        try:
-            self._ari.channels.get(channelId=caller_channel_id)
-        except ARINotFound:
-            logger.info(
-                'PSTN fallback: caller channel %s already gone for call %s, skipping',
-                caller_channel_id,
                 call_id,
             )
-            return
-        caller_id = '"{name}" <{number}>'.format(
-            name=pending.payload['peer_caller_id_name'],
-            number=pending.payload['peer_caller_id_number'],
-        )
-
-        logger.info(
-            'PSTN fallback: originating Local/%s@%s for user %s (call %s)',
-            mobile_phone_number,
-            user_context,
-            pending.user_uuid,
-            call_id,
-        )
-        self.cancel_push_mobile(call_id)
-        pstn_channel = self._ari.channels.originate(
-            endpoint=f'Local/{mobile_phone_number}@{user_context}',
-            app='dial_mobile',
-            appArgs=['join', future_bridge_uuid],
-            callerId=caller_id,
-            originator=caller_channel_id,
-            variables={'variables': {'_WAZO_TENANT_UUID': pending.tenant_uuid}},
-        )
-        self._pstn_fallback_channels[call_id] = pstn_channel.id
+            self.cancel_push_mobile(call_id)
+            pstn_channel = self._ari.channels.originate(
+                endpoint=f'Local/{mobile_phone_number}@{user_context}',
+                app='dial_mobile',
+                appArgs=['join', future_bridge_uuid],
+                callerId=caller_id,
+                originator=caller_channel_id,
+                variables={'variables': {'_WAZO_TENANT_UUID': pending.tenant_uuid}},
+            )
+            if call_id in self._pstn_fallback_cancelled:
+                # Cancellation arrived during originate; hang up the just-
+                # created channel and don't record it.
+                logger.debug(
+                    'PSTN fallback cancelled during originate for call %s; '
+                    'hanging up %s',
+                    call_id,
+                    pstn_channel.id,
+                )
+                try:
+                    self._ari.channels.hangup(channelId=pstn_channel.id)
+                except ARINotFound:
+                    pass
+                return
+            self._pstn_fallback_channels[call_id] = pstn_channel.id
+        finally:
+            self._pstn_fallback_cancelled.discard(call_id)
 
     def has_a_registered_mobile_and_pending_push(
         self, push_call_id, call_id, endpoint, user_uuid

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -121,12 +121,7 @@ class PSTNFallbackPending:
 
 @dataclass(eq=False)
 class PSTNFallbackTriggering:
-    """Timer fired; commit (cancel-push + originate) in flight.
-
-    Observable phase marker between `Pending` and `Dialing`. The
-    transition into and out of this state is serialised by the
-    per-call lock held by `_pstn_fallback`.
-    """
+    """Timer fired, but PSTN call not yet dispatched"""
 
     call_id: str
 
@@ -731,10 +726,6 @@ class DialMobileService:
                 timer.start()
 
     def _pstn_fallback_eligible(self, user_uuid: str, tenant_uuid: str) -> bool:
-        # Check user config once at push time so we don't arm a timer that
-        # would no-op when it fires.  On confd errors we err on the safe side
-        # and arm the timer anyway so the existing in-`_pstn_fallback` checks
-        # can re-evaluate when the timer fires.
         try:
             user = self._confd_client.users.get(user_uuid, tenant_uuid=tenant_uuid)
         except (HTTPError, RequestException) as e:
@@ -857,20 +848,15 @@ class DialMobileService:
                         call_id,
                     )
 
-    def _incoming_call_lock(self, call_id: str):
-        # Returns the per-call RLock for serializing IncomingCall transitions,
-        # or a no-op context manager if the call is unknown (no entry was
-        # created, or the call was already pruned). The lock is created in
-        # `send_push_notification` and reused by the PSTN state machine.
+    def _incoming_call_lock(
+        self, call_id: str
+    ) -> threading.RLock | contextlib.nullcontext:
         lock = self._call_locks.get(call_id)
+        # handle missing lock as a no-op context manager
         return lock if lock is not None else contextlib.nullcontext()
 
     def _pstn_fallback(self, call_id: str) -> None:
-        """Timer-fired callback. Drives the fallback through:
-        Pending → Triggering (early) → Dialing on success, or
-        → Cancelled on any preliminary failure / originate failure /
-        racing cancel.
-        """
+        """Timer-fired callback, dispatch PSTN fallback call"""
         lock = self._call_locks.get(call_id)
         if lock is None:
             logger.warning(

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -773,10 +773,6 @@ class DialMobileService:
                     call_id,
                 )
 
-    def remove_pending_push_mobile(self, call_id: str) -> None:
-        """Deprecated alias for complete_pending_push_mobile."""
-        self.complete_pending_push_mobile(call_id)
-
     def _pstn_fallback(self, call_id: str) -> None:
         """Timer-fired callback. Drives the fallback through:
         Pending → Triggering (early) → Dialing on success, or

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -843,6 +843,7 @@ class DialMobileService:
                 )
                 raise _PSTNFallbackAbort
 
+            # get user's dialplan context for outbound dialing; use the main line's context
             lines = user.get('lines', [])
             if not lines:
                 logger.warning(

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -755,6 +755,11 @@ class DialMobileService:
     def _cancel_pstn_fallback(self, call_id: str) -> None:
         lock = self._call_locks.get(call_id)
         if lock is None:
+            assert call_id not in self._pstn_fallbacks, (
+                f'PSTN fallback state for {call_id} present without lock '
+                f'(state={self._pstn_fallbacks[call_id]!r}); _call_locks and '
+                '_pstn_fallbacks lifetimes have drifted'
+            )
             return
         with lock:
             logger.info('cancelling PSTN fallback for call %s', call_id)

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -180,8 +180,8 @@ PSTNFallback = (
 )
 
 
-PSTN_FALLBACK_MIN_TIMEOUT = 10.0
-PSTN_FALLBACK_RING_TIMEOUT_FACTOR = 0.5
+DEFAULT_PSTN_FALLBACK_MIN_TIMEOUT = 10.0
+DEFAULT_PSTN_FALLBACK_RING_TIMEOUT_FACTOR = 0.5
 
 
 class _NoSuchChannel(Exception):
@@ -369,21 +369,32 @@ class _ContactDialer:
 
 
 class DialMobileService:
-    def __init__(self, ari, notifier, amid_client, auth_client, confd_client):
+    def __init__(
+        self,
+        ari,
+        notifier,
+        amid_client,
+        auth_client,
+        confd_client,
+        pstn_fallback_min_timeout: float = DEFAULT_PSTN_FALLBACK_MIN_TIMEOUT,
+        pstn_fallback_ring_timeout_factor: float = DEFAULT_PSTN_FALLBACK_RING_TIMEOUT_FACTOR,
+    ):
         self._ari = ari.client
         self._auth_client = auth_client
         self._amid_client = amid_client
         self._confd_client = confd_client
-        self._contact_dialers = {}
+        self._contact_dialers: dict[str, _ContactDialer] = {}
         self._dialers_by_aor: dict[str, set[_ContactDialer]] = {}
-        self._caller_channel_leg_by_bridge = {}
-        self._call_ring_time = {}
+        self._caller_channel_leg_by_bridge: dict[str, str] = {}
+        self._call_ring_time: dict[str, int] = {}
         self._incoming_calls: dict[str, IncomingCall] = {}
         self._notifier = notifier
         self._pstn_fallbacks: dict[str, PSTNFallback] = {}
         self._call_locks: dict[str, threading.RLock] = {}
         self._origin_call_id_by_bridge_uuid: dict[str, str] = {}
         self._bridge_uuid_by_origin_call_id: dict[str, str] = {}
+        self._pstn_fallback_min_timeout = pstn_fallback_min_timeout
+        self._pstn_fallback_ring_timeout_factor = pstn_fallback_ring_timeout_factor
 
     def find_bridge_by_exten_context(self, exten, context):
         pickup_mark = f'{exten}%{context}'
@@ -710,8 +721,8 @@ class DialMobileService:
 
             if pstn_fallback_enabled:
                 fallback_timeout = max(
-                    PSTN_FALLBACK_MIN_TIMEOUT,
-                    PSTN_FALLBACK_RING_TIMEOUT_FACTOR * int(ring_timeout),
+                    self._pstn_fallback_min_timeout,
+                    self._pstn_fallback_ring_timeout_factor * int(ring_timeout),
                 )
                 timer = threading.Timer(
                     fallback_timeout, self._pstn_fallback, args=[origin_call_id]

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -5,7 +5,7 @@ import logging
 import threading
 import time
 import uuid
-from collections import namedtuple
+from dataclasses import dataclass
 
 import requests
 from ari.exceptions import ARINotFound, ARIServerError
@@ -15,10 +15,61 @@ from wazo_calld.plugin_helpers.ari_ import Bridge
 
 logger = logging.getLogger(__name__)
 
-PendingPushMobile = namedtuple(
-    'PendingPushMobile',
-    ['call_id', 'tenant_uuid', 'user_uuid', 'origin_call_id', 'payload'],
-)
+
+@dataclass
+class IncomingCallPending:
+    """Push notification not yet sent — initial state."""
+
+    call_id: str
+    tenant_uuid: str
+    user_uuid: str
+    origin_call_id: str
+    payload: dict
+
+    def notified(self) -> 'IncomingCallNotified':
+        return IncomingCallNotified(
+            call_id=self.call_id,
+            tenant_uuid=self.tenant_uuid,
+            user_uuid=self.user_uuid,
+            origin_call_id=self.origin_call_id,
+            payload=self.payload,
+        )
+
+
+@dataclass
+class IncomingCallNotified(IncomingCallPending):
+    """Push sent; waiting for mobile app to register and answer."""
+
+    def received(self) -> 'IncomingCallReceived':
+        return IncomingCallReceived(
+            call_id=self.call_id,
+            tenant_uuid=self.tenant_uuid,
+            user_uuid=self.user_uuid,
+            origin_call_id=self.origin_call_id,
+            payload=self.payload,
+        )
+
+    def cancelled(self) -> 'IncomingCallCancelled':
+        return IncomingCallCancelled(
+            call_id=self.call_id,
+            tenant_uuid=self.tenant_uuid,
+            user_uuid=self.user_uuid,
+            origin_call_id=self.origin_call_id,
+            payload=self.payload,
+        )
+
+
+@dataclass
+class IncomingCallReceived(IncomingCallNotified):
+    """Mobile answered the call — terminal, no push cancellation sent."""
+
+
+@dataclass
+class IncomingCallCancelled(IncomingCallNotified):
+    """Caller hung up or PSTN fallback committed — terminal, push cancellation sent."""
+
+
+IncomingCall = IncomingCallPending | IncomingCallNotified
 
 PSTN_FALLBACK_MAX_TIMEOUT = 10.0
 PSTN_FALLBACK_RING_TIMEOUT_FACTOR = 0.5
@@ -195,7 +246,7 @@ class DialMobileService:
         self._contact_dialers = {}
         self._outgoing_calls = {}
         self._call_ring_time = {}
-        self._pending_push_mobile = {}
+        self._incoming_calls: dict[str, IncomingCall] = {}
         self._notifier = notifier
         self._pstn_fallback_timers: dict[str, threading.Timer] = {}
         self._origin_call_id_by_bridge_uuid: dict[str, str] = {}
@@ -404,13 +455,14 @@ class DialMobileService:
             'mobile_wakeup_timestamp': push_mobile_timestamp,
         }
 
-        self._pending_push_mobile[call_id] = PendingPushMobile(
-            call_id,
-            tenant_uuid,
-            user_uuid,
-            origin_call_id,
-            payload,
+        pending = IncomingCallPending(
+            call_id=call_id,
+            tenant_uuid=tenant_uuid,
+            user_uuid=user_uuid,
+            origin_call_id=origin_call_id,
+            payload=payload,
         )
+        self._incoming_calls[call_id] = pending
 
         self._call_ring_time[origin_call_id] = ring_timeout
         self._call_id_by_origin_call_id[origin_call_id] = call_id
@@ -425,29 +477,57 @@ class DialMobileService:
         timer.start()
 
         self._notifier.push_notification(payload, tenant_uuid, user_uuid)
+        self._incoming_calls[call_id] = pending.notified()
 
     def _cancel_pstn_timer(self, call_id: str) -> None:
         if timer := self._pstn_fallback_timers.pop(call_id, None):
             timer.cancel()
 
     def cancel_push_mobile(self, call_id: str) -> None:
-        pending_push = self._pending_push_mobile.pop(call_id, None)
-        if not pending_push:
-            return
+        incoming_call = self._incoming_calls.pop(call_id, None)
+        match incoming_call:
+            case IncomingCallNotified():
+                self._notifier.cancel_push_notification(
+                    incoming_call.payload,
+                    incoming_call.tenant_uuid,
+                    incoming_call.user_uuid,
+                )
+            case None:
+                logger.warning(
+                    'cancel_push_mobile: no incoming call for call_id %s', call_id
+                )
+            case _:
+                logger.warning(
+                    'cancel_push_mobile: unexpected state %s for call_id %s',
+                    type(incoming_call).__name__,
+                    call_id,
+                )
 
-        self._notifier.cancel_push_notification(
-            pending_push.payload,
-            pending_push.tenant_uuid,
-            pending_push.user_uuid,
-        )
+    def complete_pending_push_mobile(self, call_id: str) -> None:
+        incoming_call = self._incoming_calls.pop(call_id, None)
+        match incoming_call:
+            case IncomingCallNotified():
+                pass
+            case None:
+                logger.warning(
+                    'complete_pending_push_mobile: no incoming call for call_id %s',
+                    call_id,
+                )
+            case _:
+                logger.warning(
+                    'complete_pending_push_mobile: unexpected state %s for call_id %s',
+                    type(incoming_call).__name__,
+                    call_id,
+                )
 
-    def remove_pending_push_mobile(self, call_id):
-        self._pending_push_mobile.pop(call_id, None)
+    def remove_pending_push_mobile(self, call_id: str) -> None:
+        """Deprecated alias for complete_pending_push_mobile."""
+        self.complete_pending_push_mobile(call_id)
 
     def _pstn_fallback(self, call_id: str) -> None:
         # fallback call to user's mobile number over PSTN if mobile wake up push still pending
         self._pstn_fallback_timers.pop(call_id, None)  # timer fired; remove stale ref
-        pending = self._pending_push_mobile.get(call_id)
+        pending = self._incoming_calls.get(call_id)
         if not pending:
             logger.info(
                 "no pending push for call_id %s, aborting PSTN fallback", call_id
@@ -543,7 +623,7 @@ class DialMobileService:
     def has_a_registered_mobile_and_pending_push(
         self, push_call_id, call_id, endpoint, user_uuid
     ):
-        pending_push = self._pending_push_mobile.get(push_call_id)
+        pending_push = self._incoming_calls.get(push_call_id)
         if not pending_push:
             return False
 

--- a/wazo_calld/plugins/dial_mobile/stasis.py
+++ b/wazo_calld/plugins/dial_mobile/stasis.py
@@ -1,15 +1,9 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
 
 logger = logging.getLogger(__name__)
-
-ARG_LEN_BY_COMMAND = {
-    'dial': 2,
-    'join': 2,
-    'pickup': 3,
-}
 
 
 class DialMobileStasis:
@@ -34,29 +28,27 @@ class DialMobileStasis:
             args,
         )
 
-        if not args or len(args) < ARG_LEN_BY_COMMAND[args[0]]:
-            logger.info('%s called without enough arguments %s', self._app_name, args)
-            return
-
-        action = args[0]
-        origin_channel_id = event['channel']['channelvars']['CHANNEL(linkedid)']
-
-        if action == 'dial':
-            aor = args[1]
-            self._service.dial_all_contacts(channel_id, origin_channel_id, aor)
-        elif action == 'join':
-            future_bridge_uuid = args[1]
-            self._service.join_bridge(channel_id, future_bridge_uuid)
-        elif action == 'pickup':
-            exten, context = args[1], args[2]
-            future_bridge_uuid = self._service.find_bridge_by_exten_context(
-                exten, context
-            )
-            if future_bridge_uuid:
+        match args:
+            case ['dial', aor]:
+                origin_channel_id = event['channel']['channelvars']['CHANNEL(linkedid)']
+                self._service.dial_all_contacts(channel_id, origin_channel_id, aor)
+            case ['join', future_bridge_uuid]:
                 self._service.join_bridge(channel_id, future_bridge_uuid)
-            else:
-                logger.debug('no matching mobile pickup found')
-                self._ari.channels.continueInDialplan(channelId=channel_id)
+            case ['pickup', exten, context]:
+                future_bridge_uuid = self._service.find_bridge_by_exten_context(
+                    exten, context
+                )
+                if future_bridge_uuid:
+                    self._service.join_bridge(channel_id, future_bridge_uuid)
+                else:
+                    logger.debug('no matching mobile pickup found')
+                    self._ari.channels.continueInDialplan(channelId=channel_id)
+            case _:
+                logger.info(
+                    '%s called with unknown or insufficient arguments %s',
+                    self._app_name,
+                    args,
+                )
 
     def on_channel_left_bridge(self, channel, event):
         if event['application'] != self._app_name:

--- a/wazo_calld/plugins/dial_mobile/stasis.py
+++ b/wazo_calld/plugins/dial_mobile/stasis.py
@@ -1,7 +1,15 @@
 # Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from wazo_calld.ari_ import CoreARI
+
+    from .services import DialMobileService
 
 logger = logging.getLogger(__name__)
 
@@ -9,7 +17,7 @@ logger = logging.getLogger(__name__)
 class DialMobileStasis:
     _app_name = 'dial_mobile'
 
-    def __init__(self, ari, service):
+    def __init__(self, ari: CoreARI, service: DialMobileService):
         self._core_ari = ari
         self._ari = ari.client
         self._service = service
@@ -64,10 +72,45 @@ class DialMobileStasis:
     def channel_destroyed(self, channel, event):
         self._service.notify_channel_gone(event['channel']['id'])
 
+    _DIALABLE_CONTACT_STATUSES = frozenset({'Created', 'NonQualified', 'Reachable'})
+
+    def on_contact_status_change(self, event_object, event):
+        if event.get('application') != self._app_name:
+            return
+        contact_info = event.get('contact_info') or {}
+        if contact_info.get('contact_status') not in self._DIALABLE_CONTACT_STATUSES:
+            return
+        aor = contact_info.get('aor')
+        if not aor:
+            return
+        self._service.notify_contact_available(aor)
+
     def _subscribe(self):
         self._ari.on_channel_event('StasisStart', self.stasis_start)
         self._ari.on_channel_event('ChannelLeftBridge', self.on_channel_left_bridge)
         self._ari.on_channel_event('ChannelDestroyed', self.channel_destroyed)
+        self._ari.on_endpoint_event(
+            'ContactStatusChange', self.on_contact_status_change
+        )
+        self._ari.on_application_registered(
+            self._app_name, self.subscribe_to_pjsip_endpoint_events
+        )
+        self._ari.on_application_deregistered(
+            self._app_name, self.unsubscribe_from_pjsip_endpoint_events
+        )
+
+    def subscribe_to_pjsip_endpoint_events(self):
+        # Subscribing to the endpoint event source is required for
+        # `ContactStatusChange` events to be delivered to the dial_mobile
+        # application; otherwise only channel-scoped events flow.
+        self._ari.applications.subscribe(
+            applicationName=self._app_name, eventSource='endpoint:PJSIP'
+        )
+
+    def unsubscribe_from_pjsip_endpoint_events(self):
+        self._ari.applications.unsubscribe(
+            applicationName=self._app_name, eventSource='endpoint:PJSIP'
+        )
 
     def initialize(self):
         self._subscribe()

--- a/wazo_calld/plugins/dial_mobile/tests/test_bus_consume.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_bus_consume.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2022-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
@@ -202,7 +202,7 @@ class TestEventHandler(TestCase):
         self.event_handler._on_bridge_enter(event)
 
         self.service.cancel_push_mobile.assert_not_called()
-        self.service.remove_pending_push_mobile.assert_not_called()
+        self.service.complete_pending_push_mobile.assert_not_called()
 
     def test_on_bridge_enter_ignore_not_pjsip(self):
         event = {
@@ -215,7 +215,7 @@ class TestEventHandler(TestCase):
         self.event_handler._on_bridge_enter(event)
 
         self.service.cancel_push_mobile.assert_not_called()
-        self.service.remove_pending_push_mobile.assert_not_called()
+        self.service.complete_pending_push_mobile.assert_not_called()
 
     def test_on_bridge_enter_not_answered_by_mobile(self):
         self.service.has_a_registered_mobile_and_pending_push.return_value = False
@@ -240,7 +240,7 @@ class TestEventHandler(TestCase):
         )
 
         self.service.cancel_push_mobile.assert_called_once_with(s.linkedid)
-        self.service.remove_pending_push_mobile.assert_not_called()
+        self.service.complete_pending_push_mobile.assert_not_called()
 
     def test_on_bridge_enter_answered_by_mobile(self):
         self.service.has_a_registered_mobile_and_pending_push.return_value = True
@@ -265,7 +265,7 @@ class TestEventHandler(TestCase):
         )
 
         self.service.cancel_push_mobile.assert_not_called()
-        self.service.remove_pending_push_mobile.assert_called_once_with(s.linkedid)
+        self.service.complete_pending_push_mobile.assert_called_once_with(s.linkedid)
 
     def test_on_bridge_enter_caller_hung_up(self):
         self.service.has_a_registered_mobile_and_pending_push.side_effect = ARINotFound(
@@ -292,4 +292,4 @@ class TestEventHandler(TestCase):
         )
 
         self.service.cancel_push_mobile.assert_called_once_with(s.linkedid)
-        self.service.remove_pending_push_mobile.assert_not_called()
+        self.service.complete_pending_push_mobile.assert_not_called()

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
@@ -11,7 +11,7 @@ from ari.exceptions import ARINotFound
 from hamcrest import assert_that, contains_exactly, empty, equal_to, has_items
 
 from ..notifier import Notifier
-from ..services import DialMobileService, _NoSuchChannel
+from ..services import DialMobileService, PendingPushMobile, _NoSuchChannel
 from ..services import _PollingContactDialer as PollingContactDialer
 
 
@@ -212,9 +212,14 @@ class DialMobileServiceTestCase(DialerTestCase):
         self.ari.client = self.ari_client = Mock()
         self.amid_client = Mock()
         self.auth_client = Mock()
+        self.confd_client = Mock()
         self.notifier = Mock(Notifier)
         self.service = DialMobileService(
-            self.ari, self.notifier, self.amid_client, self.auth_client
+            self.ari,
+            self.notifier,
+            self.amid_client,
+            self.auth_client,
+            self.confd_client,
         )
         self.channel_id = '1234567890.42'
         self.aor = 'foobar'
@@ -341,14 +346,20 @@ class TestCancelPushNotification(TestCase):
         self.notifier = Mock(Notifier)
         self.amid_client = Mock()
         self.auth_client = Mock()
+        self.confd_client = Mock()
         self.service = DialMobileService(
-            self.ari, self.notifier, self.amid_client, self.auth_client
+            self.ari,
+            self.notifier,
+            self.amid_client,
+            self.auth_client,
+            self.confd_client,
         )
 
     def test_that_nothing_happens_when_not_a_pending_push(self):
         self.service.cancel_push_mobile(s.call_id)
 
-    def test_that_original_payload_is_sent_when_canceling(self):
+    @patch('wazo_calld.plugins.dial_mobile.services.threading.Timer')
+    def test_that_original_payload_is_sent_when_canceling(self, _mock_timer):
         self.service.send_push_notification(
             s.tenant_uuid,
             s.user_uuid,
@@ -357,7 +368,7 @@ class TestCancelPushNotification(TestCase):
             s.cid_name,
             s.cid_num,
             s.video_enabled,
-            s.ring_timeout,
+            30,
             s.origin_call_id,
             s.push_mobile_timestamp,
         )
@@ -368,4 +379,115 @@ class TestCancelPushNotification(TestCase):
 
         self.notifier.cancel_push_notification.assert_called_once_with(
             payload, s.tenant_uuid, s.user_uuid
+        )
+
+
+class TestPSTNFallback(TestCase):
+    def setUp(self):
+        self.ari = Mock()
+        self.ari.client = self.ari_client = Mock()
+        self.notifier = Mock(Notifier)
+        self.amid_client = Mock()
+        self.auth_client = Mock()
+        self.confd_client = Mock()
+        self.service = DialMobileService(
+            self.ari,
+            self.notifier,
+            self.amid_client,
+            self.auth_client,
+            self.confd_client,
+        )
+
+    def _make_pending(self, call_id='call-id', origin_call_id='origin-id'):
+        return PendingPushMobile(
+            call_id=call_id,
+            tenant_uuid='tenant-uuid',
+            user_uuid='user-uuid',
+            origin_call_id=origin_call_id,
+            payload={
+                'peer_caller_id_name': 'Alice',
+                'peer_caller_id_number': '101',
+            },
+        )
+
+    @patch('wazo_calld.plugins.dial_mobile.services.threading.Timer')
+    def test_pstn_fallback_timer_starts_on_push_notification(self, mock_timer_cls):
+        self.service.send_push_notification(
+            tenant_uuid='t-uuid',
+            user_uuid='u-uuid',
+            call_id='call-id',
+            sip_call_id='sip-id',
+            caller_id_name='Alice',
+            caller_id_number='101',
+            video_enabled=False,
+            ring_timeout=30,
+            origin_call_id='origin-id',
+            push_mobile_timestamp='ts',
+        )
+
+        mock_timer_cls.assert_called_once_with(
+            15.0, self.service._pstn_fallback, args=['call-id']
+        )
+        mock_timer_cls.return_value.start.assert_called_once()
+        assert 'call-id' in self.service._pstn_fallback_timers
+
+    def test_pstn_fallback_timer_cancelled_on_cancel_push(self):
+        timer = Mock()
+        self.service._pstn_fallback_timers['call-id'] = timer
+        self.service._pending_push_mobile['call-id'] = self._make_pending()
+
+        self.service.cancel_push_mobile('call-id')
+
+        timer.cancel.assert_called_once()
+
+    def test_pstn_fallback_timer_cancelled_on_join_bridge(self):
+        timer = Mock()
+        self.service._pstn_fallback_timers['call-id'] = timer
+        self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
+        self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'origin-id'
+
+        dialer = Mock()
+        self.service._contact_dialers['bridge-uuid'] = dialer
+        self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
+
+        self.service.join_bridge('mobile-ch', 'bridge-uuid')
+
+        timer.cancel.assert_called_once()
+
+    def test_pstn_fallback_noop_when_no_pending_push(self):
+        self.service._pstn_fallback('nonexistent-call-id')
+
+        self.ari_client.channels.originate.assert_not_called()
+
+    def test_pstn_fallback_noop_when_no_mobile_number(self):
+        self.service._pending_push_mobile['call-id'] = self._make_pending()
+        self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
+        self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
+        self.confd_client.users.get.return_value = {
+            'mobile_phone_number': None,
+            'lines': [],
+        }
+
+        self.service._pstn_fallback('call-id')
+
+        self.ari_client.channels.originate.assert_not_called()
+
+    def test_pstn_fallback_originates_local_channel(self):
+        self.service._pending_push_mobile['call-id'] = self._make_pending()
+        self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
+        self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
+        self.confd_client.users.get.return_value = {
+            'mobile_phone_number': '+33123456789',
+            'lines': [{'id': 42}],
+        }
+        self.confd_client.lines.get.return_value = {'context': 'my-outbound-context'}
+
+        self.service._pstn_fallback('call-id')
+
+        self.ari_client.channels.originate.assert_called_once_with(
+            endpoint='Local/+33123456789@my-outbound-context',
+            app='dial_mobile',
+            appArgs=['join', 'bridge-uuid'],
+            callerId='"Alice" <101>',
+            originator='caller-ch',
         )

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -459,11 +459,24 @@ class TestPSTNFallback(TestCase):
 
         self.ari_client.channels.originate.assert_not_called()
 
+    def test_pstn_fallback_noop_when_fallback_disabled(self):
+        self.service._pending_push_mobile['call-id'] = self._make_pending()
+        self.confd_client.users.get.return_value = {
+            'mobile_fallback_enabled': False,
+            'mobile_phone_number': '+33123456789',
+            'lines': [{'id': 42}],
+        }
+
+        self.service._pstn_fallback('call-id')
+
+        self.ari_client.channels.originate.assert_not_called()
+
     def test_pstn_fallback_noop_when_no_mobile_number(self):
         self.service._pending_push_mobile['call-id'] = self._make_pending()
         self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
         self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
         self.confd_client.users.get.return_value = {
+            'mobile_fallback_enabled': True,
             'mobile_phone_number': None,
             'lines': [],
         }
@@ -477,6 +490,7 @@ class TestPSTNFallback(TestCase):
         self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
         self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
         self.confd_client.users.get.return_value = {
+            'mobile_fallback_enabled': True,
             'mobile_phone_number': '+33123456789',
             'lines': [{'id': 42}],
         }

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -344,8 +344,9 @@ class DialMobileServiceTestCase(DialerTestCase):
         self.service._call_id_by_origin_call_id[self.origin_channel_id] = 'call-id'
         timer = Mock()
         self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
-            call_id='call-id', timer=timer, lock=threading.Lock()
+            call_id='call-id', timer=timer
         )
+        self.service._call_locks['call-id'] = threading.RLock()
         # mock cancel_push_mobile so it does NOT cancel the timer — proves
         # notify_channel_gone cancels it independently
         with patch.object(self.service, 'cancel_push_mobile'):
@@ -558,8 +559,9 @@ class TestPSTNFallback(TestCase):
     def test_cancel_push_does_not_touch_pstn_timer(self):
         timer = Mock()
         self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
-            call_id='call-id', timer=timer, lock=threading.Lock()
+            call_id='call-id', timer=timer
         )
+        self.service._call_locks['call-id'] = threading.RLock()
         self.service._incoming_calls['call-id'] = self._make_notified()
 
         self.service.cancel_push_mobile('call-id')
@@ -579,8 +581,9 @@ class TestPSTNFallback(TestCase):
     def test_pstn_fallback_timer_cancelled_on_join_bridge(self):
         timer = Mock()
         self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
-            call_id='call-id', timer=timer, lock=threading.Lock()
+            call_id='call-id', timer=timer
         )
+        self.service._call_locks['call-id'] = threading.RLock()
         self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
         self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'origin-id'
 
@@ -628,8 +631,9 @@ class TestPSTNFallback(TestCase):
         self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
         self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
         self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
-            call_id='call-id', timer=Mock(), lock=threading.Lock()
+            call_id='call-id', timer=Mock()
         )
+        self.service._call_locks['call-id'] = threading.RLock()
         self.confd_client.users.get.return_value = {
             'mobile_fallback_enabled': True,
             'mobile_phone_number': '+33123456789',
@@ -685,8 +689,9 @@ class TestPSTNFallback(TestCase):
         self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
         self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
         self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
-            call_id='call-id', timer=Mock(), lock=threading.Lock()
+            call_id='call-id', timer=Mock()
         )
+        self.service._call_locks['call-id'] = threading.RLock()
         self.confd_client.users.get.return_value = {
             'mobile_fallback_enabled': True,
             'mobile_phone_number': '+33123456789',
@@ -707,8 +712,8 @@ class TestPSTNFallback(TestCase):
         self.service._pstn_fallbacks['call-id'] = PSTNFallbackDialing(
             call_id='call-id',
             channel_id='pstn-channel-id',
-            lock=threading.Lock(),
         )
+        self.service._call_locks['call-id'] = threading.RLock()
 
         self.service._cancel_pstn_fallback('call-id')
 
@@ -723,8 +728,8 @@ class TestPSTNFallback(TestCase):
         self.service._pstn_fallbacks['call-id'] = PSTNFallbackDialing(
             call_id='call-id',
             channel_id='pstn-channel-id',
-            lock=threading.Lock(),
         )
+        self.service._call_locks['call-id'] = threading.RLock()
         self.ari_client.channels.hangup.side_effect = ARINotFound(
             self.ari_client, s.error
         )
@@ -740,8 +745,8 @@ class TestPSTNFallback(TestCase):
         self.service._pstn_fallbacks['call-id'] = PSTNFallbackDialing(
             call_id='call-id',
             channel_id='pstn-channel-id',
-            lock=threading.Lock(),
         )
+        self.service._call_locks['call-id'] = threading.RLock()
         self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
         self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'origin-id'
 
@@ -760,8 +765,8 @@ class TestPSTNFallback(TestCase):
         self.service._pstn_fallbacks['call-id'] = PSTNFallbackDialing(
             call_id='call-id',
             channel_id='pstn-channel-id',
-            lock=threading.Lock(),
         )
+        self.service._call_locks['call-id'] = threading.RLock()
         self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
         self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'origin-id'
 
@@ -783,8 +788,8 @@ class TestPSTNFallback(TestCase):
         self.service._pstn_fallbacks['call-id'] = PSTNFallbackDialing(
             call_id='call-id',
             channel_id='pstn-channel-id',
-            lock=threading.Lock(),
         )
+        self.service._call_locks['call-id'] = threading.RLock()
         self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
 
         self.ari.client.channels.getChannelVar.return_value = {'value': 'pickupmark'}
@@ -806,8 +811,9 @@ class TestPSTNFallback(TestCase):
         # the PSTN fallback must be cancelled.
         timer = Mock()
         self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
-            call_id='call-id', timer=timer, lock=threading.Lock()
+            call_id='call-id', timer=timer
         )
+        self.service._call_locks['call-id'] = threading.RLock()
         self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
 
         self.ari.client.channels.getChannelVar.return_value = {'value': 'pickupmark'}
@@ -831,8 +837,9 @@ class TestPSTNFallback(TestCase):
         self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
         self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
         self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
-            call_id='call-id', timer=Mock(), lock=threading.Lock()
+            call_id='call-id', timer=Mock()
         )
+        self.service._call_locks['call-id'] = threading.RLock()
         self.confd_client.users.get.return_value = {
             'mobile_fallback_enabled': True,
             'mobile_phone_number': '+33123456789',
@@ -913,10 +920,10 @@ class TestPSTNFallback(TestCase):
         timer_a = Mock()
         timer_b = Mock()
         self.service._pstn_fallbacks['call-a'] = PSTNFallbackPending(
-            call_id='call-a', timer=timer_a, lock=threading.Lock()
+            call_id='call-a', timer=timer_a
         )
         self.service._pstn_fallbacks['call-b'] = PSTNFallbackPending(
-            call_id='call-b', timer=timer_b, lock=threading.Lock()
+            call_id='call-b', timer=timer_b
         )
 
         self.service.on_calld_stopping()
@@ -928,8 +935,9 @@ class TestPSTNFallback(TestCase):
     def test_cancel_pstn_fallback_transitions_pending_to_cancelled(self):
         timer = Mock()
         self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
-            call_id='call-id', timer=timer, lock=threading.Lock()
+            call_id='call-id', timer=timer
         )
+        self.service._call_locks['call-id'] = threading.RLock()
 
         self.service._cancel_pstn_fallback('call-id')
 

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -551,6 +551,36 @@ class TestPSTNFallback(TestCase):
             self.service._pstn_fallbacks.get('call-id'), PSTNFallbackPending
         )
 
+    def test_send_push_notification_always_creates_call_lock(self):
+        # The per-call lock must be created on every push so concurrent
+        # IncomingCall transitions can be serialized, even when no PSTN
+        # fallback is armed for the call.
+        self.confd_client.users.get.return_value = {
+            'mobile_fallback_enabled': False,
+            'mobile_phone_number': None,
+        }
+
+        self._send_push()
+
+        assert 'call-id' in self.service._call_locks
+
+    def test_call_lock_reused_across_transitions(self):
+        # Reusing the same RLock across transitions is what gives us
+        # mutual exclusion; if a second push call for the same id
+        # somehow arrived, it must not replace the lock another thread
+        # may currently be holding.
+        self.confd_client.users.get.return_value = {
+            'mobile_fallback_enabled': False,
+            'mobile_phone_number': None,
+        }
+        self._send_push()
+        first_lock = self.service._call_locks['call-id']
+
+        self._send_push()
+        second_lock = self.service._call_locks['call-id']
+
+        assert first_lock is second_lock
+
     @patch('wazo_calld.plugins.dial_mobile.services.threading.Timer')
     def test_pstn_fallback_timer_skipped_when_disabled(self, mock_timer_cls):
         self.confd_client.users.get.return_value = {

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -992,3 +992,20 @@ class TestPSTNFallback(TestCase):
         self.service._pstn_fallback('call-id')
 
         self.ari_client.channels.originate.assert_not_called()
+
+    def test_pstn_fallback_aborts_cleanly_when_caller_channel_lookup_fails(self):
+        # ARI infrastructure failure (e.g. ARI down, network issue) during
+        # the caller-channel presence check must abort the fallback cleanly
+        # — push stays active, state transitions to Cancelled, Timer thread
+        # does not die with an unhandled exception.
+        self._setup_eligible_fallback()
+        self.ari_client.channels.get.side_effect = requests.HTTPError()
+
+        with patch.object(self.service, 'cancel_push_mobile') as cancel_push:
+            self.service._pstn_fallback('call-id')
+
+        cancel_push.assert_not_called()
+        self.ari_client.channels.originate.assert_not_called()
+        assert isinstance(
+            self.service._pstn_fallbacks.get('call-id'), PSTNFallbackCancelled
+        )

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -311,8 +311,7 @@ class DialMobileServiceTestCase(DialerTestCase):
         mock_dialed_channel = Mock()
         mock_dialed_channel.id = dialed_channel_id
         dialer._dialed_channels.add(mock_dialed_channel)
-        dialer.should_stop.set()
-        dialer._thread.join()
+        dialer.stop()
 
         self.service.notify_channel_gone(dialed_channel_id)
 
@@ -339,8 +338,7 @@ class DialMobileServiceTestCase(DialerTestCase):
         mock_dialed_channel = Mock()
         mock_dialed_channel.id = dialed_channel_id
         dialer._dialed_channels.add(mock_dialed_channel)
-        dialer.should_stop.set()
-        dialer._thread.join()
+        dialer.stop()
 
         # wire up call_id mapping and PSTN timer
         self.service._call_id_by_origin_call_id[self.origin_channel_id] = 'call-id'
@@ -587,6 +585,38 @@ class TestPSTNFallback(TestCase):
             variables={'variables': {'_WAZO_TENANT_UUID': 'tenant-uuid'}},
         )
 
+    def test_notify_contact_available_kicks_matching_dialers(self):
+        dialer_a = Mock()
+        dialer_b = Mock()
+        dialer_other = Mock()
+        self.service._dialers_by_aor = {
+            'aor-a': {dialer_a, dialer_b},
+            'aor-b': {dialer_other},
+        }
+
+        self.service.notify_contact_available('aor-a')
+
+        dialer_a.kick.assert_called_once_with()
+        dialer_b.kick.assert_called_once_with()
+        dialer_other.kick.assert_not_called()
+
+    def test_notify_contact_available_unknown_aor_is_noop(self):
+        self.service.notify_contact_available('unknown-aor')
+
+    def test_dial_all_contacts_registers_dialer_by_aor(self):
+        self.ari.client.channels.getChannelVar.return_value = {'value': 'pickupmark'}
+        self.ari.client.channels.get.return_value = Mock(
+            json={'caller': {'name': 'Test', 'number': '1001'}}
+        )
+
+        self.service.dial_all_contacts('caller-ch', 'origin-id', 'my-aor')
+
+        bridge_uuid = next(iter(self.service._contact_dialers))
+        dialer = self.service._contact_dialers[bridge_uuid]
+        assert dialer in self.service._dialers_by_aor['my-aor']
+        # Cleanup
+        dialer.stop()
+
     def test_pstn_fallback_records_originated_channel_id(self):
         self.service._incoming_calls['call-id'] = self._make_notified()
         self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
@@ -683,8 +713,7 @@ class TestPSTNFallback(TestCase):
         self.service.dial_all_contacts(caller_channel_id, 'origin-id', 'aor')
         bridge_uuid = next(iter(self.service._contact_dialers))
         dialer = self.service._contact_dialers[bridge_uuid]
-        dialer.should_stop.set()
-        dialer._thread.join()
+        dialer.stop()
 
         with patch.object(self.service, 'cancel_push_mobile'):
             self.service.notify_channel_gone(caller_channel_id)
@@ -706,8 +735,7 @@ class TestPSTNFallback(TestCase):
 
         bridge_uuid = next(iter(self.service._contact_dialers))
         dialer = self.service._contact_dialers[bridge_uuid]
-        dialer.should_stop.set()
-        dialer._thread.join()
+        dialer.stop()
 
         # Simulate the polling thread finding a contact and dialing it.
         dialer._send_contact_to_current_call('sip:contact', bridge_uuid, 'caller-id')

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -360,7 +360,7 @@ class DialMobileServiceTestCase(DialerTestCase):
 
         with patch.object(self.service, 'cancel_push_mobile') as push_cancel:
             self.service.join_bridge(s.channel_id, s.bridge_uuid)
-            push_cancel.assert_called_once_with(s.call_id)
+            push_cancel.assert_not_called()
 
         self.ari_client.channels.hangup.assert_called_once_with(channelId=s.channel_id)
 

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -923,6 +923,19 @@ class TestPSTNFallback(TestCase):
             self.service._pstn_fallbacks.get('call-id'), PSTNFallbackDialing
         )
 
+    def test_cancel_pstn_fallback_asserts_when_state_present_without_lock(self):
+        # Invariant: _pstn_fallbacks[call_id] and _call_locks[call_id] share
+        # their lifetime (always pruned together in _prune_call_state). If
+        # the lock is missing but a fallback state is present, that's a bug
+        # that would otherwise leak a ringing PSTN channel.
+        self.service._pstn_fallbacks['call-id'] = PSTNFallbackDialing(
+            call_id='call-id',
+            channel_id='pstn-channel-id',
+        )
+
+        with pytest.raises(AssertionError):
+            self.service._cancel_pstn_fallback('call-id')
+
     def test_join_bridge_hangs_up_active_pstn_channel(self):
         # pickup or mobile-answer must tear down an in-progress PSTN call
         self.service._pstn_fallbacks['call-id'] = PSTNFallbackDialing(

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -506,3 +506,21 @@ class TestPSTNFallback(TestCase):
             originator='caller-ch',
             variables={'variables': {'_WAZO_TENANT_UUID': 'tenant-uuid'}},
         )
+
+    def test_pstn_fallback_noop_when_caller_channel_gone(self):
+        self.service._pending_push_mobile['call-id'] = self._make_pending()
+        self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
+        self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
+        self.confd_client.users.get.return_value = {
+            'mobile_fallback_enabled': True,
+            'mobile_phone_number': '+33123456789',
+            'lines': [{'id': 42}],
+        }
+        self.confd_client.lines.get.return_value = {'context': 'my-outbound-context'}
+        self.ari_client.channels.get.side_effect = ARINotFound(
+            s.ari_client, s.original_error
+        )
+
+        self.service._pstn_fallback('call-id')
+
+        self.ari_client.channels.originate.assert_not_called()

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -480,25 +480,70 @@ class TestPSTNFallback(TestCase):
             },
         )
 
+    def _send_push(self, **overrides):
+        kwargs = {
+            'tenant_uuid': 't-uuid',
+            'user_uuid': 'u-uuid',
+            'call_id': 'call-id',
+            'sip_call_id': 'sip-id',
+            'caller_id_name': 'Alice',
+            'caller_id_number': '101',
+            'video_enabled': False,
+            'ring_timeout': 30,
+            'origin_call_id': 'origin-id',
+            'push_mobile_timestamp': 'ts',
+        }
+        kwargs.update(overrides)
+        self.service.send_push_notification(**kwargs)
+
     @patch('wazo_calld.plugins.dial_mobile.services.threading.Timer')
     def test_pstn_fallback_timer_starts_on_push_notification(self, mock_timer_cls):
-        self.service.send_push_notification(
-            tenant_uuid='t-uuid',
-            user_uuid='u-uuid',
-            call_id='call-id',
-            sip_call_id='sip-id',
-            caller_id_name='Alice',
-            caller_id_number='101',
-            video_enabled=False,
-            ring_timeout=30,
-            origin_call_id='origin-id',
-            push_mobile_timestamp='ts',
-        )
+        self.confd_client.users.get.return_value = {
+            'mobile_fallback_enabled': True,
+            'mobile_phone_number': '+33123456789',
+        }
+
+        self._send_push()
 
         mock_timer_cls.assert_called_once_with(
             15.0, self.service._pstn_fallback, args=['call-id']
         )
         mock_timer_cls.return_value.start.assert_called_once()
+        assert 'call-id' in self.service._pstn_fallback_timers
+
+    @patch('wazo_calld.plugins.dial_mobile.services.threading.Timer')
+    def test_pstn_fallback_timer_skipped_when_disabled(self, mock_timer_cls):
+        self.confd_client.users.get.return_value = {
+            'mobile_fallback_enabled': False,
+            'mobile_phone_number': '+33123456789',
+        }
+
+        self._send_push()
+
+        mock_timer_cls.assert_not_called()
+        assert 'call-id' not in self.service._pstn_fallback_timers
+
+    @patch('wazo_calld.plugins.dial_mobile.services.threading.Timer')
+    def test_pstn_fallback_timer_skipped_when_no_mobile_number(self, mock_timer_cls):
+        self.confd_client.users.get.return_value = {
+            'mobile_fallback_enabled': True,
+            'mobile_phone_number': None,
+        }
+
+        self._send_push()
+
+        mock_timer_cls.assert_not_called()
+        assert 'call-id' not in self.service._pstn_fallback_timers
+
+    @patch('wazo_calld.plugins.dial_mobile.services.threading.Timer')
+    def test_pstn_fallback_timer_armed_on_confd_error(self, mock_timer_cls):
+        # If we can't determine eligibility, preserve the existing behavior:
+        # arm the timer and let _pstn_fallback handle the re-check.
+        self.confd_client.users.get.side_effect = requests.HTTPError()
+
+        self._send_push()
+
+        mock_timer_cls.assert_called_once()
         assert 'call-id' in self.service._pstn_fallback_timers
 
     def test_cancel_push_does_not_touch_pstn_timer(self):
@@ -741,6 +786,132 @@ class TestPSTNFallback(TestCase):
         dialer._send_contact_to_current_call('sip:contact', bridge_uuid, 'caller-id')
 
         timer.cancel.assert_called_once()
+
+    def test_pstn_fallback_aborts_when_cancelled_before_run(self):
+        # Cancellation arrived between timer firing and the callback executing.
+        self.service._pstn_fallback_cancelled.add('call-id')
+        self.service._incoming_calls['call-id'] = self._make_notified()
+
+        self.service._pstn_fallback('call-id')
+
+        self.ari_client.channels.originate.assert_not_called()
+        # Flag is cleaned up so the set doesn't grow forever.
+        assert 'call-id' not in self.service._pstn_fallback_cancelled
+
+    def test_pstn_fallback_aborts_when_cancelled_during_confd(self):
+        # Mobile registers (cancellation arrives) while we're still doing
+        # the confd lookups inside _pstn_fallback. We must abort before
+        # cancelling the push and before originating.
+        self.service._incoming_calls['call-id'] = self._make_notified()
+
+        def confd_side_effect(*args, **kwargs):
+            self.service._pstn_fallback_cancelled.add('call-id')
+            return {
+                'mobile_fallback_enabled': True,
+                'mobile_phone_number': '+33123456789',
+                'lines': [{'id': 42}],
+            }
+
+        self.confd_client.users.get.side_effect = confd_side_effect
+
+        with patch.object(self.service, 'cancel_push_mobile') as cancel_push:
+            self.service._pstn_fallback('call-id')
+
+        cancel_push.assert_not_called()
+        self.ari_client.channels.originate.assert_not_called()
+
+    def test_pstn_fallback_hangs_up_channel_if_cancelled_during_originate(self):
+        # Cancellation arrives between the confd lookups and the originate.
+        # Once originate returns, we must hang up the just-created channel
+        # and not record it in _pstn_fallback_channels.
+        self.service._incoming_calls['call-id'] = self._make_notified()
+        self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
+        self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
+        self.confd_client.users.get.return_value = {
+            'mobile_fallback_enabled': True,
+            'mobile_phone_number': '+33123456789',
+            'lines': [{'id': 42}],
+        }
+        self.confd_client.lines.get.return_value = {'context': 'my-outbound-context'}
+
+        originated = Mock()
+        originated.id = 'pstn-channel-id'
+
+        def originate_side_effect(*args, **kwargs):
+            self.service._pstn_fallback_cancelled.add('call-id')
+            return originated
+
+        self.ari_client.channels.originate.side_effect = originate_side_effect
+
+        self.service._pstn_fallback('call-id')
+
+        self.ari_client.channels.hangup.assert_called_with(channelId='pstn-channel-id')
+        assert 'call-id' not in self.service._pstn_fallback_channels
+
+    def test_join_bridge_prunes_call_state(self):
+        # Successful bridge creation should clean up per-call mapping dicts
+        # so they don't grow unbounded.
+        self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
+        self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'origin-id'
+        self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
+        self.service._call_ring_time['origin-id'] = 30
+        dialer = Mock()
+        self.service._contact_dialers['bridge-uuid'] = dialer
+        self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
+
+        self.service.join_bridge('mobile-ch', 'bridge-uuid')
+
+        assert 'bridge-uuid' not in self.service._origin_call_id_by_bridge_uuid
+        assert 'origin-id' not in self.service._bridge_uuid_by_origin_call_id
+        assert 'origin-id' not in self.service._call_id_by_origin_call_id
+        assert 'origin-id' not in self.service._call_ring_time
+        assert 'bridge-uuid' not in self.service._outgoing_calls
+
+    def test_notify_channel_gone_prunes_call_state(self):
+        caller_channel_id = '1234567890.42'
+        dialed_channel_id = '1234567890.99'
+
+        self.ari.client.channels.getChannelVar.return_value = {'value': 'pickupmark'}
+        self.ari.client.channels.get.return_value = Mock(
+            json={'caller': {'name': 'Test', 'number': '1001'}}
+        )
+
+        self.service.dial_all_contacts(caller_channel_id, 'origin-id', 'aor')
+        bridge_uuid = next(iter(self.service._contact_dialers))
+        assert 'origin-id' in self.service._bridge_uuid_by_origin_call_id
+
+        dialer = self.service._contact_dialers[bridge_uuid]
+        mock_dialed_channel = Mock()
+        mock_dialed_channel.id = dialed_channel_id
+        dialer._dialed_channels.add(mock_dialed_channel)
+        dialer.stop()
+
+        self.service.notify_channel_gone(dialed_channel_id)
+
+        assert bridge_uuid not in self.service._origin_call_id_by_bridge_uuid
+        assert 'origin-id' not in self.service._bridge_uuid_by_origin_call_id
+        assert 'origin-id' not in self.service._call_id_by_origin_call_id
+        assert 'origin-id' not in self.service._call_ring_time
+        assert bridge_uuid not in self.service._outgoing_calls
+
+    def test_on_calld_stopping_cancels_pstn_timers(self):
+        timer_a = Mock()
+        timer_b = Mock()
+        self.service._pstn_fallback_timers['call-a'] = timer_a
+        self.service._pstn_fallback_timers['call-b'] = timer_b
+
+        self.service.on_calld_stopping()
+
+        timer_a.cancel.assert_called_once()
+        timer_b.cancel.assert_called_once()
+        assert self.service._pstn_fallback_timers == {}
+
+    def test_cancel_pstn_fallback_marks_cancelled(self):
+        # Even when no timer/channel is recorded yet, _cancel_pstn_fallback
+        # must flag the call so a racing _pstn_fallback can abort.
+        self.service._cancel_pstn_fallback('call-id')
+
+        assert 'call-id' in self.service._pstn_fallback_cancelled
 
     def test_pstn_fallback_noop_when_caller_channel_gone(self):
         self.service._incoming_calls['call-id'] = self._make_notified()

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -870,6 +870,35 @@ class TestPSTNFallback(TestCase):
 
         self.ari_client.channels.originate.assert_called_once()
 
+    def test_pstn_fallback_originate_failure_preserves_push(self):
+        # If originate fails, the push must remain active so the mobile can
+        # still register and answer. Cancelling push before a confirmed PSTN
+        # dispatch would silently drop the call when originate raises.
+        self._setup_eligible_fallback()
+        self.ari_client.channels.originate.side_effect = requests.HTTPError()
+
+        with patch.object(self.service, 'cancel_push_mobile') as cancel_push:
+            self.service._pstn_fallback('call-id')
+
+        cancel_push.assert_not_called()
+        assert isinstance(
+            self.service._pstn_fallbacks.get('call-id'), PSTNFallbackCancelled
+        )
+
+    def test_pstn_fallback_originate_success_cancels_push(self):
+        # Push must be cancelled only after a successful originate so that
+        # both legs of the commit succeed or neither does.
+        self._setup_eligible_fallback()
+
+        with patch.object(self.service, 'cancel_push_mobile') as cancel_push:
+            self.service._pstn_fallback('call-id')
+
+        cancel_push.assert_called_once_with('call-id')
+        self.ari_client.channels.originate.assert_called_once()
+        assert isinstance(
+            self.service._pstn_fallbacks.get('call-id'), PSTNFallbackDialing
+        )
+
     def test_join_bridge_prunes_call_state(self):
         # Successful bridge creation should clean up per-call mapping dicts
         # so they don't grow unbounded.

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -21,9 +21,9 @@ from ..services import (
     PSTNFallbackCancelled,
     PSTNFallbackDialing,
     PSTNFallbackPending,
+    _ContactDialer,
     _NoSuchChannel,
 )
-from ..services import _PollingContactDialer as PollingContactDialer
 
 
 class DialerTestCase(TestCase):
@@ -35,7 +35,7 @@ class DialerTestCase(TestCase):
         self.ringing_time = 42
         self.pickup_mark = '1003%default'
 
-        self.poller = PollingContactDialer(
+        self.poller = _ContactDialer(
             self.ari,
             self.future_bridge_uuid,
             self.channel_id,
@@ -584,7 +584,6 @@ class TestPSTNFallback(TestCase):
         self._send_push(call_id='channel-uniqueid', origin_call_id='call-linkedid')
 
         self.service.complete_pending_push_mobile('call-linkedid')
-
         from ..services import IncomingCallReceived
 
         assert isinstance(

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -366,7 +366,7 @@ class DialMobileServiceTestCase(DialerTestCase):
     def test_join_bridge_caller_gone_will_hangup(self):
         dialer = Mock()
         self.service._contact_dialers = {s.bridge_uuid: dialer}
-        self.service._outgoing_calls = {s.bridge_uuid: s.caller_channel}
+        self.service._caller_channel_leg_by_bridge = {s.bridge_uuid: s.caller_channel}
         self.service._origin_call_id_by_bridge_uuid[s.bridge_uuid] = s.origin_call_id
         self.service._call_id_by_origin_call_id[s.origin_call_id] = s.call_id
         self.ari_client.channels.answer.side_effect = ARINotFound(
@@ -586,7 +586,7 @@ class TestPSTNFallback(TestCase):
 
         dialer = Mock()
         self.service._contact_dialers['bridge-uuid'] = dialer
-        self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
+        self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
 
         self.service.join_bridge('mobile-ch', 'bridge-uuid')
 
@@ -612,7 +612,7 @@ class TestPSTNFallback(TestCase):
     def test_pstn_fallback_noop_when_no_mobile_number(self):
         self.service._incoming_calls['call-id'] = self._make_notified()
         self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
-        self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
+        self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
         self.confd_client.users.get.return_value = {
             'mobile_fallback_enabled': True,
             'mobile_phone_number': None,
@@ -626,7 +626,7 @@ class TestPSTNFallback(TestCase):
     def test_pstn_fallback_originates_local_channel(self):
         self.service._incoming_calls['call-id'] = self._make_notified()
         self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
-        self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
+        self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
         self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
             call_id='call-id', timer=Mock(), lock=threading.Lock()
         )
@@ -683,7 +683,7 @@ class TestPSTNFallback(TestCase):
     def test_pstn_fallback_records_originated_channel_id(self):
         self.service._incoming_calls['call-id'] = self._make_notified()
         self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
-        self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
+        self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
         self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
             call_id='call-id', timer=Mock(), lock=threading.Lock()
         )
@@ -747,7 +747,7 @@ class TestPSTNFallback(TestCase):
 
         dialer = Mock()
         self.service._contact_dialers['bridge-uuid'] = dialer
-        self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
+        self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
 
         self.service.join_bridge('answering-ch', 'bridge-uuid')
 
@@ -767,7 +767,7 @@ class TestPSTNFallback(TestCase):
 
         dialer = Mock()
         self.service._contact_dialers['bridge-uuid'] = dialer
-        self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
+        self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
 
         self.service.join_bridge('pstn-channel-id', 'bridge-uuid')
         # PSTN channel must not be hung up
@@ -829,7 +829,7 @@ class TestPSTNFallback(TestCase):
         # lock without short-circuiting.
         self.service._incoming_calls['call-id'] = self._make_notified()
         self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
-        self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
+        self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
         self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
             call_id='call-id', timer=Mock(), lock=threading.Lock()
         )
@@ -872,7 +872,7 @@ class TestPSTNFallback(TestCase):
         self.service._call_ring_time['origin-id'] = 30
         dialer = Mock()
         self.service._contact_dialers['bridge-uuid'] = dialer
-        self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
+        self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
 
         self.service.join_bridge('mobile-ch', 'bridge-uuid')
 
@@ -880,7 +880,7 @@ class TestPSTNFallback(TestCase):
         assert 'origin-id' not in self.service._bridge_uuid_by_origin_call_id
         assert 'origin-id' not in self.service._call_id_by_origin_call_id
         assert 'origin-id' not in self.service._call_ring_time
-        assert 'bridge-uuid' not in self.service._outgoing_calls
+        assert 'bridge-uuid' not in self.service._caller_channel_leg_by_bridge
 
     def test_notify_channel_gone_prunes_call_state(self):
         caller_channel_id = '1234567890.42'
@@ -907,7 +907,7 @@ class TestPSTNFallback(TestCase):
         assert 'origin-id' not in self.service._bridge_uuid_by_origin_call_id
         assert 'origin-id' not in self.service._call_id_by_origin_call_id
         assert 'origin-id' not in self.service._call_ring_time
-        assert bridge_uuid not in self.service._outgoing_calls
+        assert bridge_uuid not in self.service._caller_channel_leg_by_bridge
 
     def test_on_calld_stopping_cancels_pstn_timers(self):
         timer_a = Mock()
@@ -941,7 +941,7 @@ class TestPSTNFallback(TestCase):
     def test_pstn_fallback_noop_when_caller_channel_gone(self):
         self.service._incoming_calls['call-id'] = self._make_notified()
         self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
-        self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
+        self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
         self.confd_client.users.get.return_value = {
             'mobile_fallback_enabled': True,
             'mobile_phone_number': '+33123456789',

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -342,13 +342,13 @@ class DialMobileServiceTestCase(DialerTestCase):
         mock_dialed_channel.id = dialed_channel_id
         dialer._dialed_channels.add(mock_dialed_channel)
         dialer.stop()
-        # wire up call_id mapping and PSTN timer
-        self.service._call_id_by_origin_call_id[self.origin_channel_id] = 'call-id'
+        # PSTN fallback state is keyed by the call's linkedid
+        # (origin_call_id), which here is self.origin_channel_id.
         timer = Mock()
-        self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
-            call_id='call-id', timer=timer
+        self.service._pstn_fallbacks[self.origin_channel_id] = PSTNFallbackPending(
+            call_id=self.origin_channel_id, timer=timer
         )
-        self.service._call_locks['call-id'] = threading.RLock()
+        self.service._call_locks[self.origin_channel_id] = threading.RLock()
         # mock cancel_push_mobile so it does NOT cancel the timer — proves
         # notify_channel_gone cancels it independently
         with patch.object(self.service, 'cancel_push_mobile'):
@@ -357,8 +357,7 @@ class DialMobileServiceTestCase(DialerTestCase):
         timer.cancel.assert_called_once()
 
     def test_join_bridge_unknown_future_bridge_will_hangup(self):
-        self.service._origin_call_id_by_bridge_uuid[s.bridge_uuid] = s.origin_call_id
-        self.service._call_id_by_origin_call_id[s.origin_call_id] = s.call_id
+        self.service._origin_call_id_by_bridge_uuid[s.bridge_uuid] = s.call_id
 
         with patch.object(self.service, 'cancel_push_mobile') as push_cancel:
             self.service.join_bridge(s.channel_id, s.bridge_uuid)
@@ -370,8 +369,7 @@ class DialMobileServiceTestCase(DialerTestCase):
         dialer = Mock()
         self.service._contact_dialers = {s.bridge_uuid: dialer}
         self.service._caller_channel_leg_by_bridge = {s.bridge_uuid: s.caller_channel}
-        self.service._origin_call_id_by_bridge_uuid[s.bridge_uuid] = s.origin_call_id
-        self.service._call_id_by_origin_call_id[s.origin_call_id] = s.call_id
+        self.service._origin_call_id_by_bridge_uuid[s.bridge_uuid] = s.call_id
         self.ari_client.channels.answer.side_effect = ARINotFound(
             self.ari_client, s.error
         )
@@ -405,7 +403,7 @@ class TestCancelPushNotification(TestCase):
             call_id=s.call_id,
             tenant_uuid=s.tenant_uuid,
             user_uuid=s.user_uuid,
-            origin_call_id=s.origin_call_id,
+            origin_call_id=s.call_id,
             payload={'peer_caller_id_name': 'Alice', 'peer_caller_id_number': '101'},
         )
 
@@ -436,7 +434,7 @@ class TestCancelPushNotification(TestCase):
             call_id=s.call_id,
             tenant_uuid=s.tenant_uuid,
             user_uuid=s.user_uuid,
-            origin_call_id=s.origin_call_id,
+            origin_call_id=s.call_id,
             payload={},
         )
 
@@ -465,7 +463,7 @@ class TestCancelPushNotification(TestCase):
             s.cid_num,
             s.video_enabled,
             30,
-            s.origin_call_id,
+            s.call_id,
             s.push_mobile_timestamp,
         )
 
@@ -494,7 +492,7 @@ class TestPSTNFallback(TestCase):
             self.confd_client,
         )
 
-    def _make_notified(self, call_id='call-id', origin_call_id='origin-id'):
+    def _make_notified(self, call_id='call-id', origin_call_id='call-id'):
         return IncomingCallNotified(
             call_id=call_id,
             tenant_uuid='tenant-uuid',
@@ -506,7 +504,7 @@ class TestPSTNFallback(TestCase):
             },
         )
 
-    def _make_pending(self, call_id='call-id', origin_call_id='origin-id'):
+    def _make_pending(self, call_id='call-id', origin_call_id='call-id'):
         return IncomingCallPending(
             call_id=call_id,
             tenant_uuid='tenant-uuid',
@@ -528,11 +526,70 @@ class TestPSTNFallback(TestCase):
             'caller_id_number': '101',
             'video_enabled': False,
             'ring_timeout': 30,
-            'origin_call_id': 'origin-id',
+            'origin_call_id': 'call-id',
             'push_mobile_timestamp': 'ts',
         }
         kwargs.update(overrides)
         self.service.send_push_notification(**kwargs)
+
+    def test_push_state_keyed_by_origin_call_id(self):
+        # Internal state must be keyed by the call's linkedid
+        # (origin_call_id) so the bus-consumer paths — which only know the
+        # linkedid — can look up the state created by send_push_notification.
+        self.confd_client.users.get.return_value = {
+            'mobile_fallback_enabled': False,
+            'mobile_phone_number': None,
+        }
+
+        self._send_push(call_id='channel-uniqueid', origin_call_id='call-linkedid')
+
+        assert 'call-linkedid' in self.service._incoming_calls
+        assert 'channel-uniqueid' not in self.service._incoming_calls
+        assert 'call-linkedid' in self.service._call_locks
+        assert 'channel-uniqueid' not in self.service._call_locks
+
+    def test_pstn_fallback_state_keyed_by_origin_call_id(self):
+        # Same invariant for the PSTN fallback state machine.
+        self.confd_client.users.get.return_value = {
+            'mobile_fallback_enabled': True,
+            'mobile_phone_number': '+33123456789',
+        }
+
+        with patch('wazo_calld.plugins.dial_mobile.services.threading.Timer'):
+            self._send_push(call_id='channel-uniqueid', origin_call_id='call-linkedid')
+
+        assert 'call-linkedid' in self.service._pstn_fallbacks
+        assert 'channel-uniqueid' not in self.service._pstn_fallbacks
+
+    def test_cancel_push_mobile_called_with_linkedid_finds_state(self):
+        # The bus consumer passes the linkedid (origin_call_id) when
+        # cancelling. Even when the Pushmobile event's Uniqueid differs
+        # from the Linkedid, cancel_push_mobile(linkedid) must dispatch
+        # the cancellation.
+        self.confd_client.users.get.return_value = {
+            'mobile_fallback_enabled': False,
+            'mobile_phone_number': None,
+        }
+        self._send_push(call_id='channel-uniqueid', origin_call_id='call-linkedid')
+
+        self.service.cancel_push_mobile('call-linkedid')
+
+        self.notifier.cancel_push_notification.assert_called_once()
+
+    def test_complete_pending_push_mobile_called_with_linkedid_finds_state(self):
+        self.confd_client.users.get.return_value = {
+            'mobile_fallback_enabled': False,
+            'mobile_phone_number': None,
+        }
+        self._send_push(call_id='channel-uniqueid', origin_call_id='call-linkedid')
+
+        self.service.complete_pending_push_mobile('call-linkedid')
+
+        from ..services import IncomingCallReceived
+
+        assert isinstance(
+            self.service._incoming_calls['call-linkedid'], IncomingCallReceived
+        )
 
     @patch('wazo_calld.plugins.dial_mobile.services.threading.Timer')
     def test_pstn_fallback_timer_starts_on_push_notification(self, mock_timer_cls):
@@ -650,8 +707,7 @@ class TestPSTNFallback(TestCase):
             call_id='call-id', timer=timer
         )
         self.service._call_locks['call-id'] = threading.RLock()
-        self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
-        self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'origin-id'
+        self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'call-id'
 
         dialer = Mock()
         self.service._contact_dialers['bridge-uuid'] = dialer
@@ -680,7 +736,7 @@ class TestPSTNFallback(TestCase):
 
     def test_pstn_fallback_noop_when_no_mobile_number(self):
         self.service._incoming_calls['call-id'] = self._make_notified()
-        self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
+        self.service._bridge_uuid_by_origin_call_id['call-id'] = 'bridge-uuid'
         self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
         self.confd_client.users.get.return_value = {
             'mobile_fallback_enabled': True,
@@ -694,7 +750,7 @@ class TestPSTNFallback(TestCase):
 
     def test_pstn_fallback_originates_local_channel(self):
         self.service._incoming_calls['call-id'] = self._make_notified()
-        self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
+        self.service._bridge_uuid_by_origin_call_id['call-id'] = 'bridge-uuid'
         self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
         self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
             call_id='call-id', timer=Mock()
@@ -742,7 +798,7 @@ class TestPSTNFallback(TestCase):
             json={'caller': {'name': 'Test', 'number': '1001'}}
         )
 
-        self.service.dial_all_contacts('caller-ch', 'origin-id', 'my-aor')
+        self.service.dial_all_contacts('caller-ch', 'call-id', 'my-aor')
 
         bridge_uuid = next(iter(self.service._contact_dialers))
         dialer = self.service._contact_dialers[bridge_uuid]
@@ -752,7 +808,7 @@ class TestPSTNFallback(TestCase):
 
     def test_pstn_fallback_records_originated_channel_id(self):
         self.service._incoming_calls['call-id'] = self._make_notified()
-        self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
+        self.service._bridge_uuid_by_origin_call_id['call-id'] = 'bridge-uuid'
         self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
         self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
             call_id='call-id', timer=Mock()
@@ -813,8 +869,7 @@ class TestPSTNFallback(TestCase):
             channel_id='pstn-channel-id',
         )
         self.service._call_locks['call-id'] = threading.RLock()
-        self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
-        self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'origin-id'
+        self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'call-id'
 
         dialer = Mock()
         self.service._contact_dialers['bridge-uuid'] = dialer
@@ -833,8 +888,7 @@ class TestPSTNFallback(TestCase):
             channel_id='pstn-channel-id',
         )
         self.service._call_locks['call-id'] = threading.RLock()
-        self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
-        self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'origin-id'
+        self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'call-id'
 
         dialer = Mock()
         self.service._contact_dialers['bridge-uuid'] = dialer
@@ -856,13 +910,12 @@ class TestPSTNFallback(TestCase):
             channel_id='pstn-channel-id',
         )
         self.service._call_locks['call-id'] = threading.RLock()
-        self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
 
         self.ari.client.channels.getChannelVar.return_value = {'value': 'pickupmark'}
         self.ari.client.channels.get.return_value = Mock(
             json={'caller': {'name': 'Test', 'number': '1001'}}
         )
-        self.service.dial_all_contacts(caller_channel_id, 'origin-id', 'aor')
+        self.service.dial_all_contacts(caller_channel_id, 'call-id', 'aor')
         bridge_uuid = next(iter(self.service._contact_dialers))
         dialer = self.service._contact_dialers[bridge_uuid]
         dialer.stop()
@@ -880,13 +933,12 @@ class TestPSTNFallback(TestCase):
             call_id='call-id', timer=timer
         )
         self.service._call_locks['call-id'] = threading.RLock()
-        self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
 
         self.ari.client.channels.getChannelVar.return_value = {'value': 'pickupmark'}
         self.ari.client.channels.get.return_value = Mock(
             json={'caller': {'name': 'Test', 'number': '1001'}}
         )
-        self.service.dial_all_contacts('caller-ch', 'origin-id', 'aor')
+        self.service.dial_all_contacts('caller-ch', 'call-id', 'aor')
 
         bridge_uuid = next(iter(self.service._contact_dialers))
         dialer = self.service._contact_dialers[bridge_uuid]
@@ -900,7 +952,7 @@ class TestPSTNFallback(TestCase):
         # Populate the state needed for _pstn_fallback to reach the commit
         # lock without short-circuiting.
         self.service._incoming_calls['call-id'] = self._make_notified()
-        self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
+        self.service._bridge_uuid_by_origin_call_id['call-id'] = 'bridge-uuid'
         self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
         self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
             call_id='call-id', timer=Mock()
@@ -968,10 +1020,9 @@ class TestPSTNFallback(TestCase):
     def test_join_bridge_prunes_call_state(self):
         # Successful bridge creation should clean up per-call mapping dicts
         # so they don't grow unbounded.
-        self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
-        self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'origin-id'
-        self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
-        self.service._call_ring_time['origin-id'] = 30
+        self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'call-id'
+        self.service._bridge_uuid_by_origin_call_id['call-id'] = 'bridge-uuid'
+        self.service._call_ring_time['call-id'] = 30
         self.service._incoming_calls['call-id'] = self._make_notified().received()
         dialer = Mock()
         self.service._contact_dialers['bridge-uuid'] = dialer
@@ -980,9 +1031,8 @@ class TestPSTNFallback(TestCase):
         self.service.join_bridge('mobile-ch', 'bridge-uuid')
 
         assert 'bridge-uuid' not in self.service._origin_call_id_by_bridge_uuid
-        assert 'origin-id' not in self.service._bridge_uuid_by_origin_call_id
-        assert 'origin-id' not in self.service._call_id_by_origin_call_id
-        assert 'origin-id' not in self.service._call_ring_time
+        assert 'call-id' not in self.service._bridge_uuid_by_origin_call_id
+        assert 'call-id' not in self.service._call_ring_time
         assert 'bridge-uuid' not in self.service._caller_channel_leg_by_bridge
         assert 'call-id' not in self.service._incoming_calls
 
@@ -1016,9 +1066,9 @@ class TestPSTNFallback(TestCase):
             json={'caller': {'name': 'Test', 'number': '1001'}}
         )
 
-        self.service.dial_all_contacts(caller_channel_id, 'origin-id', 'aor')
+        self.service.dial_all_contacts(caller_channel_id, 'call-id', 'aor')
         bridge_uuid = next(iter(self.service._contact_dialers))
-        assert 'origin-id' in self.service._bridge_uuid_by_origin_call_id
+        assert 'call-id' in self.service._bridge_uuid_by_origin_call_id
 
         dialer = self.service._contact_dialers[bridge_uuid]
         mock_dialed_channel = Mock()
@@ -1029,9 +1079,8 @@ class TestPSTNFallback(TestCase):
         self.service.notify_channel_gone(dialed_channel_id)
 
         assert bridge_uuid not in self.service._origin_call_id_by_bridge_uuid
-        assert 'origin-id' not in self.service._bridge_uuid_by_origin_call_id
-        assert 'origin-id' not in self.service._call_id_by_origin_call_id
-        assert 'origin-id' not in self.service._call_ring_time
+        assert 'call-id' not in self.service._bridge_uuid_by_origin_call_id
+        assert 'call-id' not in self.service._call_ring_time
         assert bridge_uuid not in self.service._caller_channel_leg_by_bridge
 
     def test_on_calld_stopping_cancels_pstn_timers(self):
@@ -1066,7 +1115,7 @@ class TestPSTNFallback(TestCase):
 
     def test_pstn_fallback_noop_when_caller_channel_gone(self):
         self.service._incoming_calls['call-id'] = self._make_notified()
-        self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
+        self.service._bridge_uuid_by_origin_call_id['call-id'] = 'bridge-uuid'
         self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
         self.confd_client.users.get.return_value = {
             'mobile_fallback_enabled': True,

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -607,6 +607,40 @@ class TestPSTNFallback(TestCase):
             self.service._pstn_fallbacks.get('call-id'), PSTNFallbackPending
         )
 
+    @patch('wazo_calld.plugins.dial_mobile.services.threading.Timer')
+    def test_pstn_fallback_timer_uses_configured_min_and_factor(self, mock_timer_cls):
+        service = DialMobileService(
+            self.ari,
+            self.notifier,
+            self.amid_client,
+            self.auth_client,
+            self.confd_client,
+            pstn_fallback_min_timeout=1.0,
+            pstn_fallback_ring_timeout_factor=0.05,
+        )
+        self.confd_client.users.get.return_value = {
+            'mobile_fallback_enabled': True,
+            'mobile_phone_number': '+33123456789',
+        }
+
+        service.send_push_notification(
+            tenant_uuid='t-uuid',
+            user_uuid='u-uuid',
+            call_id='call-id',
+            sip_call_id='sip-id',
+            caller_id_name='Alice',
+            caller_id_number='101',
+            video_enabled=False,
+            ring_timeout=20,
+            origin_call_id='call-id',
+            push_mobile_timestamp='ts',
+        )
+
+        # max(1.0, 0.05 * 20) == 1.0
+        mock_timer_cls.assert_called_once_with(
+            1.0, service._pstn_fallback, args=['call-id']
+        )
+
     def test_send_push_notification_always_creates_call_lock(self):
         # The per-call lock must be created on every push so concurrent
         # IncomingCall transitions can be serialized, even when no PSTN

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -316,10 +316,46 @@ class DialMobileServiceTestCase(DialerTestCase):
         )
         assert_that(self.service._contact_dialers, equal_to({}))
 
+    def test_notify_channel_gone_cancels_pstn_timer(self):
+        caller_channel_id = '1234567890.42'
+        dialed_channel_id = '1234567890.99'
+
+        self.ari.client.channels.getChannelVar.return_value = {'value': 'pickupmark'}
+        self.ari.client.channels.get.return_value = Mock(
+            json={'caller': {'name': 'Test', 'number': '1001'}}
+        )
+
+        self.service.dial_all_contacts(
+            caller_channel_id, self.origin_channel_id, self.aor
+        )
+
+        bridge_uuid = next(iter(self.service._contact_dialers))
+        dialer = self.service._contact_dialers[bridge_uuid]
+        mock_dialed_channel = Mock()
+        mock_dialed_channel.id = dialed_channel_id
+        dialer._dialed_channels.add(mock_dialed_channel)
+        dialer.should_stop.set()
+        dialer._thread.join()
+
+        # wire up call_id mapping and PSTN timer
+        self.service._call_id_by_origin_call_id[self.origin_channel_id] = 'call-id'
+        timer = Mock()
+        self.service._pstn_fallback_timers['call-id'] = timer
+
+        # mock cancel_push_mobile so it does NOT cancel the timer — proves
+        # notify_channel_gone cancels it independently
+        with patch.object(self.service, 'cancel_push_mobile'):
+            self.service.notify_channel_gone(dialed_channel_id)
+
+        timer.cancel.assert_called_once()
+
     def test_join_bridge_unknown_future_bridge_will_hangup(self):
+        self.service._origin_call_id_by_bridge_uuid[s.bridge_uuid] = s.origin_call_id
+        self.service._call_id_by_origin_call_id[s.origin_call_id] = s.call_id
+
         with patch.object(self.service, 'cancel_push_mobile') as push_cancel:
             self.service.join_bridge(s.channel_id, s.bridge_uuid)
-            push_cancel.assert_called_once_with(s.channel_id)
+            push_cancel.assert_called_once_with(s.call_id)
 
         self.ari_client.channels.hangup.assert_called_once_with(channelId=s.channel_id)
 
@@ -327,13 +363,15 @@ class DialMobileServiceTestCase(DialerTestCase):
         dialer = Mock()
         self.service._contact_dialers = {s.bridge_uuid: dialer}
         self.service._outgoing_calls = {s.bridge_uuid: s.caller_channel}
+        self.service._origin_call_id_by_bridge_uuid[s.bridge_uuid] = s.origin_call_id
+        self.service._call_id_by_origin_call_id[s.origin_call_id] = s.call_id
         self.ari_client.channels.answer.side_effect = ARINotFound(
             self.ari_client, s.error
         )
 
         with patch.object(self.service, 'cancel_push_mobile') as push_cancel:
             self.service.join_bridge(s.channel_id, s.bridge_uuid)
-            push_cancel.assert_called_once_with(s.channel_id)
+            push_cancel.assert_called_once_with(s.call_id)
 
         dialer.stop.assert_called_once_with()
 
@@ -431,14 +469,15 @@ class TestPSTNFallback(TestCase):
         mock_timer_cls.return_value.start.assert_called_once()
         assert 'call-id' in self.service._pstn_fallback_timers
 
-    def test_pstn_fallback_timer_cancelled_on_cancel_push(self):
+    def test_cancel_push_does_not_touch_pstn_timer(self):
         timer = Mock()
         self.service._pstn_fallback_timers['call-id'] = timer
         self.service._pending_push_mobile['call-id'] = self._make_pending()
 
         self.service.cancel_push_mobile('call-id')
 
-        timer.cancel.assert_called_once()
+        timer.cancel.assert_not_called()
+        assert 'call-id' in self.service._pstn_fallback_timers
 
     def test_pstn_fallback_timer_cancelled_on_join_bridge(self):
         timer = Mock()

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -504,4 +504,5 @@ class TestPSTNFallback(TestCase):
             appArgs=['join', 'bridge-uuid'],
             callerId='"Alice" <101>',
             originator='caller-ch',
+            variables={'variables': {'_WAZO_TENANT_UUID': 'tenant-uuid'}},
         )

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -145,7 +145,7 @@ class TestRemoveUnansweredChannels(DialerTestCase):
         channel_2.id = s.channel_2_id
         channel_2.get.return_value = Mock(json={'state': 'Ringing'})
         # set is replaced with a list to enforce the looping order
-        self.poller._dialed_channels = {channel_1, channel_2}  # type: ignore[assignment]
+        self.poller._dialed_channels = {channel_1, channel_2}
 
         self.poller._remove_unanswered_channels()
 

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -638,6 +638,34 @@ class TestPSTNFallback(TestCase):
 
         assert first_lock is second_lock
 
+    def test_push_not_sent_when_cancelled_during_eligibility_lookup(self):
+        # Race: caller hangs up while send_push_notification has released
+        # the per-call lock to query confd for fallback eligibility. The
+        # concurrent cancel_push_mobile must take effect — the push must
+        # not be dispatched and the Cancelled state must not be overwritten.
+        self.confd_client.users.get.return_value = {
+            'mobile_fallback_enabled': False,
+            'mobile_phone_number': None,
+        }
+
+        real_eligible = self.service._pstn_fallback_eligible
+
+        def cancel_then_eligible(user_uuid, tenant_uuid):
+            self.service.cancel_push_mobile('call-id')
+            return real_eligible(user_uuid, tenant_uuid)
+
+        with patch.object(
+            self.service,
+            '_pstn_fallback_eligible',
+            side_effect=cancel_then_eligible,
+        ):
+            self._send_push()
+
+        self.notifier.push_notification.assert_not_called()
+        assert isinstance(
+            self.service._incoming_calls['call-id'], IncomingCallPushCancelled
+        )
+
     @patch('wazo_calld.plugins.dial_mobile.services.threading.Timer')
     def test_pstn_fallback_timer_skipped_when_disabled(self, mock_timer_cls):
         self.confd_client.users.get.return_value = {

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -587,6 +587,133 @@ class TestPSTNFallback(TestCase):
             variables={'variables': {'_WAZO_TENANT_UUID': 'tenant-uuid'}},
         )
 
+    def test_pstn_fallback_records_originated_channel_id(self):
+        self.service._incoming_calls['call-id'] = self._make_notified()
+        self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
+        self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
+        self.confd_client.users.get.return_value = {
+            'mobile_fallback_enabled': True,
+            'mobile_phone_number': '+33123456789',
+            'lines': [{'id': 42}],
+        }
+        self.confd_client.lines.get.return_value = {'context': 'my-outbound-context'}
+        originated_channel = Mock()
+        originated_channel.id = 'pstn-channel-id'
+        self.ari_client.channels.originate.return_value = originated_channel
+
+        self.service._pstn_fallback('call-id')
+
+        assert self.service._pstn_fallback_channels.get('call-id') == 'pstn-channel-id'
+
+    def test_cancel_pstn_fallback_hangs_up_active_pstn_channel(self):
+        self.service._pstn_fallback_channels['call-id'] = 'pstn-channel-id'
+
+        self.service._cancel_pstn_fallback('call-id')
+
+        self.ari_client.channels.hangup.assert_called_once_with(
+            channelId='pstn-channel-id'
+        )
+        assert 'call-id' not in self.service._pstn_fallback_channels
+
+    def test_cancel_pstn_fallback_swallows_already_gone(self):
+        self.service._pstn_fallback_channels['call-id'] = 'pstn-channel-id'
+        self.ari_client.channels.hangup.side_effect = ARINotFound(
+            self.ari_client, s.error
+        )
+
+        self.service._cancel_pstn_fallback('call-id')
+
+        assert 'call-id' not in self.service._pstn_fallback_channels
+
+    def test_cancel_pstn_fallback_cancels_timer_and_hangs_up_channel(self):
+        timer = Mock()
+        self.service._pstn_fallback_timers['call-id'] = timer
+        self.service._pstn_fallback_channels['call-id'] = 'pstn-channel-id'
+
+        self.service._cancel_pstn_fallback('call-id')
+
+        timer.cancel.assert_called_once()
+        self.ari_client.channels.hangup.assert_called_once_with(
+            channelId='pstn-channel-id'
+        )
+
+    def test_join_bridge_hangs_up_active_pstn_channel(self):
+        # pickup or mobile-answer must tear down an in-progress PSTN call
+        self.service._pstn_fallback_channels['call-id'] = 'pstn-channel-id'
+        self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
+        self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'origin-id'
+
+        dialer = Mock()
+        self.service._contact_dialers['bridge-uuid'] = dialer
+        self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
+
+        self.service.join_bridge('answering-ch', 'bridge-uuid')
+
+        self.ari_client.channels.hangup.assert_any_call(channelId='pstn-channel-id')
+
+    def test_join_bridge_pstn_channel_itself_joining_is_not_hung_up(self):
+        # When the PSTN-fallback call answers, its channel enters dial_mobile
+        # with action='join'. We must NOT hang up the channel we're about to
+        # bridge to the caller.
+        self.service._pstn_fallback_channels['call-id'] = 'pstn-channel-id'
+        self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
+        self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'origin-id'
+
+        dialer = Mock()
+        self.service._contact_dialers['bridge-uuid'] = dialer
+        self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
+
+        self.service.join_bridge('pstn-channel-id', 'bridge-uuid')
+
+        # PSTN channel must not be hung up
+        for call in self.ari_client.channels.hangup.call_args_list:
+            assert call.kwargs.get('channelId') != 'pstn-channel-id'
+        # Tracking should still be cleared
+        assert 'call-id' not in self.service._pstn_fallback_channels
+
+    def test_notify_channel_gone_caller_gone_hangs_up_active_pstn_channel(self):
+        caller_channel_id = '1234567890.42'
+        self.service._pstn_fallback_channels['call-id'] = 'pstn-channel-id'
+        self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
+
+        self.ari.client.channels.getChannelVar.return_value = {'value': 'pickupmark'}
+        self.ari.client.channels.get.return_value = Mock(
+            json={'caller': {'name': 'Test', 'number': '1001'}}
+        )
+        self.service.dial_all_contacts(caller_channel_id, 'origin-id', 'aor')
+        bridge_uuid = next(iter(self.service._contact_dialers))
+        dialer = self.service._contact_dialers[bridge_uuid]
+        dialer.should_stop.set()
+        dialer._thread.join()
+
+        with patch.object(self.service, 'cancel_push_mobile'):
+            self.service.notify_channel_gone(caller_channel_id)
+
+        self.ari_client.channels.hangup.assert_any_call(channelId='pstn-channel-id')
+
+    def test_on_contact_dialed_cancels_pstn_fallback(self):
+        # When the mobile registers and we originate the SIP INVITE,
+        # the PSTN fallback must be cancelled.
+        timer = Mock()
+        self.service._pstn_fallback_timers['call-id'] = timer
+        self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
+
+        self.ari.client.channels.getChannelVar.return_value = {'value': 'pickupmark'}
+        self.ari.client.channels.get.return_value = Mock(
+            json={'caller': {'name': 'Test', 'number': '1001'}}
+        )
+        self.service.dial_all_contacts('caller-ch', 'origin-id', 'aor')
+
+        bridge_uuid = next(iter(self.service._contact_dialers))
+        dialer = self.service._contact_dialers[bridge_uuid]
+        dialer.should_stop.set()
+        dialer._thread.join()
+
+        # Simulate the polling thread finding a contact and dialing it.
+        dialer._send_contact_to_current_call('sip:contact', bridge_uuid, 'caller-id')
+
+        timer.cancel.assert_called_once()
+
     def test_pstn_fallback_noop_when_caller_channel_gone(self):
         self.service._incoming_calls['call-id'] = self._make_notified()
         self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -16,6 +16,8 @@ from ..services import (
     DialMobileService,
     IncomingCallNotified,
     IncomingCallPending,
+    IncomingCallPushCancelled,
+    IncomingCallReceived,
     PSTNFallbackCancelled,
     PSTNFallbackDialing,
     PSTNFallbackPending,
@@ -410,13 +412,47 @@ class TestCancelPushNotification(TestCase):
     def test_that_nothing_happens_when_not_a_pending_push(self):
         self.service.cancel_push_mobile(s.call_id)
 
-    def test_complete_push_mobile_removes_without_sending_cancellation(self):
+    def test_complete_push_mobile_transitions_to_received(self):
         self.service._incoming_calls[s.call_id] = self._make_notified()
 
         self.service.complete_pending_push_mobile(s.call_id)
 
         self.notifier.cancel_push_notification.assert_not_called()
-        assert s.call_id not in self.service._incoming_calls
+        assert isinstance(self.service._incoming_calls[s.call_id], IncomingCallReceived)
+
+    def test_cancel_push_mobile_transitions_notified_to_cancelled(self):
+        self.service._incoming_calls[s.call_id] = self._make_notified()
+
+        self.service.cancel_push_mobile(s.call_id)
+
+        assert isinstance(
+            self.service._incoming_calls[s.call_id], IncomingCallPushCancelled
+        )
+
+    def test_cancel_push_mobile_transitions_pending_directly_to_cancelled(self):
+        # The Pending → Cancelled transition must be direct (no push to
+        # cancel, since none was sent yet).
+        self.service._incoming_calls[s.call_id] = IncomingCallPending(
+            call_id=s.call_id,
+            tenant_uuid=s.tenant_uuid,
+            user_uuid=s.user_uuid,
+            origin_call_id=s.origin_call_id,
+            payload={},
+        )
+
+        self.service.cancel_push_mobile(s.call_id)
+
+        self.notifier.cancel_push_notification.assert_not_called()
+        assert isinstance(
+            self.service._incoming_calls[s.call_id], IncomingCallPushCancelled
+        )
+
+    def test_cancel_push_mobile_terminal_state_is_idempotent(self):
+        self.service._incoming_calls[s.call_id] = self._make_notified().push_cancelled()
+
+        self.service.cancel_push_mobile(s.call_id)
+        # Already terminal — no second cancellation dispatched.
+        self.notifier.cancel_push_notification.assert_not_called()
 
     @patch('wazo_calld.plugins.dial_mobile.services.threading.Timer')
     def test_that_original_payload_is_sent_when_canceling(self, _mock_timer):
@@ -906,6 +942,7 @@ class TestPSTNFallback(TestCase):
         self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'origin-id'
         self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
         self.service._call_ring_time['origin-id'] = 30
+        self.service._incoming_calls['call-id'] = self._make_notified().received()
         dialer = Mock()
         self.service._contact_dialers['bridge-uuid'] = dialer
         self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
@@ -917,6 +954,28 @@ class TestPSTNFallback(TestCase):
         assert 'origin-id' not in self.service._call_id_by_origin_call_id
         assert 'origin-id' not in self.service._call_ring_time
         assert 'bridge-uuid' not in self.service._caller_channel_leg_by_bridge
+        assert 'call-id' not in self.service._incoming_calls
+
+    def test_has_a_registered_mobile_and_pending_push_false_on_terminal_state(
+        self,
+    ):
+        # Once a call reaches Received or Cancelled, it is no longer
+        # considered to have a pending push.
+        self.service._incoming_calls['call-id'] = self._make_notified().received()
+        assert (
+            self.service.has_a_registered_mobile_and_pending_push(
+                'call-id', 'asterisk-call-id', 'PJSIP/aor', 'user-uuid'
+            )
+            is False
+        )
+
+        self.service._incoming_calls['call-id'] = self._make_notified().push_cancelled()
+        assert (
+            self.service.has_a_registered_mobile_and_pending_push(
+                'call-id', 'asterisk-call-id', 'PJSIP/aor', 'user-uuid'
+            )
+            is False
+        )
 
     def test_notify_channel_gone_prunes_call_state(self):
         caller_channel_id = '1234567890.42'

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -11,7 +11,12 @@ from ari.exceptions import ARINotFound
 from hamcrest import assert_that, contains_exactly, empty, equal_to, has_items
 
 from ..notifier import Notifier
-from ..services import DialMobileService, PendingPushMobile, _NoSuchChannel
+from ..services import (
+    DialMobileService,
+    IncomingCallNotified,
+    IncomingCallPending,
+    _NoSuchChannel,
+)
 from ..services import _PollingContactDialer as PollingContactDialer
 
 
@@ -393,8 +398,25 @@ class TestCancelPushNotification(TestCase):
             self.confd_client,
         )
 
+    def _make_notified(self):
+        return IncomingCallNotified(
+            call_id=s.call_id,
+            tenant_uuid=s.tenant_uuid,
+            user_uuid=s.user_uuid,
+            origin_call_id=s.origin_call_id,
+            payload={'peer_caller_id_name': 'Alice', 'peer_caller_id_number': '101'},
+        )
+
     def test_that_nothing_happens_when_not_a_pending_push(self):
         self.service.cancel_push_mobile(s.call_id)
+
+    def test_complete_push_mobile_removes_without_sending_cancellation(self):
+        self.service._incoming_calls[s.call_id] = self._make_notified()
+
+        self.service.complete_pending_push_mobile(s.call_id)
+
+        self.notifier.cancel_push_notification.assert_not_called()
+        assert s.call_id not in self.service._incoming_calls
 
     @patch('wazo_calld.plugins.dial_mobile.services.threading.Timer')
     def test_that_original_payload_is_sent_when_canceling(self, _mock_timer):
@@ -436,8 +458,20 @@ class TestPSTNFallback(TestCase):
             self.confd_client,
         )
 
+    def _make_notified(self, call_id='call-id', origin_call_id='origin-id'):
+        return IncomingCallNotified(
+            call_id=call_id,
+            tenant_uuid='tenant-uuid',
+            user_uuid='user-uuid',
+            origin_call_id=origin_call_id,
+            payload={
+                'peer_caller_id_name': 'Alice',
+                'peer_caller_id_number': '101',
+            },
+        )
+
     def _make_pending(self, call_id='call-id', origin_call_id='origin-id'):
-        return PendingPushMobile(
+        return IncomingCallPending(
             call_id=call_id,
             tenant_uuid='tenant-uuid',
             user_uuid='user-uuid',
@@ -472,12 +506,19 @@ class TestPSTNFallback(TestCase):
     def test_cancel_push_does_not_touch_pstn_timer(self):
         timer = Mock()
         self.service._pstn_fallback_timers['call-id'] = timer
-        self.service._pending_push_mobile['call-id'] = self._make_pending()
+        self.service._incoming_calls['call-id'] = self._make_notified()
 
         self.service.cancel_push_mobile('call-id')
 
         timer.cancel.assert_not_called()
         assert 'call-id' in self.service._pstn_fallback_timers
+
+    def test_cancel_push_noop_when_pending_not_notified(self):
+        self.service._incoming_calls['call-id'] = self._make_pending()
+
+        self.service.cancel_push_mobile('call-id')
+
+        self.notifier.cancel_push_notification.assert_not_called()
 
     def test_pstn_fallback_timer_cancelled_on_join_bridge(self):
         timer = Mock()
@@ -499,7 +540,7 @@ class TestPSTNFallback(TestCase):
         self.ari_client.channels.originate.assert_not_called()
 
     def test_pstn_fallback_noop_when_fallback_disabled(self):
-        self.service._pending_push_mobile['call-id'] = self._make_pending()
+        self.service._incoming_calls['call-id'] = self._make_notified()
         self.confd_client.users.get.return_value = {
             'mobile_fallback_enabled': False,
             'mobile_phone_number': '+33123456789',
@@ -511,7 +552,7 @@ class TestPSTNFallback(TestCase):
         self.ari_client.channels.originate.assert_not_called()
 
     def test_pstn_fallback_noop_when_no_mobile_number(self):
-        self.service._pending_push_mobile['call-id'] = self._make_pending()
+        self.service._incoming_calls['call-id'] = self._make_notified()
         self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
         self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
         self.confd_client.users.get.return_value = {
@@ -525,7 +566,7 @@ class TestPSTNFallback(TestCase):
         self.ari_client.channels.originate.assert_not_called()
 
     def test_pstn_fallback_originates_local_channel(self):
-        self.service._pending_push_mobile['call-id'] = self._make_pending()
+        self.service._incoming_calls['call-id'] = self._make_notified()
         self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
         self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
         self.confd_client.users.get.return_value = {
@@ -547,7 +588,7 @@ class TestPSTNFallback(TestCase):
         )
 
     def test_pstn_fallback_noop_when_caller_channel_gone(self):
-        self.service._pending_push_mobile['call-id'] = self._make_pending()
+        self.service._incoming_calls['call-id'] = self._make_notified()
         self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
         self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
         self.confd_client.users.get.return_value = {

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -1,6 +1,7 @@
 # Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import threading
 from unittest import TestCase
 from unittest.mock import Mock, patch
 from unittest.mock import sentinel as s
@@ -15,6 +16,9 @@ from ..services import (
     DialMobileService,
     IncomingCallNotified,
     IncomingCallPending,
+    PSTNFallbackCancelled,
+    PSTNFallbackDialing,
+    PSTNFallbackPending,
     _NoSuchChannel,
 )
 from ..services import _PollingContactDialer as PollingContactDialer
@@ -138,7 +142,6 @@ class TestRemoveUnansweredChannels(DialerTestCase):
         channel_2 = Mock()
         channel_2.id = s.channel_2_id
         channel_2.get.return_value = Mock(json={'state': 'Ringing'})
-
         # set is replaced with a list to enforce the looping order
         self.poller._dialed_channels = {channel_1, channel_2}  # type: ignore[assignment]
 
@@ -154,7 +157,6 @@ class TestRemoveUnansweredChannels(DialerTestCase):
         channel_2 = Mock()
         channel_2.id = s.channel_2_id
         channel_2.get.return_value = Mock(json={'state': 'Ringing'})
-
         # set is replaced with a list to enforce the looping order
         self.poller._dialed_channels = [channel_1, channel_2]  # type: ignore[assignment]
 
@@ -306,7 +308,6 @@ class DialMobileServiceTestCase(DialerTestCase):
         assert_that(len(self.service._contact_dialers), equal_to(1))
         bridge_uuid = next(iter(self.service._contact_dialers))
         dialer = self.service._contact_dialers[bridge_uuid]
-
         # Simulate the poller having dialed a channel
         mock_dialed_channel = Mock()
         mock_dialed_channel.id = dialed_channel_id
@@ -339,12 +340,12 @@ class DialMobileServiceTestCase(DialerTestCase):
         mock_dialed_channel.id = dialed_channel_id
         dialer._dialed_channels.add(mock_dialed_channel)
         dialer.stop()
-
         # wire up call_id mapping and PSTN timer
         self.service._call_id_by_origin_call_id[self.origin_channel_id] = 'call-id'
         timer = Mock()
-        self.service._pstn_fallback_timers['call-id'] = timer
-
+        self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
+            call_id='call-id', timer=timer, lock=threading.Lock()
+        )
         # mock cancel_push_mobile so it does NOT cancel the timer — proves
         # notify_channel_gone cancels it independently
         with patch.object(self.service, 'cancel_push_mobile'):
@@ -509,7 +510,9 @@ class TestPSTNFallback(TestCase):
             15.0, self.service._pstn_fallback, args=['call-id']
         )
         mock_timer_cls.return_value.start.assert_called_once()
-        assert 'call-id' in self.service._pstn_fallback_timers
+        assert isinstance(
+            self.service._pstn_fallbacks.get('call-id'), PSTNFallbackPending
+        )
 
     @patch('wazo_calld.plugins.dial_mobile.services.threading.Timer')
     def test_pstn_fallback_timer_skipped_when_disabled(self, mock_timer_cls):
@@ -521,7 +524,9 @@ class TestPSTNFallback(TestCase):
         self._send_push()
 
         mock_timer_cls.assert_not_called()
-        assert 'call-id' not in self.service._pstn_fallback_timers
+        assert not isinstance(
+            self.service._pstn_fallbacks.get('call-id'), PSTNFallbackPending
+        )
 
     @patch('wazo_calld.plugins.dial_mobile.services.threading.Timer')
     def test_pstn_fallback_timer_skipped_when_no_mobile_number(self, mock_timer_cls):
@@ -533,7 +538,9 @@ class TestPSTNFallback(TestCase):
         self._send_push()
 
         mock_timer_cls.assert_not_called()
-        assert 'call-id' not in self.service._pstn_fallback_timers
+        assert not isinstance(
+            self.service._pstn_fallbacks.get('call-id'), PSTNFallbackPending
+        )
 
     @patch('wazo_calld.plugins.dial_mobile.services.threading.Timer')
     def test_pstn_fallback_timer_armed_on_confd_error(self, mock_timer_cls):
@@ -544,17 +551,23 @@ class TestPSTNFallback(TestCase):
         self._send_push()
 
         mock_timer_cls.assert_called_once()
-        assert 'call-id' in self.service._pstn_fallback_timers
+        assert isinstance(
+            self.service._pstn_fallbacks.get('call-id'), PSTNFallbackPending
+        )
 
     def test_cancel_push_does_not_touch_pstn_timer(self):
         timer = Mock()
-        self.service._pstn_fallback_timers['call-id'] = timer
+        self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
+            call_id='call-id', timer=timer, lock=threading.Lock()
+        )
         self.service._incoming_calls['call-id'] = self._make_notified()
 
         self.service.cancel_push_mobile('call-id')
 
         timer.cancel.assert_not_called()
-        assert 'call-id' in self.service._pstn_fallback_timers
+        assert isinstance(
+            self.service._pstn_fallbacks.get('call-id'), PSTNFallbackPending
+        )
 
     def test_cancel_push_noop_when_pending_not_notified(self):
         self.service._incoming_calls['call-id'] = self._make_pending()
@@ -565,7 +578,9 @@ class TestPSTNFallback(TestCase):
 
     def test_pstn_fallback_timer_cancelled_on_join_bridge(self):
         timer = Mock()
-        self.service._pstn_fallback_timers['call-id'] = timer
+        self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
+            call_id='call-id', timer=timer, lock=threading.Lock()
+        )
         self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
         self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'origin-id'
 
@@ -612,6 +627,9 @@ class TestPSTNFallback(TestCase):
         self.service._incoming_calls['call-id'] = self._make_notified()
         self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
         self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
+        self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
+            call_id='call-id', timer=Mock(), lock=threading.Lock()
+        )
         self.confd_client.users.get.return_value = {
             'mobile_fallback_enabled': True,
             'mobile_phone_number': '+33123456789',
@@ -666,6 +684,9 @@ class TestPSTNFallback(TestCase):
         self.service._incoming_calls['call-id'] = self._make_notified()
         self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
         self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
+        self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
+            call_id='call-id', timer=Mock(), lock=threading.Lock()
+        )
         self.confd_client.users.get.return_value = {
             'mobile_fallback_enabled': True,
             'mobile_phone_number': '+33123456789',
@@ -678,43 +699,49 @@ class TestPSTNFallback(TestCase):
 
         self.service._pstn_fallback('call-id')
 
-        assert self.service._pstn_fallback_channels.get('call-id') == 'pstn-channel-id'
+        state = self.service._pstn_fallbacks.get('call-id')
+        assert isinstance(state, PSTNFallbackDialing)
+        assert state.channel_id == 'pstn-channel-id'
 
     def test_cancel_pstn_fallback_hangs_up_active_pstn_channel(self):
-        self.service._pstn_fallback_channels['call-id'] = 'pstn-channel-id'
+        self.service._pstn_fallbacks['call-id'] = PSTNFallbackDialing(
+            call_id='call-id',
+            channel_id='pstn-channel-id',
+            lock=threading.Lock(),
+        )
 
         self.service._cancel_pstn_fallback('call-id')
 
         self.ari_client.channels.hangup.assert_called_once_with(
             channelId='pstn-channel-id'
         )
-        assert 'call-id' not in self.service._pstn_fallback_channels
+        assert not isinstance(
+            self.service._pstn_fallbacks.get('call-id'), PSTNFallbackDialing
+        )
 
     def test_cancel_pstn_fallback_swallows_already_gone(self):
-        self.service._pstn_fallback_channels['call-id'] = 'pstn-channel-id'
+        self.service._pstn_fallbacks['call-id'] = PSTNFallbackDialing(
+            call_id='call-id',
+            channel_id='pstn-channel-id',
+            lock=threading.Lock(),
+        )
         self.ari_client.channels.hangup.side_effect = ARINotFound(
             self.ari_client, s.error
         )
 
         self.service._cancel_pstn_fallback('call-id')
 
-        assert 'call-id' not in self.service._pstn_fallback_channels
-
-    def test_cancel_pstn_fallback_cancels_timer_and_hangs_up_channel(self):
-        timer = Mock()
-        self.service._pstn_fallback_timers['call-id'] = timer
-        self.service._pstn_fallback_channels['call-id'] = 'pstn-channel-id'
-
-        self.service._cancel_pstn_fallback('call-id')
-
-        timer.cancel.assert_called_once()
-        self.ari_client.channels.hangup.assert_called_once_with(
-            channelId='pstn-channel-id'
+        assert not isinstance(
+            self.service._pstn_fallbacks.get('call-id'), PSTNFallbackDialing
         )
 
     def test_join_bridge_hangs_up_active_pstn_channel(self):
         # pickup or mobile-answer must tear down an in-progress PSTN call
-        self.service._pstn_fallback_channels['call-id'] = 'pstn-channel-id'
+        self.service._pstn_fallbacks['call-id'] = PSTNFallbackDialing(
+            call_id='call-id',
+            channel_id='pstn-channel-id',
+            lock=threading.Lock(),
+        )
         self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
         self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'origin-id'
 
@@ -730,7 +757,11 @@ class TestPSTNFallback(TestCase):
         # When the PSTN-fallback call answers, its channel enters dial_mobile
         # with action='join'. We must NOT hang up the channel we're about to
         # bridge to the caller.
-        self.service._pstn_fallback_channels['call-id'] = 'pstn-channel-id'
+        self.service._pstn_fallbacks['call-id'] = PSTNFallbackDialing(
+            call_id='call-id',
+            channel_id='pstn-channel-id',
+            lock=threading.Lock(),
+        )
         self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
         self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'origin-id'
 
@@ -739,16 +770,21 @@ class TestPSTNFallback(TestCase):
         self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
 
         self.service.join_bridge('pstn-channel-id', 'bridge-uuid')
-
         # PSTN channel must not be hung up
         for call in self.ari_client.channels.hangup.call_args_list:
             assert call.kwargs.get('channelId') != 'pstn-channel-id'
         # Tracking should still be cleared
-        assert 'call-id' not in self.service._pstn_fallback_channels
+        assert not isinstance(
+            self.service._pstn_fallbacks.get('call-id'), PSTNFallbackDialing
+        )
 
     def test_notify_channel_gone_caller_gone_hangs_up_active_pstn_channel(self):
         caller_channel_id = '1234567890.42'
-        self.service._pstn_fallback_channels['call-id'] = 'pstn-channel-id'
+        self.service._pstn_fallbacks['call-id'] = PSTNFallbackDialing(
+            call_id='call-id',
+            channel_id='pstn-channel-id',
+            lock=threading.Lock(),
+        )
         self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
 
         self.ari.client.channels.getChannelVar.return_value = {'value': 'pickupmark'}
@@ -769,7 +805,9 @@ class TestPSTNFallback(TestCase):
         # When the mobile registers and we originate the SIP INVITE,
         # the PSTN fallback must be cancelled.
         timer = Mock()
-        self.service._pstn_fallback_timers['call-id'] = timer
+        self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
+            call_id='call-id', timer=timer, lock=threading.Lock()
+        )
         self.service._call_id_by_origin_call_id['origin-id'] = 'call-id'
 
         self.ari.client.channels.getChannelVar.return_value = {'value': 'pickupmark'}
@@ -781,52 +819,20 @@ class TestPSTNFallback(TestCase):
         bridge_uuid = next(iter(self.service._contact_dialers))
         dialer = self.service._contact_dialers[bridge_uuid]
         dialer.stop()
-
         # Simulate the polling thread finding a contact and dialing it.
         dialer._send_contact_to_current_call('sip:contact', bridge_uuid, 'caller-id')
 
         timer.cancel.assert_called_once()
 
-    def test_pstn_fallback_aborts_when_cancelled_before_run(self):
-        # Cancellation arrived between timer firing and the callback executing.
-        self.service._pstn_fallback_cancelled.add('call-id')
-        self.service._incoming_calls['call-id'] = self._make_notified()
-
-        self.service._pstn_fallback('call-id')
-
-        self.ari_client.channels.originate.assert_not_called()
-        # Flag is cleaned up so the set doesn't grow forever.
-        assert 'call-id' not in self.service._pstn_fallback_cancelled
-
-    def test_pstn_fallback_aborts_when_cancelled_during_confd(self):
-        # Mobile registers (cancellation arrives) while we're still doing
-        # the confd lookups inside _pstn_fallback. We must abort before
-        # cancelling the push and before originating.
-        self.service._incoming_calls['call-id'] = self._make_notified()
-
-        def confd_side_effect(*args, **kwargs):
-            self.service._pstn_fallback_cancelled.add('call-id')
-            return {
-                'mobile_fallback_enabled': True,
-                'mobile_phone_number': '+33123456789',
-                'lines': [{'id': 42}],
-            }
-
-        self.confd_client.users.get.side_effect = confd_side_effect
-
-        with patch.object(self.service, 'cancel_push_mobile') as cancel_push:
-            self.service._pstn_fallback('call-id')
-
-        cancel_push.assert_not_called()
-        self.ari_client.channels.originate.assert_not_called()
-
-    def test_pstn_fallback_hangs_up_channel_if_cancelled_during_originate(self):
-        # Cancellation arrives between the confd lookups and the originate.
-        # Once originate returns, we must hang up the just-created channel
-        # and not record it in _pstn_fallback_channels.
+    def _setup_eligible_fallback(self):
+        # Populate the state needed for _pstn_fallback to reach the commit
+        # lock without short-circuiting.
         self.service._incoming_calls['call-id'] = self._make_notified()
         self.service._bridge_uuid_by_origin_call_id['origin-id'] = 'bridge-uuid'
         self.service._outgoing_calls['bridge-uuid'] = 'caller-ch'
+        self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
+            call_id='call-id', timer=Mock(), lock=threading.Lock()
+        )
         self.confd_client.users.get.return_value = {
             'mobile_fallback_enabled': True,
             'mobile_phone_number': '+33123456789',
@@ -834,19 +840,28 @@ class TestPSTNFallback(TestCase):
         }
         self.confd_client.lines.get.return_value = {'context': 'my-outbound-context'}
 
-        originated = Mock()
-        originated.id = 'pstn-channel-id'
+    def test_pstn_fallback_aborts_when_cancelled(self):
+        # _cancel_pstn_fallback was called before _pstn_fallback could reach
+        # the commit lock. Inside the lock, _pstn_fallback re-reads the
+        # state and aborts when it isn't Pending anymore.
+        self._setup_eligible_fallback()
+        # Cancelled state replaces the Pending state seeded by _setup.
+        self.service._pstn_fallbacks['call-id'] = PSTNFallbackCancelled('call-id')
 
-        def originate_side_effect(*args, **kwargs):
-            self.service._pstn_fallback_cancelled.add('call-id')
-            return originated
+        with patch.object(self.service, 'cancel_push_mobile') as cancel_push:
+            self.service._pstn_fallback('call-id')
 
-        self.ari_client.channels.originate.side_effect = originate_side_effect
+        cancel_push.assert_not_called()
+        self.ari_client.channels.originate.assert_not_called()
+
+    def test_pstn_fallback_originates_when_not_cancelled(self):
+        # Sanity check that the lock-protected commit path still runs when
+        # no cancellation is signalled.
+        self._setup_eligible_fallback()
 
         self.service._pstn_fallback('call-id')
 
-        self.ari_client.channels.hangup.assert_called_with(channelId='pstn-channel-id')
-        assert 'call-id' not in self.service._pstn_fallback_channels
+        self.ari_client.channels.originate.assert_called_once()
 
     def test_join_bridge_prunes_call_state(self):
         # Successful bridge creation should clean up per-call mapping dicts
@@ -897,21 +912,31 @@ class TestPSTNFallback(TestCase):
     def test_on_calld_stopping_cancels_pstn_timers(self):
         timer_a = Mock()
         timer_b = Mock()
-        self.service._pstn_fallback_timers['call-a'] = timer_a
-        self.service._pstn_fallback_timers['call-b'] = timer_b
+        self.service._pstn_fallbacks['call-a'] = PSTNFallbackPending(
+            call_id='call-a', timer=timer_a, lock=threading.Lock()
+        )
+        self.service._pstn_fallbacks['call-b'] = PSTNFallbackPending(
+            call_id='call-b', timer=timer_b, lock=threading.Lock()
+        )
 
         self.service.on_calld_stopping()
 
         timer_a.cancel.assert_called_once()
         timer_b.cancel.assert_called_once()
-        assert self.service._pstn_fallback_timers == {}
+        assert self.service._pstn_fallbacks == {}
 
-    def test_cancel_pstn_fallback_marks_cancelled(self):
-        # Even when no timer/channel is recorded yet, _cancel_pstn_fallback
-        # must flag the call so a racing _pstn_fallback can abort.
+    def test_cancel_pstn_fallback_transitions_pending_to_cancelled(self):
+        timer = Mock()
+        self.service._pstn_fallbacks['call-id'] = PSTNFallbackPending(
+            call_id='call-id', timer=timer, lock=threading.Lock()
+        )
+
         self.service._cancel_pstn_fallback('call-id')
 
-        assert 'call-id' in self.service._pstn_fallback_cancelled
+        timer.cancel.assert_called_once()
+        assert isinstance(
+            self.service._pstn_fallbacks.get('call-id'), PSTNFallbackCancelled
+        )
 
     def test_pstn_fallback_noop_when_caller_channel_gone(self):
         self.service._incoming_calls['call-id'] = self._make_notified()

--- a/wazo_calld/plugins/dial_mobile/tests/test_stasis.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_stasis.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
@@ -151,3 +151,87 @@ class TestStasisStart(TestCase):
         )
 
         self.service.clean_bridge.assert_called_once_with(s.bridge_uuid)
+
+
+class TestEndpointSubscription(TestCase):
+    def setUp(self):
+        self.core_ari = Mock()
+        self.ari = Mock()
+        self.core_ari.client = self.ari
+        self.service = Mock()
+        self.stasis = DialMobileStasis(self.core_ari, self.service)
+
+    def test_subscribe_wires_endpoint_subscription_on_app_registered(self):
+        self.stasis._subscribe()
+
+        self.ari.on_application_registered.assert_any_call(
+            DialMobileStasis._app_name,
+            self.stasis.subscribe_to_pjsip_endpoint_events,
+        )
+        self.ari.on_application_deregistered.assert_any_call(
+            DialMobileStasis._app_name,
+            self.stasis.unsubscribe_from_pjsip_endpoint_events,
+        )
+
+    def test_subscribe_to_pjsip_endpoint_events(self):
+        self.stasis.subscribe_to_pjsip_endpoint_events()
+
+        self.ari.applications.subscribe.assert_called_once_with(
+            applicationName=DialMobileStasis._app_name,
+            eventSource='endpoint:PJSIP',
+        )
+
+    def test_unsubscribe_from_pjsip_endpoint_events(self):
+        self.stasis.unsubscribe_from_pjsip_endpoint_events()
+
+        self.ari.applications.unsubscribe.assert_called_once_with(
+            applicationName=DialMobileStasis._app_name,
+            eventSource='endpoint:PJSIP',
+        )
+
+
+class TestContactStatusChange(TestCase):
+    def setUp(self):
+        self.core_ari = Mock()
+        self.ari = Mock()
+        self.core_ari.client = self.ari
+        self.service = Mock()
+        self.stasis = DialMobileStasis(self.core_ari, self.service)
+
+    def _event(self, contact_status='Reachable', aor='9vCJK5Ob'):
+        return {
+            'type': 'ContactStatusChange',
+            'application': DialMobileStasis._app_name,
+            'endpoint': {
+                'technology': 'PJSIP',
+                'resource': aor,
+                'state': 'online',
+                'channel_ids': [],
+            },
+            'contact_info': {
+                'uri': f'sip:{aor}@127.0.0.1:54332;transport=WS',
+                'contact_status': contact_status,
+                'aor': aor,
+                'roundtrip_usec': '0',
+            },
+        }
+
+    def test_dialable_statuses_route_to_service(self):
+        for status in ('Created', 'NonQualified', 'Reachable'):
+            self.service.notify_contact_available.reset_mock()
+            self.stasis.on_contact_status_change(Mock(), self._event(status))
+            self.service.notify_contact_available.assert_called_once_with('9vCJK5Ob')
+
+    def test_unreachable_statuses_ignored(self):
+        for status in ('Unreachable', 'Removed', 'Unknown'):
+            self.service.notify_contact_available.reset_mock()
+            self.stasis.on_contact_status_change(Mock(), self._event(status))
+            self.service.notify_contact_available.assert_not_called()
+
+    def test_other_application_ignored(self):
+        event = self._event('Reachable')
+        event['application'] = 'somethingelse'
+
+        self.stasis.on_contact_status_change(Mock(), event)
+
+        self.service.notify_contact_available.assert_not_called()


### PR DESCRIPTION
- **feat(pstn/gsm fallback): dial_mobile PSTN fallback path**
- **fix(dial_mobile): handle ARIServerError on PJSIP_ENDPOINT lookup**
- **fix(dial_mobile): cancel pending push when caller hangs up**
- **feat(pstn/gsm fallback): use mobile_fallback_enabled user config**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new timer-driven PSTN (GSM) fallback call path and refactors dial_mobile’s call-state handling, affecting core call routing and notification cancellation behavior under multiple race conditions.
> 
> **Overview**
> Adds a **PSTN/GSM fallback** path to `dial_mobile`: after sending the incoming-call push, a configurable timer can originate a `Local/<mobile>@<context>` leg (using `confd` user/line data and `mobile_fallback_enabled`) and cancels the push only after a successful dispatch.
> 
> Refactors dial_mobile’s internal state to be **`Linkedid`-keyed** with explicit state machines + per-call locks, fixes cancellation races (caller hangup, DialEnd, bridge enter), and improves robustness by handling `ARIServerError` during `PJSIP_ENDPOINT(...,PICKUPMARK)` lookup.
> 
> Improves contact dialing responsiveness by subscribing to ARI `ContactStatusChange` events and waking dialers when endpoints become reachable, and expands unit/integration coverage plus adds integration-test config overrides for fallback timing (`conf.d/30-dial-mobile.yml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fe859e34cdb1731d305803adc4009a8f3cf9a4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->