### PR TITLE
ITEM 554 dtmf letters

### DIFF
--- a/integration_tests/suite/test_applications.py
+++ b/integration_tests/suite/test_applications.py
@@ -3176,3 +3176,34 @@ class TestApplicationSendDTMF(BaseApplicationTestCase):
                 )
 
         until.assert_(amid_dtmf_events_received, tries=5)
+
+    def test_put_dtmf_letters_are_case_insensitive(self):
+        app_uuid = self.node_app_uuid
+        channel = self.call_app(app_uuid)
+
+        event_accumulator = self.bus.accumulator(
+            headers={
+                'name': 'DTMFEnd',
+            }
+        )
+
+        self.calld_client.applications.send_dtmf_digits(app_uuid, channel.id, 'aBcD')
+
+        def amid_dtmf_events_received():
+            events = event_accumulator.accumulate()
+            for expected_digit in 'ABCD':
+                assert_that(
+                    events,
+                    has_item(
+                        has_entries(
+                            name='DTMFEnd',
+                            data=has_entries(
+                                Direction='Received',
+                                Digit=expected_digit,
+                                Uniqueid=channel.id,
+                            ),
+                        )
+                    ),
+                )
+
+        until.assert_(amid_dtmf_events_received, tries=5)

--- a/integration_tests/suite/test_applications.py
+++ b/integration_tests/suite/test_applications.py
@@ -3148,6 +3148,14 @@ class TestApplicationSendDTMF(BaseApplicationTestCase):
             raises(CalldError).matching(has_properties(status_code=400)),
         )
 
