### PR TITLE
ITEM-447-dynamic-thread-pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 26.08
+
+* New `rest_api.min_threads` option: threads kept ready at all times.
+  `max_threads` is now a ceiling the pool grows to under load, not a fixed
+  thread count.
+
 ## 26.05
 
 * The call listing endpoints (`GET /calls`, `GET /users/me/calls`) and the call events relayed to the bus now read channel variables from the `channelvars` dict embedded in ARI channel snapshots, falling back to live `getChannelVar` requests for variables missing from the snapshot. This drastically reduces the number of HTTP requests made to Asterisk; the full reduction requires the updated `channelvars` list in the platform `ari.conf` (see wazo-asterisk-config). There is no API change.

--- a/etc/wazo-calld/config.yml
+++ b/etc/wazo-calld/config.yml
@@ -74,8 +74,9 @@ ari:
     username: xivo
     password: Nasheow8Eag
 
-    # Maximum number of simultaneous ARI HTTP connections
-    pool_size: 10
+    # Maximum number of ARI HTTP connections kept alive for reuse.
+    # null: defaults to rest_api.max_threads
+    pool_size: null
 
   # How many seconds between each try to reconnect to ARI
   reconnection_delay: 10

--- a/etc/wazo-calld/config.yml
+++ b/etc/wazo-calld/config.yml
@@ -29,10 +29,16 @@ rest_api:
     # Allow JSON preflight requests
     allow_headers: [Content-Type, X-Auth-Token, Wazo-Tenant]
 
-  # Maximum of concurrent threads processing requests
+  # Minimum of concurrent threads processing requests. This many threads
+  # (and database connections) are kept ready at all times.
+  min_threads: 10
+
+  # Maximum of concurrent threads processing requests. The number of threads
+  # (and database connections) scales with demand between min_threads and
+  # max_threads.
   # See the performance documentation for more details
   # https://wazo-platform.org/uc-doc/system/performance/
-  max_threads: 10
+  max_threads: 100
 
 # wazo-auth (authentication daemon) connection settings.
 auth:

--- a/wazo_calld/ari_.py
+++ b/wazo_calld/ari_.py
@@ -18,7 +18,6 @@ from .exceptions import AsteriskARINotInitialized
 logger = logging.getLogger(__name__)
 
 DEFAULT_APPLICATION_NAME = 'callcontrol'
