### PR TITLE
fix-flaky-tests

### DIFF
--- a/integration_tests/assets/docker-compose.real_asterisk.override.yml
+++ b/integration_tests/assets/docker-compose.real_asterisk.override.yml
@@ -13,6 +13,10 @@ services:
 
   amid:
     image: wazoplatform/wazo-amid
+    # amid must not start before rabbitmq is up
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
     expose:
       - "9491"
     volumes:

--- a/integration_tests/assets/docker-compose.real_asterisk_call_logd.override.yml
+++ b/integration_tests/assets/docker-compose.real_asterisk_call_logd.override.yml
@@ -16,6 +16,10 @@ services:
 
   amid:
     image: wazoplatform/wazo-amid
+    # amid must not start before rabbitmq is up
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
     expose:
       - "9491"
     volumes:

--- a/integration_tests/assets/docker-compose.real_asterisk_conference.override.yml
+++ b/integration_tests/assets/docker-compose.real_asterisk_conference.override.yml
@@ -12,6 +12,10 @@ services:
 
   amid:
     image: wazoplatform/wazo-amid
+    # amid must not start before rabbitmq is up
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
     expose:
       - "9491"
     volumes:

--- a/integration_tests/assets/docker-compose.real_asterisk_fax.override.yml
+++ b/integration_tests/assets/docker-compose.real_asterisk_fax.override.yml
@@ -12,6 +12,10 @@ services:
 
   amid:
     image: wazoplatform/wazo-amid
+    # amid must not start before rabbitmq is up
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
     expose:
       - "9491"
     volumes:

--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -67,3 +67,10 @@ services:
     volumes:
       - type: tmpfs
         target: /var/lib/rabbitmq
+    healthcheck:
+      # plain TCP check: rabbitmq-diagnostics as root would create a
+      # root-owned erlang cookie and crash the server boot
+      test: ["CMD", "bash", "-c", "</dev/tcp/localhost/5672"]
+      interval: 2s
+      timeout: 10s
+      retries: 60


### PR DESCRIPTION
Why: wazo-amid's bus publisher connects lazily: it only opens the
rabbitmq connection when a message is queued, retries for ~5 seconds,
then drops the message without re-queueing. On a slow CI node rabbitmq
boots in 15-18s, so amid's startup AMI events are dropped and, with an
idle Asterisk, nothing triggers a reconnection: /status reports
bus_publisher: fail forever and AmidReadyWaitStrategy times out.
Gating amid on a healthy rabbitmq guarantees its first publish
succeeds.

The healthcheck is a bash TCP connect, not rabbitmq-diagnostics:
healthchecks exec as root (image has no USER) and any diagnostics call
creates a root-owned .erlang.cookie when it is missing, crashing the
server boot with eacces. The TCP connect checks the same condition and
matches the RabbitMQ docs' container best practice.

Only amid depends on the healthcheck: gating services in the base file
would pull rabbitmq into the no_rabbitmq asset, which relies on it not
being started. calld and Asterisk reconnect on their own.

This is a CI workaround; the root fix (proactive reconnection, no
message drop) belongs in wazo-bus QueuePublisherMixin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Docker Compose ordering and healthcheck changes; no production runtime or application code paths.
> 
> **Overview**
> Addresses flaky real-Asterisk integration tests where **wazo-amid** could start before RabbitMQ was listening, causing startup bus publishes to fail permanently and **`AmidReadyWaitStrategy`** to time out on slow CI.
> 
> The base **`docker-compose.yml`** now defines a **RabbitMQ healthcheck** that probes port **5672** via bash TCP (not `rabbitmq-diagnostics`, to avoid root-owned Erlang cookie issues during healthcheck). In the four **`real_asterisk*`** override files, **`amid`** is gated with **`depends_on: rabbitmq: condition: service_healthy`** so its first publish runs against a ready broker. Other services are unchanged so **`no_rabbitmq`** assets stay unaffected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25fcd859e9a73975788c84e8891dbd602f6da2a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->