+        # Missing DTMF
+        assert_that(
+            calling(self.calld_client.applications.send_dtmf_digits).with_args(
+                app_uuid, channel.id, None
+            ),
+            raises(CalldError).matching(has_properties(status_code=400)),
+        )
+
         event_accumulator = self.bus.accumulator(
             headers={
                 'name': 'DTMFEnd',

--- a/integration_tests/suite/test_calls.py
+++ b/integration_tests/suite/test_calls.py
@@ -3712,6 +3712,37 @@ class TestCallSendDTMF(RealAsteriskIntegrationTest):
 
         until.assert_(amid_dtmf_events_received, tries=10)
 
+    def test_put_dtmf_letters_are_case_insensitive(self):
+        channel_id = self.given_call_not_stasis()
+
+        event_accumulator = self.bus.accumulator(headers={'name': 'DTMFEnd'})
+
+        self.calld_client.calls.send_dtmf_digits(channel_id, 'aBcD')
+
+        def amid_dtmf_events_received():
+            events = event_accumulator.accumulate(with_headers=True)
+            for expected_digit in 'ABCD':
+                assert_that(
+                    events,
+                    has_item(
+                        has_entries(
+                            message=has_entries(
+                                name='DTMFEnd',
+                                data=has_entries(
+                                    Direction='Received',
+                                    Digit=expected_digit,
+                                    Uniqueid=channel_id,
+                                ),
+                            ),
+                            headers=has_entries(
+                                name='DTMFEnd',
+                            ),
+                        )
+                    ),
+                )
+
+        until.assert_(amid_dtmf_events_received, tries=10)
+
     def test_put_dtmf_tenant_isolation(self):
         user_uuid_1 = str(uuid.uuid4())
         tenant_uuid_1 = str(uuid.uuid4())

--- a/integration_tests/suite/test_calls.py
+++ b/integration_tests/suite/test_calls.py
@@ -3682,6 +3682,14 @@ class TestCallSendDTMF(RealAsteriskIntegrationTest):
             raises(CalldError).matching(has_properties(status_code=400)),
         )
 
+        # Missing DTMF
+        assert_that(
+            calling(self.calld_client.calls.send_dtmf_digits).with_args(
+                channel_id, None
+            ),
+            raises(CalldError).matching(has_properties(status_code=400)),
+        )
+
         event_accumulator = self.bus.accumulator(headers={'name': 'DTMFEnd'})
 
         # Valid DTMF

--- a/wazo_calld/plugin_helpers/mallow.py
+++ b/wazo_calld/plugin_helpers/mallow.py
@@ -1,7 +1,9 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import fields
+
+DTMF_DIGITS_REGEX = r'^[0-9*#A-Da-d]+$'
 
 
 class StrictDict(fields.Dict):

--- a/wazo_calld/plugins/api/api.yml
+++ b/wazo_calld/plugins/api/api.yml
@@ -108,6 +108,7 @@ parameters:
   DTMFDigits:
     name: digits
     in: query
-    description: Digits to send via DTMF. Must contain only `0-9*#`.
+    description: Digits to send via DTMF. Must contain only `0-9*#ABCD` (letters are
+      case insensitive).
     required: True
     type: string

--- a/wazo_calld/plugins/applications/schemas.py
+++ b/wazo_calld/plugins/applications/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import EXCLUDE, Schema, fields, post_load, pre_load
@@ -97,7 +97,13 @@ class ApplicationSchema(Schema):
 
 
 class ApplicationDTMFSchema(BaseSchema):
-    digits = fields.String(validate=Regexp(r'^[0-9*#]+$'))
+    digits = fields.String(validate=Regexp(r'^[0-9*#A-Da-d]+$'))
+
+    @post_load
+    def normalize_digits(self, dtmf_request, **kwargs):
+        if 'digits' in dtmf_request:
+            dtmf_request['digits'] = dtmf_request['digits'].upper()
+        return dtmf_request
 
 
 application_call_request_schema = ApplicationCallRequestSchema()

--- a/wazo_calld/plugins/applications/schemas.py
+++ b/wazo_calld/plugins/applications/schemas.py
@@ -4,7 +4,7 @@
 from marshmallow import EXCLUDE, Schema, fields, post_load, pre_load
 from xivo.mallow.validate import Length, OneOf, Regexp, validate_string_dict
 
-from wazo_calld.plugin_helpers.mallow import StrictDict
+from wazo_calld.plugin_helpers.mallow import DTMF_DIGITS_REGEX, StrictDict
 
 
 class BaseSchema(Schema):
@@ -97,7 +97,7 @@ class ApplicationSchema(Schema):
 
 
 class ApplicationDTMFSchema(BaseSchema):
-    digits = fields.String(validate=Regexp(r'^[0-9*#A-Da-d]+$'), required=True)
+    digits = fields.String(validate=Regexp(DTMF_DIGITS_REGEX), required=True)
 
     @post_load
     def normalize_digits(self, dtmf_request, **kwargs):

--- a/wazo_calld/plugins/applications/schemas.py
+++ b/wazo_calld/plugins/applications/schemas.py
@@ -97,12 +97,11 @@ class ApplicationSchema(Schema):
 
 
 class ApplicationDTMFSchema(BaseSchema):
-    digits = fields.String(validate=Regexp(r'^[0-9*#A-Da-d]+$'))
+    digits = fields.String(validate=Regexp(r'^[0-9*#A-Da-d]+$'), required=True)
 
     @post_load
     def normalize_digits(self, dtmf_request, **kwargs):
-        if 'digits' in dtmf_request:
-            dtmf_request['digits'] = dtmf_request['digits'].upper()
+        dtmf_request['digits'] = dtmf_request['digits'].upper()
         return dtmf_request
 
 

--- a/wazo_calld/plugins/calls/schemas.py
+++ b/wazo_calld/plugins/calls/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import EXCLUDE, Schema, fields, post_dump, post_load
@@ -60,7 +60,12 @@ class UserCallRequestSchema(CallBaseSchema):
 
 
 class CallDtmfSchema(CallBaseSchema):
-    digits = fields.String(validate=Regexp(r'^[0-9*#]+$'), required=True)
+    digits = fields.String(validate=Regexp(r'^[0-9*#A-Da-d]+$'), required=True)
+
+    @post_load
+    def normalize_digits(self, dtmf_request, **kwargs):
+        dtmf_request['digits'] = dtmf_request['digits'].upper()
+        return dtmf_request
 
 
 class CallSchema(CallBaseSchema):

--- a/wazo_calld/plugins/calls/schemas.py
+++ b/wazo_calld/plugins/calls/schemas.py
@@ -4,7 +4,7 @@
 from marshmallow import EXCLUDE, Schema, fields, post_dump, post_load
 from marshmallow.validate import Length, Range, Regexp
 
-from wazo_calld.plugin_helpers.mallow import StrictDict
+from wazo_calld.plugin_helpers.mallow import DTMF_DIGITS_REGEX, StrictDict
 
 
 class CallBaseSchema(Schema):
@@ -60,7 +60,7 @@ class UserCallRequestSchema(CallBaseSchema):
 
 
 class CallDtmfSchema(CallBaseSchema):
-    digits = fields.String(validate=Regexp(r'^[0-9*#A-Da-d]+$'), required=True)
+    digits = fields.String(validate=Regexp(DTMF_DIGITS_REGEX), required=True)
 
     @post_load
     def normalize_digits(self, dtmf_request, **kwargs):


### PR DESCRIPTION
- **calls: allow A, B, C, D DTMF**
- **applications: allow A, B, C, D DTMF**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow input-validation and normalization change on existing DTMF endpoints, with integration test coverage and no auth or data-model changes.
> 
> **Overview**
> **DTMF send** endpoints for **calls** and **applications** now accept **A–D** in addition to `0-9`, `*`, and `#`, with letters treated as **case-insensitive** and normalized to **uppercase** before being sent to Asterisk.
> 
> Validation is centralized in `DTMF_DIGITS_REGEX` in `mallow.py` and wired into `CallDtmfSchema` and `ApplicationDTMFSchema`; **`digits` is required** on the application DTMF schema (aligned with calls). OpenAPI `DTMFDigits` documents the expanded character set.
> 
> Integration tests cover **missing** `digits` (400) and mixed-case letter input producing **ABCD** `DTMFEnd` events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9e4eabad8c2f1b293cf43b2e34b4a4c0a31b854. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->