### PR TITLE
http: fix stop-before-start shutdown race

### DIFF
--- a/wazo_calld/http_server.py
+++ b/wazo_calld/http_server.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+import threading
 from datetime import timedelta
 
 from flask import Flask
@@ -30,6 +31,7 @@ class HTTPServer:
         app.config['auth'] = global_config['auth']
         self._load_cors()
         self.server = None
+        self._stopped = threading.Event()
 
     def _load_cors(self):
         cors_config = dict(self.config.get('cors', {}))
@@ -67,8 +69,13 @@ class HTTPServer:
         for route in http_helpers.list_routes(app):
             logger.debug(route)
 
+        if self._stopped.is_set():
+            logger.warning('stop requested during startup: not starting the server')
+            return
+
         self.server.start()
 
     def stop(self):
+        self._stopped.set()
         if self.server:
             self.server.stop()

--- a/wazo_calld/tests/test_http_server.py
+++ b/wazo_calld/tests/test_http_server.py
@@ -1,0 +1,47 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from unittest.mock import patch
+
+import pytest
+
+from wazo_calld.http_server import HTTPServer
+
+
+@pytest.fixture
+def http_server():
+    config = {
+        'auth': {},
+        'rest_api': {
+            'listen': '127.0.0.1',
+            'port': 9500,
+            'min_threads': 1,
+            'max_threads': 1,
+            'certificate': None,
+            'private_key': None,
+            'cors': {'enabled': False},
+        },
+    }
+    return HTTPServer(config)
+
+
+def test_stop_before_run_does_not_raise_and_sets_the_tombstone(http_server):
+    http_server.stop()
+
+    assert http_server._stopped.is_set()
+
+
+@patch('wazo_calld.http_server.wsgi')
+def test_run_after_stop_does_not_start_the_server(wsgi, http_server):
+    http_server.stop()
+    http_server.run()
+
+    wsgi.DynamicWSGIServer.return_value.start.assert_not_called()
+
+
+@patch('wazo_calld.http_server.wsgi')
+def test_stop_after_run_stops_the_server(wsgi, http_server):
+    http_server.run()
+    http_server.stop()
+
+    wsgi.DynamicWSGIServer.return_value.stop.assert_called_once_with()


### PR DESCRIPTION
Why: a SIGTERM landing during startup was silently lost when stop()
ran before run() assigned self.server: the stop was a no-op, run()
then started the server with nothing left to stop it, and systemd
escalated to SIGKILL after TimeoutStopSec. The window was the whole
startup phase (ARI connection, plugin loading).

stop() now sets a tombstone before stopping the server, and run()
checks it after assigning self.server: whichever side loses the
race, either run() sees the tombstone or stop() sees a real server.

Same fix as wazo-auth (ITEM-589).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to HTTP server lifecycle with tests; no auth or data-path impact.
> 
> **Overview**
> Fixes a shutdown race where **SIGTERM during startup** could be ignored: if `stop()` ran before `run()` assigned `self.server`, stop was a no-op and the server still started, leading to systemd **SIGKILL** after `TimeoutStopSec`.
> 
> `HTTPServer` now keeps a **`_stopped` tombstone** (`threading.Event`). **`stop()`** sets it before stopping the WSGI server; **`run()`** checks it after building `self.server` and **skips `start()`** if shutdown was already requested. Unit tests cover stop-before-run, run-after-stop, and stop-after-run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8a369de585b206a89670972202d3deb5fbec6da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->