### PR TITLE
force rebuild of image every time integration tests are run

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -3,7 +3,7 @@ CHAN_TEST_DIR ?= ../../chan-test
 test-setup: build-calld build-ari build-call-logd
 
 build-calld: egg-info
-	docker build -t wazoplatform/wazo-calld ..
+	docker build --no-cache -t wazoplatform/wazo-calld ..
 	docker build --no-cache -t wazo-calld-test -f docker/Dockerfile-calld-test ..
 
 build-ari:


### PR DESCRIPTION
- fixes issue with stale dependencies (wazo-bus, xivo-lib-python, etc)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a Makefile change that only affects integration-test build behavior; main impact is longer builds and potentially different image contents due to uncached rebuilds.
> 
> **Overview**
> Integration test setup now builds the `wazoplatform/wazo-calld` Docker image with `--no-cache`, ensuring a fresh rebuild each run to prevent stale dependencies from being reused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e71574d5f1c2100f5d5f8ba3c96b1fcb75e60838. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->