### PR TITLE
Use nginx for internal wazo-auth requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 26.09
+
+* Requests to wazo-auth now default to `localhost:80`, through nginx.
+
 ## 26.08
 
 * New `rest_api.min_threads` option: threads kept ready at all times.

--- a/etc/wazo-calld/config.yml
+++ b/etc/wazo-calld/config.yml
@@ -43,8 +43,7 @@ rest_api:
 # wazo-auth (authentication daemon) connection settings.
 auth:
   host: localhost
-  port: 9497
-  prefix: null
+  port: 80
   https: false
   key_file: /var/lib/wazo-auth-keys/wazo-calld-key.yml
 

--- a/integration_tests/assets/etc/wazo-amid/config.yml
+++ b/integration_tests/assets/etc/wazo-amid/config.yml
@@ -14,6 +14,8 @@ ajam:
 
 auth:
   host: auth
+  port: 9497
+  prefix: null
   # *-service usernames will be rejected by wazo-auth-mock
   # until we setup a valid token for those credentials
   username: wazo-amid-service

--- a/integration_tests/assets/etc/wazo-call-logd/conf.d/50-calld-tests.yml
+++ b/integration_tests/assets/etc/wazo-call-logd/conf.d/50-calld-tests.yml
@@ -7,6 +7,8 @@ cel_db_uri: postgresql://asterisk:proformatique@call-logd-cel-postgres/asterisk
 
 auth:
   host: auth
+  port: 9497
+  prefix: null
   username: wazo-call-logd
   password: opensesame
   master_tenant_uuid: ffffffff-ffff-ffff-ffff-ffffffffffff

--- a/integration_tests/assets/etc/wazo-calld/conf.d/50-base.yml
+++ b/integration_tests/assets/etc/wazo-calld/conf.d/50-base.yml
@@ -13,6 +13,8 @@ ari:
 
 auth:
   host: auth
+  port: 9497
+  prefix: null
   key_file: /etc/wazo-calld/key.yml
 
 bus:

--- a/wazo_calld/config.py
+++ b/wazo_calld/config.py
@@ -51,8 +51,7 @@ _DEFAULT_CONFIG: CalldConfigDict = {
     },
     'auth': {
         'host': 'localhost',
-        'port': 9497,
-        'prefix': None,
+        'port': 80,
         'https': False,
         'key_file': '/var/lib/wazo-auth-keys/wazo-calld-key.yml',
     },

--- a/wazo_calld/types.py
+++ b/wazo_calld/types.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Collection
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from flask_restful import Api
 from xivo.pubsub import Pubsub
@@ -41,7 +41,7 @@ class AriConfigDict(TypedDict):
 class AuthConfigDict(TypedDict):
     host: str
     port: int
-    prefix: str | None
+    prefix: NotRequired[str | None]
     https: bool
     key_file: str
 


### PR DESCRIPTION
Points requests to wazo-auth at the nginx internal entry point
(`localhost:80`) instead of the wazo-auth process port, in both the Python
defaults and the shipped `config.yml` (the YAML is loaded on top of the Python
defaults, so both must change).

The `prefix` override is dropped rather than set: `wazo-auth-client` already
defaults to `/api/auth`.

Depends on:

* wazo-platform/wazo-nginx#23 — the internal entry point itself
* wazo-platform/wazo-auth#449 — the wazo-auth location served on it

Both must be deployed before this merges, otherwise internal auth calls 404.
Ticket: TASK-504

Notes:

* Integration test assets now pin `port: 9497` and `prefix: null` explicitly:
  their stacks have no nginx, and those values used to come from the defaults
  changed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every internal auth request is reached at runtime and depends on coordinated nginx/wazo-auth deployment; mis-ordering breaks service authentication.
> 
> **Overview**
> **Internal wazo-auth** traffic is retargeted from the wazo-auth daemon port (`9497`) to **nginx on `localhost:80`**, in both Python defaults (`wazo_calld/config.py`) and the shipped `etc/wazo-calld/config.yml` (YAML overlays defaults, so both must match).
> 
> The explicit **`auth.prefix: null`** override is removed from production defaults; **`AuthConfigDict`** marks `prefix` as optional so configs can omit it and rely on **`wazo-auth-client`**’s default **`/api/auth`**.
> 
> **Integration test** asset configs (`wazo-calld`, `wazo-amid`, `wazo-call-logd`) now **explicitly set `port: 9497` and `prefix: null`** because those stacks have no nginx and previously inherited the old defaults.
> 
> **CHANGELOG** documents the 26.09 behavior change. **Deploy order:** nginx internal entry and wazo-auth location must be live before this ships, or internal auth calls will fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5da7c6aba4a8c7c31654577aa2ff5775cbf2b75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->