### PR TITLE
[ITEM-304] switchboards: fix phantom call when attended transfer

### DIFF
--- a/integration_tests/suite/helpers/stasis.py
+++ b/integration_tests/suite/helpers/stasis.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_bus.publisher import BusPublisher

--- a/integration_tests/suite/helpers/stasis.py
+++ b/integration_tests/suite/helpers/stasis.py
@@ -129,6 +129,44 @@ class StasisClient:
         }
         return self._send_stasis_event(body)
 
+    def event_stasis_start_replacing_switchboard_queued_call(
+        self,
+        new_channel_id,
+        replaced_channel_id,
+        tenant_uuid,
+        switchboard_uuid,
+        stasis_app='callcontrol',
+    ):
+        body = {
+            "application": stasis_app,
+            "args": [],
+            "channel": {
+                "accountcode": "",
+                "caller": {"name": "", "number": ""},
+                "connected": {"name": "", "number": ""},
+                "creationtime": "2026-05-11T10:25:14.090-0400",
+                "dialplan": {
+                    "context": "transfer",
+                    "exten": "_attended",
+                    "priority": 1,
+                },
+                "id": new_channel_id,
+                "language": "en",
+                "name": "Local/_attended@transfer-test;2",
+                "state": "Up",
+            },
+            "replace_channel": {
+                "id": replaced_channel_id,
+                "channelvars": {
+                    "WAZO_SWITCHBOARD_QUEUE": switchboard_uuid,
+                    "WAZO_TENANT_UUID": tenant_uuid,
+                },
+            },
+            "timestamp": "2026-05-11T10:25:14.591-0400",
+            "type": "StasisStart",
+        }
+        return self._send_stasis_event(body)
+
     def event_channel_destroyed(
         self,
         channel_id,

--- a/integration_tests/suite/test_switchboards.py
+++ b/integration_tests/suite/test_switchboards.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import random

--- a/integration_tests/suite/test_switchboards.py
+++ b/integration_tests/suite/test_switchboards.py
@@ -220,6 +220,86 @@ class TestSwitchboardCallsQueued(TestSwitchboards):
 
         until.assert_(calls_are_queued, new_channel_2.id, tries=3)
 
+    def test_given_local_channel_queued_via_stasis_then_listed(self):
+        switchboard_uuid = random_uuid(prefix='my-switchboard-uuid-')
+        self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
+        local_channel = self.ari.channels.originate(
+            endpoint='Local/recipient_autoanswer@local',
+            app=STASIS_APP,
+            appArgs=[
+                STASIS_APP_INSTANCE,
+                STASIS_APP_QUEUE,
+                VALID_TENANT,
+                switchboard_uuid,
+            ],
+        )
+
+        def assert_function():
+            calls = self.calld.switchboard_queued_calls(switchboard_uuid)
+            assert_that(
+                calls,
+                has_entry(
+                    'items',
+                    contains_inanyorder(has_entry('id', local_channel.id)),
+                ),
+            )
+
+        until.assert_(assert_function, tries=5)
+
+    def test_given_channel_replacing_queued_call_then_listed(self):
+        switchboard_uuid = random_uuid(prefix='my-switchboard-uuid-')
+        self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
+        queued_bus_events = self.bus.accumulator(
+            headers={
+                'switchboard_uuid': switchboard_uuid,
+                'name': 'switchboard_queued_calls_updated',
+            }
+        )
+        real_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[
+                STASIS_APP_INSTANCE,
+                STASIS_APP_QUEUE,
+                VALID_TENANT,
+                switchboard_uuid,
+            ],
+        )
+        until.true(queued_bus_events.accumulate, tries=3)
+
+        replacement_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE],
+        )
+        until.true(self.channel_is_in_stasis, replacement_channel.id, tries=3)
+        queue_bridge = self.ari.bridges.get(
+            bridgeId=f'switchboard-{switchboard_uuid}-queue'
+        )
+        queue_bridge.addChannel(channel=replacement_channel.id)
+
+        self.stasis.event_stasis_start_replacing_switchboard_queued_call(
+            new_channel_id=replacement_channel.id,
+            replaced_channel_id=real_channel.id,
+            tenant_uuid=VALID_TENANT,
+            switchboard_uuid=switchboard_uuid,
+        )
+
+        def replacement_bus_event_published():
+            events = queued_bus_events.accumulate()
+            assert_that(
+                events,
+                has_item(
+                    has_entries(
+                        data=has_entries(
+                            items=has_item(has_entry('id', replacement_channel.id)),
+                        ),
+                    )
+                ),
+            )
+
+        until.assert_(replacement_bus_event_published, tries=5)
+
     def test_given_no_calls_when_new_queued_call_then_bus_event(self):
         switchboard_uuid = random_uuid(prefix='my-switchboard-uuid-')
         bus_events = self.bus.accumulator(

--- a/wazo_calld/plugins/switchboards/services.py
+++ b/wazo_calld/plugins/switchboards/services.py
@@ -338,7 +338,15 @@ class SwitchboardsService:
 
         result = []
         for channel_id in channel_ids:
-            channel = self._ari.channels.get(channelId=channel_id)
+            try:
+                channel = self._ari.channels.get(channelId=channel_id)
+            except ARINotFound:
+                logger.debug(
+                    'Switchboard %s: channel %s not found in ARI, skipping',
+                    switchboard_uuid,
+                    channel_id,
+                )
+                continue
 
             call = HeldCall(channel.id)
             call.caller_id_name = channel.json['caller']['name']

--- a/wazo_calld/plugins/switchboards/services.py
+++ b/wazo_calld/plugins/switchboards/services.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging

--- a/wazo_calld/plugins/switchboards/stasis.py
+++ b/wazo_calld/plugins/switchboards/stasis.py
@@ -57,6 +57,7 @@ class SwitchboardsStasis:
         try:
             sub_app, *_ = event['args']
         except ValueError:
+            self._stasis_start_replace(event_objects, event)
             return
 
         if sub_app != 'switchboard':
@@ -84,6 +85,35 @@ class SwitchboardsStasis:
         except Exception:
             logger.exception('failed handle a stasis_start %s', event)
             self._ari.channels.continueInDialplan(channelId=event_objects['channel'].id)
+
+    def _stasis_start_replace(self, event_objects, event):
+        replace_channel = event.get('replace_channel')
+        if not replace_channel:
+            return
+        channelvars = replace_channel.get('channelvars') or {}
+        tenant_uuid = channelvars.get('WAZO_TENANT_UUID') or ''
+        queue_uuid = channelvars.get('WAZO_SWITCHBOARD_QUEUE') or ''
+        hold_uuid = channelvars.get('WAZO_SWITCHBOARD_HOLD') or ''
+        if not (queue_uuid or hold_uuid):
+            return
+        channel = event_objects['channel']
+        try:
+            if tenant_uuid:
+                channel.setChannelVar(variable='WAZO_TENANT_UUID', value=tenant_uuid)
+            if queue_uuid:
+                channel.setChannelVar(
+                    variable='WAZO_SWITCHBOARD_QUEUE', value=queue_uuid
+                )
+                queued = self._service.queued_calls(tenant_uuid, queue_uuid)
+                self._notifier.queued_calls(tenant_uuid, queue_uuid, queued)
+            if hold_uuid:
+                channel.setChannelVar(variable='WAZO_SWITCHBOARD_HOLD', value=hold_uuid)
+                held = self._service.held_calls(tenant_uuid, hold_uuid)
+                self._notifier.held_calls(tenant_uuid, hold_uuid, held)
+        except ARINotFound:
+            return
+        except NoSuchSwitchboard:
+            return
 
     def _stasis_start_queue(self, event_objects, event):
         try:

--- a/wazo_calld/plugins/switchboards/stasis.py
+++ b/wazo_calld/plugins/switchboards/stasis.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates switchboard StasisStart handling and call listing logic in ARI-facing paths; mistakes could cause incorrect queue/hold state or missed notifications during transfers, but changes are localized and covered by new integration tests.
> 
> **Overview**
> Fixes switchboard “phantom call” scenarios during attended/blind transfers by handling `StasisStart` events that *replace* an existing channel: the new channel inherits `WAZO_TENANT_UUID` and switchboard queue/hold vars and triggers refreshed queued/held call notifications.
> 
> Hardens held-call listing to skip channels that disappeared from ARI instead of failing, and adds integration tests covering Local-channel queuing and queued-call replacement behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14cad14e411373d83a97237d901bb7eed2be31f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->