### PR TITLE
Pass CHAN_TEST_DIR through tox for integration tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ use_develop = true
 deps = -rintegration_tests/test-requirements.txt
 change_dir = integration_tests
 pass_env =
+    CHAN_TEST_DIR
     INTEGRATION_TEST_TIMEOUT
     TEST_LOGS
     WAZO_TEST_COVERAGE_DIR


### PR DESCRIPTION
Tested with: https://jenkins.wazo.community/job/integration-tests-nolock/14392/ (aborted after setup completed)

CI now runs `tox -e integration` instead of calling make directly. tox strips environment variables not listed in `pass_env`, so the `CHAN_TEST_DIR` exported by CI never reached the Makefile and `build-ari` failed on the `../../chan-test` fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single tox configuration change with no runtime or security impact.
> 
> **Overview**
> **CI integration runs via `tox -e integration`**, but tox only forwards env vars listed under `pass_env`. **`CHAN_TEST_DIR` is now whitelisted** so the value set in CI reaches the integration `Makefile` (e.g. `build-ari`) instead of falling back to `../../chan-test` and failing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 137eae607681f921249a401beda515e0da236be8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->