-DEFAULT_ARI_POOL_SIZE = 10
 ALL_STASIS_EVENTS = [
     "ApplicationReplaced",
     "BridgeAttendedTransfer",
@@ -186,7 +185,7 @@ def _build_ari_http_client(
 
 
 class ARIClientProxy(ari.client.Client):
-    def __init__(self, base_url, username, password, pool_size=DEFAULT_ARI_POOL_SIZE):
+    def __init__(self, base_url, username, password, pool_size):
         self._base_url = base_url
         self._username = username
         self._password = password

--- a/wazo_calld/config.py
+++ b/wazo_calld/config.py
@@ -30,7 +30,8 @@ _DEFAULT_CONFIG: CalldConfigDict = {
             'enabled': True,
             'allow_headers': ['Content-Type', 'X-Auth-Token', 'Wazo-Tenant'],
         },
-        'max_threads': 10,
+        'min_threads': 10,
+        'max_threads': 100,
     },
     'amid': {
         'host': 'localhost',

--- a/wazo_calld/config.py
+++ b/wazo_calld/config.py
@@ -44,7 +44,7 @@ _DEFAULT_CONFIG: CalldConfigDict = {
             'base_url': 'http://localhost:5039',
             'username': 'xivo',
             'password': 'opensesame',
-            'pool_size': 10,
+            'pool_size': None,  # None: use rest_api.max_threads
         },
         'reconnection_delay': 10,
         'startup_connection_delay': 1,
@@ -190,5 +190,9 @@ def _get_reinterpreted_raw_values(config: dict[str, Any]) -> dict[str, Any]:
     log_level = config.get('log_level')
     if log_level:
         result['log_level'] = get_log_level_by_name(log_level)
+
+    if config['ari']['connection']['pool_size'] is None:
+        # Default: one retained ARI connection per REST API worker thread
+        result['ari'] = {'connection': {'pool_size': config['rest_api']['max_threads']}}
 
     return result

--- a/wazo_calld/http_server.py
+++ b/wazo_calld/http_server.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -43,10 +43,11 @@ class HTTPServer:
         )
 
         bind_addr = (self.config['listen'], self.config['port'])
-        self.server = wsgi.WSGIServer(
+        self.server = wsgi.DynamicWSGIServer(
             bind_addr=bind_addr,
             wsgi_app=wsgi_app_https,
-            numthreads=self.config['max_threads'],
+            numthreads=self.config['min_threads'],
+            max=self.config['max_threads'],
         )
         if self.config['certificate'] and self.config['private_key']:
             logger.warning(

--- a/wazo_calld/tests/test_ari_.py
+++ b/wazo_calld/tests/test_ari_.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 
 from hamcrest import assert_that, equal_to
 
-from ..ari_ import DEFAULT_ARI_POOL_SIZE, ARIClientProxy, _build_ari_http_client
+from ..ari_ import ARIClientProxy, _build_ari_http_client
 
 
 class TestBuildAriHttpClient(TestCase):
@@ -19,11 +19,6 @@ class TestBuildAriHttpClient(TestCase):
 
 
 class TestARIClientProxyPoolSize(TestCase):
-    def test_default_pool_size(self):
-        proxy = ARIClientProxy('http://localhost:5039', 'xivo', 'secret')
-
-        assert_that(proxy._pool_size, equal_to(DEFAULT_ARI_POOL_SIZE))
-
     def test_explicit_pool_size(self):
         proxy = ARIClientProxy('http://localhost:5039', 'xivo', 'secret', pool_size=42)
 

--- a/wazo_calld/tests/test_config.py
+++ b/wazo_calld/tests/test_config.py
@@ -1,0 +1,52 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from unittest import TestCase
+
+from hamcrest import assert_that, equal_to, has_key, not_
+from xivo.chain_map import ChainMap
+
+from ..config import _DEFAULT_CONFIG, _get_reinterpreted_raw_values
+
+
+class TestAriPoolSizeDerivation(TestCase):
+    def test_pool_size_defaults_to_max_threads(self):
+        config = ChainMap({}, _DEFAULT_CONFIG)
+
+        result = _get_reinterpreted_raw_values(config)
+
+        assert_that(
+            result['ari']['connection']['pool_size'],
+            equal_to(_DEFAULT_CONFIG['rest_api']['max_threads']),
+        )
+
+    def test_pool_size_follows_configured_max_threads(self):
+        file_config = {'rest_api': {'max_threads': 250}}
+        config = ChainMap(file_config, _DEFAULT_CONFIG)
+
+        result = _get_reinterpreted_raw_values(config)
+
+        assert_that(result['ari']['connection']['pool_size'], equal_to(250))
+
+    def test_explicit_pool_size_is_not_overridden(self):
+        file_config = {'ari': {'connection': {'pool_size': 42}}}
+        config = ChainMap(file_config, _DEFAULT_CONFIG)
+
+        result = _get_reinterpreted_raw_values(config)
+
+        assert_that(result, not_(has_key('ari')))
+
+    def test_derived_overlay_keeps_other_connection_settings(self):
+        config = ChainMap({}, _DEFAULT_CONFIG)
+        overlay = _get_reinterpreted_raw_values(config)
+
+        final = ChainMap(overlay, _DEFAULT_CONFIG)
+
+        assert_that(
+            final['ari']['connection']['base_url'],
+            equal_to(_DEFAULT_CONFIG['ari']['connection']['base_url']),
+        )
+        assert_that(
+            final['ari']['connection']['pool_size'],
+            equal_to(_DEFAULT_CONFIG['rest_api']['max_threads']),
+        )

--- a/wazo_calld/types.py
+++ b/wazo_calld/types.py
@@ -98,6 +98,7 @@ class RestApiConfigDict(TypedDict):
     certificate: str | None
     private_key: str | None
     cors: RestApiCorsConfigDict
+    min_threads: int
     max_threads: int
 
 

--- a/wazo_calld/types.py
+++ b/wazo_calld/types.py
@@ -29,7 +29,7 @@ class AriConnectionConfigDict(TypedDict):
     base_url: str
     username: str
     password: str
-    pool_size: int
+    pool_size: int | None
 
 
 class AriConfigDict(TypedDict):


### PR DESCRIPTION

Depends-on: https://github.com/wazo-platform/xivo-dao/pull/350
Depends-on: https://github.com/wazo-platform/xivo-lib-python/pull/187

Why: max_threads was a fixed thread count spawned at startup, wasting
idle threads and DB connections on quiet systems. The pool now grows
and shrinks between the new min_threads setting and max_threads, which
becomes a real ceiling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core request concurrency defaults and ties ARI connection pooling to max_threads, which can affect resource use under load; behavior relies on new xivo-lib-python WSGI support.
> 
> **Overview**
> Replaces the fixed REST worker thread count with a **dynamic pool** between new `rest_api.min_threads` and `rest_api.max_threads`, wired through `DynamicWSGIServer` instead of `WSGIServer`. **Defaults shift** from a flat 10 threads to **10 ready at idle** and up to **100 under load** (config and sample `config.yml` updated; changelog 26.08).
> 
> **ARI HTTP connection pooling** is aligned with peak concurrency: `ari.connection.pool_size` may be `null` and is then set to `rest_api.max_threads` at config load; explicit `pool_size` is unchanged. `ARIClientProxy` no longer has a built-in default pool size—tests and types reflect the new options.
> 
> **Risk note:** Depends on companion changes in **xivo-lib-python** (`DynamicWSGIServer`) and related stack PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fc34a36c16784acb469cfbc74311613bb6855f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->