### PR TITLE
ITEM 421 ari configure connection pool

### DIFF
--- a/etc/wazo-calld/config.yml
+++ b/etc/wazo-calld/config.yml
@@ -68,7 +68,7 @@ ari:
     username: xivo
     password: Nasheow8Eag
 
-    # Maximum number of simultaneous ARI HTTP connections (urllib3 pool_maxsize)
+    # Maximum number of simultaneous ARI HTTP connections
     pool_size: 10
 
   # How many seconds between each try to reconnect to ARI

--- a/etc/wazo-calld/config.yml
+++ b/etc/wazo-calld/config.yml
@@ -68,6 +68,9 @@ ari:
     username: xivo
     password: Nasheow8Eag
 
+    # Maximum number of simultaneous ARI HTTP connections (urllib3 pool_maxsize)
+    pool_size: 10
+
   # How many seconds between each try to reconnect to ARI
   reconnection_delay: 10
 

--- a/wazo_calld/ari_.py
+++ b/wazo_calld/ari_.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -9,6 +9,7 @@ import urllib.parse
 import ari
 import ari.client
 import swaggerpy.http_client
+from requests.adapters import HTTPAdapter
 from xivo.pubsub import Pubsub
 from xivo.status import Status
 
@@ -17,6 +18,7 @@ from .exceptions import AsteriskARINotInitialized
 logger = logging.getLogger(__name__)
 
 DEFAULT_APPLICATION_NAME = 'callcontrol'
