### PR TITLE
ITEM-563-switchboard-empty-uuid-guard

### DIFF
--- a/wazo_calld/plugins/switchboards/stasis.py
+++ b/wazo_calld/plugins/switchboards/stasis.py
@@ -207,6 +207,8 @@ class SwitchboardsStasis:
 
     def unqueue(self, channel, event):
         switchboard_uuid = channel.json['channelvars']['WAZO_SWITCHBOARD_QUEUE']
+        if not switchboard_uuid:
+            return
         tenant_uuid = channel.json['channelvars']['WAZO_TENANT_UUID']
 
         try:
@@ -218,6 +220,8 @@ class SwitchboardsStasis:
 
     def unhold(self, channel, event):
         switchboard_uuid = channel.json['channelvars']['WAZO_SWITCHBOARD_HOLD']
+        if not switchboard_uuid:
+            return
         tenant_uuid = channel.json['channelvars']['WAZO_TENANT_UUID']
 
         try:

--- a/wazo_calld/plugins/switchboards/tests/test_stasis.py
+++ b/wazo_calld/plugins/switchboards/tests/test_stasis.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
@@ -23,4 +23,62 @@ class TestStasis(TestCase):
 
         ari.client.channels.continueInDialplan.assert_called_once_with(
             channelId=channel.id
+        )
+
+    def test_unqueue_ignores_channel_with_empty_switchboard_uuid(self):
+        ari, confd, notifier, service = Mock(), Mock(), Mock(), Mock()
+        stasis = SwitchboardsStasis(ari, confd, notifier, service)
+        channel = Mock()
+        channel.json = {'channelvars': {'WAZO_SWITCHBOARD_QUEUE': ''}}
+
+        stasis.unqueue(channel, event={})
+
+        service.queued_calls.assert_not_called()
+        notifier.queued_calls.assert_not_called()
+
+    def test_unqueue_notifies_queued_calls(self):
+        ari, confd, notifier, service = Mock(), Mock(), Mock(), Mock()
+        stasis = SwitchboardsStasis(ari, confd, notifier, service)
+        channel = Mock()
+        channel.json = {
+            'channelvars': {
+                'WAZO_SWITCHBOARD_QUEUE': 'switchboard-uuid',
+                'WAZO_TENANT_UUID': 'tenant-uuid',
+            }
+        }
+
+        stasis.unqueue(channel, event={})
+
+        service.queued_calls.assert_called_once_with('tenant-uuid', 'switchboard-uuid')
+        notifier.queued_calls.assert_called_once_with(
+            'tenant-uuid', 'switchboard-uuid', service.queued_calls.return_value
+        )
+
+    def test_unhold_ignores_channel_with_empty_switchboard_uuid(self):
+        ari, confd, notifier, service = Mock(), Mock(), Mock(), Mock()
+        stasis = SwitchboardsStasis(ari, confd, notifier, service)
+        channel = Mock()
+        channel.json = {'channelvars': {'WAZO_SWITCHBOARD_HOLD': ''}}
+
+        stasis.unhold(channel, event={})
+
+        service.held_calls.assert_not_called()
+        notifier.held_calls.assert_not_called()
+
+    def test_unhold_notifies_held_calls(self):
+        ari, confd, notifier, service = Mock(), Mock(), Mock(), Mock()
+        stasis = SwitchboardsStasis(ari, confd, notifier, service)
+        channel = Mock()
+        channel.json = {
+            'channelvars': {
+                'WAZO_SWITCHBOARD_HOLD': 'switchboard-uuid',
+                'WAZO_TENANT_UUID': 'tenant-uuid',
+            }
+        }
+
+        stasis.unhold(channel, event={})
+
+        service.held_calls.assert_called_once_with('tenant-uuid', 'switchboard-uuid')
+        notifier.held_calls.assert_called_once_with(
+            'tenant-uuid', 'switchboard-uuid', service.held_calls.return_value
         )


### PR DESCRIPTION
Why: these handlers run on every ChannelLeftBridge event system-wide,
and channels that were never in a switchboard carry empty
WAZO_SWITCHBOARD_QUEUE/WAZO_SWITCHBOARD_HOLD channelvars. The empty
uuid was passed down to a confd switchboard lookup, generating a
useless confd request on every bridge exit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow early-return guard with no change to switchboard traffic; only skips work for channels without a switchboard UUID.
> 
> **Overview**
> **`unqueue`** and **`unhold`** now return immediately when **`WAZO_SWITCHBOARD_QUEUE`** or **`WAZO_SWITCHBOARD_HOLD`** is empty. Those handlers run on every **`ChannelLeftBridge`** event; channels that never touched a switchboard still carry empty vars, which previously triggered pointless **`confd`** switchboard lookups on every bridge exit.
> 
> Unit tests cover the early-exit paths and the existing notify behavior when a real switchboard UUID is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6956e368463503147624c9aa1f9d3c3e1f161ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->