### PR TITLE
ITEM-450 pre-generate-call-id

### DIFF
--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -3,19 +3,29 @@
 
 import contextlib
 import logging
+import random
 import threading
+import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
 import requests
-from ari.exceptions import ARINotFound, ARIServerError
+from ari.exceptions import ARINotFound, ARINotInStasis, ARIServerError
 from requests import HTTPError, RequestException
 
 from wazo_calld.plugin_helpers.ari_ import Bridge
 
 logger = logging.getLogger(__name__)
+
+
+def _generate_channel_id() -> str:
+    # Channel id predetermined for mobile contact legs. Mimics Asterisk's own
+    # uniqueid format (<epoch>.<small integer>, see main/channel_internal_api.c).
+    # A collision with a live channel id makes the originate fail with a 409,
+    # handled by retrying with a new value.
+    return f'{int(time.time())}.{random.randint(0, 999)}'
 
 
 @dataclass
@@ -302,14 +312,33 @@ class _ContactDialer:
         self.logger.debug(
             'sending %s to the future bridge %s', contact, future_bridge_uuid
         )
-        channel = self._ari.channels.originate(
-            endpoint=contact,
-            app='dial_mobile',
-            appArgs=['join', future_bridge_uuid],
-            callerId=caller_id,
-            originator=self._caller_channel_id,
-            timeout=self._ringing_time,
-        )
+        # Predetermine the channel id and expose it in the INVITE so the
+        # client learns its call_id at the same time as its sip_call_id,
+        # avoiding any mismatch between the two.
+        max_attempts = 3
+        for attempt in range(1, max_attempts + 1):
+            channel_id = _generate_channel_id()
+            try:
+                channel = self._ari.channels.originate(
+                    endpoint=contact,
+                    app='dial_mobile',
+                    appArgs=['join', future_bridge_uuid],
+                    callerId=caller_id,
+                    originator=self._caller_channel_id,
+                    timeout=self._ringing_time,
+                    channelId=channel_id,
+                    variables={
+                        'variables': {
+                            'PJSIP_HEADER(add,X-Wazo-Call-ID)': channel_id,
+                        },
+                    },
+                )
+            except ARINotInStasis:  # 409: a channel with this id already exists
+                if attempt == max_attempts:
+                    raise
+                self.logger.info('channel id %s already in use, retrying', channel_id)
+            else:
+                break
 
         self.logger.debug('Dialed channel %s', channel.id)
         self._called_contacts.add(contact)

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -3,13 +3,21 @@
 
 import threading
 from unittest import TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 from unittest.mock import sentinel as s
 
 import pytest
 import requests
-from ari.exceptions import ARINotFound
-from hamcrest import assert_that, contains_exactly, empty, equal_to, has_items
+from ari.exceptions import ARINotFound, ARINotInStasis
+from hamcrest import (
+    assert_that,
+    contains_exactly,
+    empty,
+    equal_to,
+    has_items,
+    is_not,
+    matches_regexp,
+)
 
 from ..notifier import Notifier
 from ..services import (
@@ -83,7 +91,61 @@ class TestSendContactToCurrentCall(DialerTestCase):
             callerId=s.caller_id,
             originator=self.channel_id,
             timeout=self.ringing_time,
+            channelId=ANY,
+            variables=ANY,
         )
+
+    def test_that_the_channel_id_is_exposed_in_the_invite(self):
+        self.poller._send_contact_to_current_call(
+            s.contact, self.future_bridge_uuid, s.caller_id
+        )
+
+        kwargs = self.ari.channels.originate.call_args.kwargs
+        channel_id = kwargs['channelId']
+        assert_that(
+            kwargs['variables'],
+            equal_to({'variables': {'PJSIP_HEADER(add,X-Wazo-Call-ID)': channel_id}}),
+        )
+
+    def test_that_the_channel_id_has_the_asterisk_uniqueid_format(self):
+        self.poller._send_contact_to_current_call(
+            s.contact, self.future_bridge_uuid, s.caller_id
+        )
+
+        channel_id = self.ari.channels.originate.call_args.kwargs['channelId']
+        assert_that(channel_id, matches_regexp(r'^\d{10}\.\d{1,3}$'))
+
+    def test_that_a_channel_id_collision_is_retried_with_a_new_id(self):
+        self.ari.channels.originate.side_effect = [
+            ARINotInStasis(s.ari_client, s.original_error),
+            Mock(),
+        ]
+
+        with patch(
+            'wazo_calld.plugins.dial_mobile.services.random.randint',
+            side_effect=[42, 43],
+        ):
+            self.poller._send_contact_to_current_call(
+                s.contact, self.future_bridge_uuid, s.caller_id
+            )
+
+        first, second = (
+            call.kwargs['channelId']
+            for call in self.ari.channels.originate.call_args_list
+        )
+        assert_that(second, is_not(equal_to(first)))
+
+    def test_that_a_persistent_channel_id_collision_raises(self):
+        self.ari.channels.originate.side_effect = ARINotInStasis(
+            s.ari_client, s.original_error
+        )
+
+        with pytest.raises(ARINotInStasis):
+            self.poller._send_contact_to_current_call(
+                s.contact, self.future_bridge_uuid, s.caller_id
+            )
+
+        assert_that(len(self.ari.channels.originate.call_args_list), equal_to(3))
 
 
 class TestChannelIsUp(DialerTestCase):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches live call origination for mobile legs; misaligned IDs or failed retries could affect ringing, though scope is limited to dial_mobile contact dialing.
> 
> **Overview**
> Mobile contact legs now get a **predetermined Asterisk-style channel ID** before originate, and the same value is sent to the client in the SIP INVITE via `X-Wazo-Call-ID`, so `call_id` and `sip_call_id` can align when the app receives the ring.
> 
> `_ContactDialer._send_contact_to_current_call` passes `channelId` and the matching PJSIP header on ARI originate. If that ID is already in use (`ARINotInStasis` / 409), it retries with a new ID up to three times.
> 
> Unit tests cover header wiring, ID format, retry on collision, and failure after max attempts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 303ba2ad25d8a9675c1e7cff554a56867d24e003. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->