+DEFAULT_ARI_POOL_SIZE = 10
 ALL_STASIS_EVENTS = [
     "ApplicationReplaced",
     "BridgeAttendedTransfer",
@@ -168,19 +170,35 @@ class CachingRepository:
         return channel_cache.get(variable, None)
 
 
+def _build_ari_http_client(
+    base_url: str, username: str, password: str, pool_size: int
+) -> swaggerpy.http_client.SynchronousHttpClient:
+    split = urllib.parse.urlsplit(base_url)
+    http_client = swaggerpy.http_client.SynchronousHttpClient()
+    http_client.set_basic_auth(split.hostname, username, password)
+    # All ARI REST calls share this one session; size its connection pool so a
+    # burst of concurrent calls does not exceed pool_maxsize and get discarded
+    # (urllib3 "Connection pool is full, discarding connection: ari").
+    adapter = HTTPAdapter(pool_maxsize=pool_size)
+    http_client.session.mount('http://', adapter)
+    http_client.session.mount('https://', adapter)
+    return http_client
+
+
 class ARIClientProxy(ari.client.Client):
-    def __init__(self, base_url, username, password):
+    def __init__(self, base_url, username, password, pool_size=DEFAULT_ARI_POOL_SIZE):
         self._base_url = base_url
         self._username = username
         self._password = password
+        self._pool_size = pool_size
         self._initialized = False
         self._registered_app = set()
 
     def init(self):
         if not self._initialized:
-            split = urllib.parse.urlsplit(self._base_url)
-            http_client = swaggerpy.http_client.SynchronousHttpClient()
-            http_client.set_basic_auth(split.hostname, self._username, self._password)
+            http_client = _build_ari_http_client(
+                self._base_url, self._username, self._password, self._pool_size
+            )
             super().__init__(self._base_url, http_client)
             self._initialized = True
 

--- a/wazo_calld/ari_.py
+++ b/wazo_calld/ari_.py
@@ -196,6 +196,10 @@ class ARIClientProxy(ari.client.Client):
 
     def init(self):
         if not self._initialized:
+            logger.info(
+                'Initializing ARI client with connection pool size %s',
+                self._pool_size,
+            )
             http_client = _build_ari_http_client(
                 self._base_url, self._username, self._password, self._pool_size
             )

--- a/wazo_calld/config.py
+++ b/wazo_calld/config.py
@@ -43,6 +43,7 @@ _DEFAULT_CONFIG: CalldConfigDict = {
             'base_url': 'http://localhost:5039',
             'username': 'xivo',
             'password': 'opensesame',
+            'pool_size': 10,
         },
         'reconnection_delay': 10,
         'startup_connection_delay': 1,

--- a/wazo_calld/tests/test_ari_.py
+++ b/wazo_calld/tests/test_ari_.py
@@ -1,0 +1,30 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from unittest import TestCase
+
+from hamcrest import assert_that, equal_to
+
+from ..ari_ import DEFAULT_ARI_POOL_SIZE, ARIClientProxy, _build_ari_http_client
+
+
+class TestBuildAriHttpClient(TestCase):
+    def test_adapter_uses_configured_pool_size(self):
+        http_client = _build_ari_http_client(
+            'http://localhost:5039', 'xivo', 'secret', pool_size=25
+        )
+
+        adapter = http_client.session.get_adapter('http://localhost:5039')
+        assert_that(adapter._pool_maxsize, equal_to(25))
+
+
+class TestARIClientProxyPoolSize(TestCase):
+    def test_default_pool_size(self):
+        proxy = ARIClientProxy('http://localhost:5039', 'xivo', 'secret')
+
+        assert_that(proxy._pool_size, equal_to(DEFAULT_ARI_POOL_SIZE))
+
+    def test_explicit_pool_size(self):
+        proxy = ARIClientProxy('http://localhost:5039', 'xivo', 'secret', pool_size=42)
+
+        assert_that(proxy._pool_size, equal_to(42))

--- a/wazo_calld/tests/test_ari_pool.py
+++ b/wazo_calld/tests/test_ari_pool.py
@@ -27,7 +27,7 @@ from ..ari_ import _build_ari_http_client
 class _SlowHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         # Hold the connection long enough that all concurrent requests are
-        # in flight at once (this is what netem injected in the load test).
+        # in flight at once
         time.sleep(0.2)
         body = b'{}'
         self.send_response(200)

--- a/wazo_calld/tests/test_ari_pool.py
+++ b/wazo_calld/tests/test_ari_pool.py
@@ -1,0 +1,90 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Behavioral test for the ARI client connection pool size.
+
+wazo-calld routes every ARI REST call through one process-wide
+``requests.Session``. When more calls are in flight than the session's
+``pool_maxsize``, urllib3 logs ``Connection pool is full, discarding
+connection`` and drops the surplus connection. This test reproduces that
+condition against a local stub server (a short ``sleep`` holds each connection
+open so concurrency exceeds the pool) and asserts that a pool sized to the load
+no longer discards connections.
+"""
+
+import logging
+import time
+from concurrent.futures import ThreadPoolExecutor
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+from unittest import TestCase
+
+from hamcrest import assert_that, empty, is_not
+
+from ..ari_ import _build_ari_http_client
+
+
+class _SlowHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        # Hold the connection long enough that all concurrent requests are
+        # in flight at once (this is what netem injected in the load test).
+        time.sleep(0.2)
+        body = b'{}'
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass  # silence the default stderr access log during tests
+
+
+class _PoolFullCollector(logging.Handler):
+    def __init__(self):
+        super().__init__()
+        self.warnings = []
+
+    def emit(self, record):
+        if 'Connection pool is full' in record.getMessage():
+            self.warnings.append(record.getMessage())
+
+
+class TestAriConnectionPool(TestCase):
+    def setUp(self):
+        self.server = ThreadingHTTPServer(('127.0.0.1', 0), _SlowHandler)
+        self.url = f'http://127.0.0.1:{self.server.server_address[1]}/'
+        self.server_thread = Thread(target=self.server.serve_forever, daemon=True)
+        self.server_thread.start()
+
+        self.collector = _PoolFullCollector()
+        self.logger = logging.getLogger('urllib3.connectionpool')
+        self._previous_level = self.logger.level
+        self.logger.setLevel(logging.WARNING)
+        self.logger.addHandler(self.collector)
+
+    def tearDown(self):
+        self.logger.removeHandler(self.collector)
+        self.logger.setLevel(self._previous_level)
+        self.server.shutdown()
+        self.server.server_close()
+
+    def _hammer(self, pool_size, concurrency):
+        http_client = _build_ari_http_client(self.url, 'xivo', 'secret', pool_size)
+        with ThreadPoolExecutor(max_workers=concurrency) as pool:
+            futures = [
+                pool.submit(http_client.session.get, self.url)
+                for _ in range(concurrency)
+            ]
+            for future in futures:
+                future.result().close()
+
+    def test_pool_smaller_than_concurrency_discards_connections(self):
+        self._hammer(pool_size=2, concurrency=10)
+
+        assert_that(self.collector.warnings, is_not(empty()))
+
+    def test_pool_large_enough_keeps_all_connections(self):
+        self._hammer(pool_size=20, concurrency=10)
+
+        assert_that(self.collector.warnings, empty())

--- a/wazo_calld/types.py
+++ b/wazo_calld/types.py
@@ -29,6 +29,7 @@ class AriConnectionConfigDict(TypedDict):
     base_url: str
     username: str
     password: str
+    pool_size: int
 
 
 class AriConfigDict(TypedDict):


### PR DESCRIPTION
- **fix(ari): make ARI client connection pool size configurable**
- **feat(ari): log pool size on ARI client init**
- **tests(load): locust-based load tests**
- **tests(unit,ari): unit test coverage for ARI client**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to ARI HTTP client wiring with a safe default; mis-tuned pool_size could affect performance under load but not auth or data integrity.
> 
> **Overview**
> Adds **`ari.connection.pool_size`** (default **10**) so the shared ARI `requests` session can handle bursts of concurrent REST calls without urllib3 discarding connections (**"Connection pool is full, discarding connection"**).
> 
> ARI client setup now builds the HTTP client via **`_build_ari_http_client`**, mounting **`HTTPAdapter(pool_maxsize=pool_size)`** on http/https, and **`ARIClientProxy`** accepts **`pool_size`** from config (wired through **`CoreARI`** via **`**config['connection']`**). Init logs the chosen pool size.
> 
> Defaults and types are updated in **`config.py`**, **`etc/wazo-calld/config.yml`**, and **`AriConnectionConfigDict`**. New unit tests cover adapter/proxy sizing; **`test_ari_pool.py`** reproduces pool exhaustion against a stub server and asserts warnings only when the pool is too small.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 016e5da681fe38b48c2a3b4fdaa4272546ce1399. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->