### PR TITLE
integration-chan-test-pull

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -1,4 +1,8 @@
-CHAN_TEST_DIR ?= ../../chan-test
+ifeq ($(CHAN_TEST_DIR),)
+	CHAN_TEST_TARGET=chan-test-pull
+else
+	CHAN_TEST_TARGET=chan-test-build
+endif
 
 test-setup: build-calld build-ari build-call-logd
 
@@ -6,9 +10,18 @@ build-calld: egg-info
 	docker build --no-cache -t wazoplatform/wazo-calld ..
 	docker build --no-cache -t wazo-calld-test -f docker/Dockerfile-calld-test ..
 
-build-ari:
-	test -d $(CHAN_TEST_DIR)
+build-ari: ari-mock chan-test
+
+ari-mock:
 	docker build -t ari-mock -f docker/Dockerfile-ari-mock .
+
+chan-test: $(CHAN_TEST_TARGET)
+
+chan-test-pull:
+	docker pull wazoplatform/chan-test
+	docker tag wazoplatform/chan-test:latest ari-real
+
+chan-test-build:
 	docker build -t ari-real --pull -f $(CHAN_TEST_DIR)/Dockerfile $(CHAN_TEST_DIR)
 
 build-call-logd:
@@ -29,4 +42,4 @@ egg-info:
 test:
 	pytest
 
-.PHONY: test-setup build-calld build-ari build-call-logd egg-info test
+.PHONY: test-setup build-calld build-ari ari-mock chan-test chan-test-pull chan-test-build build-call-logd egg-info test


### PR DESCRIPTION
Why: CI runs tox -e integration and has no local chan-test checkout
to build the ari-real image from. Follow the wazo-confd pattern: pull
the published wazoplatform/chan-test image by default and build from
CHAN_TEST_DIR only when it is set; both produce the ari-real tag used
by the docker-compose override files.

Side effect: local runs no longer build from ../../chan-test by
default; set CHAN_TEST_DIR to build from a local checkout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only integration test Docker/Makefile wiring changes; no production runtime or application logic is affected.
> 
> **Overview**
> Integration test setup no longer assumes a local **`../../chan-test`** checkout. **`build-ari`** now builds **`ari-mock`** and provisions **`ari-real`** via a **`chan-test`** target that branches on whether **`CHAN_TEST_DIR`** is set.
> 
> When **`CHAN_TEST_DIR`** is empty (typical CI), Make runs **`chan-test-pull`**: pull **`wazoplatform/chan-test`** and tag it as **`ari-real`**, matching the wazo-confd pattern. When **`CHAN_TEST_DIR`** points at a checkout, **`chan-test-build`** still builds **`ari-real`** from that directory’s Dockerfile.
> 
> **Local default behavior changes:** developers who relied on the implicit **`../../chan-test`** path must set **`CHAN_TEST_DIR`** to build from a local tree; otherwise they get the published image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fccea2a1cfd2afc78dfc5088c6e6597a699460c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->