### PR TITLE
fix-config-log-filename

### DIFF
--- a/etc/wazo-calld/config.yml
+++ b/etc/wazo-calld/config.yml
@@ -9,7 +9,7 @@ extra_config_files: /etc/wazo-calld/conf.d/
 debug: false
 
 # Log file.
-logfile: /var/log/wazo-calld.log
+log_filename: /var/log/wazo-calld.log
 
 # REST API server
 rest_api:

--- a/integration_tests/suite/helpers/wait_strategy.py
+++ b/integration_tests/suite/helpers/wait_strategy.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import requests
@@ -23,6 +23,11 @@ class CalldComponentsWaitStrategy(ComponentsWaitStrategy):
 class CalldUpWaitStrategy(WaitStrategy):
     def wait(self, integration_test):
         until.true(integration_test.calld_client.is_up, tries=5)
+
+
+class CallLogdUpWaitStrategy(WaitStrategy):
+    def wait(self, integration_test):
+        until.true(integration_test.call_logd.is_up, tries=10)
 
 
 class CalldConnectionsOkWaitStrategy(WaitStrategy):

--- a/integration_tests/suite/test_voicemail_transcription.py
+++ b/integration_tests/suite/test_voicemail_transcription.py
@@ -19,7 +19,7 @@ from .helpers.base import IntegrationTest
 from .helpers.confd import MockVoicemail
 from .helpers.constants import VALID_TENANT, VALID_TENANT_MULTITENANT_1, XIVO_UUID
 from .helpers.real_asterisk import RealAsteriskIntegrationTest
-from .helpers.wait_strategy import CalldEverythingOkWaitStrategy
+from .helpers.wait_strategy import CalldEverythingOkWaitStrategy, CallLogdUpWaitStrategy
 
 
 class TestVoicemailTranscriptionBusConsume(IntegrationTest):
@@ -621,7 +621,6 @@ class TestVoicemailTranscriptionEnrichment(RealAsteriskIntegrationTest):
 
         calld = self.make_user_calld(user_uuid, tenant_uuid=VALID_TENANT)
         # default/8001 has 3 more messages, total = 4
-
         # no filter: both transcribed and non-transcribed included
         result = calld.voicemails.list_voicemail_messages()
         assert_that(
@@ -635,7 +634,6 @@ class TestVoicemailTranscriptionEnrichment(RealAsteriskIntegrationTest):
                 filtered=4,
             ),
         )
-
         # transcribed=True: only transcribed messages
         result = calld.voicemails.list_voicemail_messages(transcribed=True)
         assert_that(
@@ -648,7 +646,6 @@ class TestVoicemailTranscriptionEnrichment(RealAsteriskIntegrationTest):
                 filtered=1,
             ),
         )
-
         # transcribed=False: only non-transcribed messages
         result = calld.voicemails.list_voicemail_messages(transcribed=False)
         assert_that(
@@ -701,6 +698,7 @@ class TestVoicemailTranscriptionEnrichment(RealAsteriskIntegrationTest):
         finally:
             self.start_service('call-logd')
             self.reset_clients()
+            CallLogdUpWaitStrategy().wait(self)
 
     def test_personal_voicemail_transcription_deleted_event(self):
         user_uuid_1 = str(uuid.uuid4())


### PR DESCRIPTION
Why: wazo-calld reads the log file path from the log_filename key;
the logfile key shipped in config.yml was silently ignored, so
overriding it there had no effect.
