### PR TITLE
Resolve mobile push state in join_bridge before pruning it

### DIFF
--- a/integration_tests/suite/test_dial_mobile.py
+++ b/integration_tests/suite/test_dial_mobile.py
@@ -523,9 +523,7 @@ class TestDialMobile(RealAsteriskIntegrationTest):
         until.assert_(
             push_notification_cancelled,
             timeout=5,
-            message=(
-                'push was not cancelled at join time'
-            ),
+            message=('push was not cancelled at join time'),
         )
 
         chan.hangup()

--- a/integration_tests/suite/test_dial_mobile.py
+++ b/integration_tests/suite/test_dial_mobile.py
@@ -524,8 +524,7 @@ class TestDialMobile(RealAsteriskIntegrationTest):
             push_notification_cancelled,
             timeout=5,
             message=(
-                'push was not cancelled at join time; the push state was '
-                'probably pruned before being resolved'
+                'push was not cancelled at join time'
             ),
         )
 

--- a/integration_tests/suite/test_dial_mobile.py
+++ b/integration_tests/suite/test_dial_mobile.py
@@ -1,6 +1,7 @@
 # Copyright 2024-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import re
 import time
 from uuid import uuid4
 
@@ -459,6 +460,72 @@ class TestDialMobile(RealAsteriskIntegrationTest):
             message=(
                 'cancel_push_notification was not published despite DialEnd '
                 'carrying the matching Linkedid'
+            ),
+        )
+
+        chan.hangup()
+
+    def test_push_resolved_at_join_when_answered_by_non_mobile_channel(self):
+        # Non-regression test: the push state used to be pruned at join
+        # before being resolved. A non-mobile channel answering must publish
+        # a cancel push at join time.
+        line_id = 424242
+        self.confd.set_users(
+            MockUser(
+                uuid=_TEST_USER_UUID,
+                line_ids=[line_id],
+                mobile='ring',
+                mobile_fallback_enabled=False,
+                tenant_uuid=_TEST_TENANT_UUID,
+            )
+        )
+        self.confd.set_lines(
+            MockLine(id=line_id, context='local', tenant_uuid=_TEST_TENANT_UUID)
+        )
+
+        chan = self._start_dial_mobile_dial()
+
+        # The future bridge uuid is only exposed in the dial_all_contacts debug log
+        def find_future_bridge_uuid():
+            match = re.search(
+                re.escape(chan.id)
+                + r' is waiting for a channel to join the bridge ([0-9a-f-]{36})',
+                self.service_logs(),
+            )
+            return match.group(1) if match else None
+
+        future_bridge_uuid = until.true(
+            find_future_bridge_uuid,
+            timeout=5,
+            message='future bridge uuid was never logged by dial_all_contacts',
+        )
+
+        push_events = self.bus.accumulator(headers={'name': 'call_push_notification'})
+        cancel_events = self.bus.accumulator(
+            headers={'name': 'call_cancel_push_notification'}
+        )
+        self._publish_pushmobile(chan, f'test-join-resolve-{uuid4()}', ring_time='200')
+        self._wait_push_notification(push_events)
+
+        # A channel that is not the user's mobile answers the call
+        self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app='dial_mobile',
+            appArgs=['join', future_bridge_uuid],
+        )
+
+        def push_notification_cancelled():
+            assert_that(
+                cancel_events.accumulate(),
+                has_item(has_entries(name='call_cancel_push_notification')),
+            )
+
+        until.assert_(
+            push_notification_cancelled,
+            timeout=5,
+            message=(
+                'push was not cancelled at join time; the push state was '
+                'probably pruned before being resolved'
             ),
         )
 

--- a/wazo_calld/plugins/dial_mobile/bus_consume.py
+++ b/wazo_calld/plugins/dial_mobile/bus_consume.py
@@ -3,9 +3,6 @@
 
 import logging
 
-from ari.exceptions import ARINotFound
-from xivo.asterisk.protocol_interface import protocol_interface_from_channel
-
 from wazo_calld.plugins.dial_mobile.services import DialMobileService
 
 logger = logging.getLogger(__name__)
@@ -16,7 +13,6 @@ class EventHandler:
         self._service: DialMobileService = service
 
     def subscribe(self, bus_consumer):
-        bus_consumer.subscribe('BridgeEnter', self._on_bridge_enter)
         bus_consumer.subscribe('DialEnd', self._on_dial_end)
         bus_consumer.subscribe('UserEvent', self._on_user_event)
         bus_consumer.subscribe(
@@ -68,41 +64,12 @@ class EventHandler:
 
         self._service.on_mobile_refresh_token_deleted(event['user_uuid'])
 
-    def _on_bridge_enter(self, event):
-        if not event['BridgeUniqueid'].startswith('wazo-dial-mobile-'):
-            return
-
-        protocol, endpoint = protocol_interface_from_channel(event['Channel'])
-        if protocol.lower() != 'sip':
-            return
-
-        linkedid = event['Linkedid']
-        user_uuid = event['ChanVariable']['WAZO_USERUUID']
-
-        try:
-            has_a_registered_mobile_and_pending_push = (
-                self._service.has_a_registered_mobile_and_pending_push(
-                    linkedid,
-                    event['Uniqueid'],
-                    endpoint,
-                    user_uuid,
-                )
-            )
-        except ARINotFound:
-            # The channel that entered the bridge has already been hung up
-            return self._service.cancel_push_mobile(linkedid)
-
-        if has_a_registered_mobile_and_pending_push:
-            self._service.complete_pending_push_mobile(linkedid)
-        else:
-            self._service.cancel_push_mobile(linkedid)
-
     def _on_dial_end(self, event):
         # Ignore dial_end if it's in an unrelated context
         if event['DestContext'] != 'wazo_wait_for_registration':
             return
 
-        # Ignore dial_end if the call was answered, those are handled in _on_bridge_enter
+        # Ignore dial_end if the call was answered, those are resolved by join_bridge
         if event['DialStatus'] == 'ANSWER':
             return
 

--- a/wazo_calld/plugins/dial_mobile/services.py
+++ b/wazo_calld/plugins/dial_mobile/services.py
@@ -12,6 +12,10 @@ from typing import Any
 import requests
 from ari.exceptions import ARINotFound, ARIServerError
 from requests import HTTPError, RequestException
+from xivo.asterisk.protocol_interface import (
+    InvalidChannelError,
+    protocol_interface_from_channel,
+)
 
 from wazo_calld.plugin_helpers.ari_ import Bridge
 
@@ -533,7 +537,12 @@ class DialMobileService:
                     'the answered (%s) left the call before being bridged',
                     channel_id,
                 )
+                if call_id:
+                    self.cancel_push_mobile(call_id)
                 return
+
+            if call_id:
+                self._resolve_pending_push(call_id, channel_id)
 
             bridge = self._ari.bridges.createWithId(
                 type='mixing',
@@ -865,6 +874,59 @@ class DialMobileService:
                         call_id,
                     )
 
+    def _resolve_pending_push(self, call_id: str, channel_id: str) -> None:
+        # Must run before _prune_call_state discards the push state
+        pending_push = self._incoming_calls.get(call_id)
+        match pending_push:
+            case None | IncomingCallReceived() | IncomingCallPushCancelled():
+                return
+
+        try:
+            answered_by_mobile = self._is_users_mobile_channel(
+                channel_id, pending_push.user_uuid
+            )
+        except (ARINotFound, InvalidChannelError):
+            # the answering channel is already gone or has no usable name
+            answered_by_mobile = False
+        except (ARIServerError, HTTPError, RequestException) as e:
+            logger.error(
+                'call %s: cannot inspect answering channel %s, '
+                'cancelling mobile push: %s',
+                call_id,
+                channel_id,
+                e,
+            )
+            answered_by_mobile = False
+
+        if answered_by_mobile:
+            self.complete_pending_push_mobile(call_id)
+        else:
+            self.cancel_push_mobile(call_id)
+
+    def _is_users_mobile_channel(self, channel_id: str, user_uuid: str) -> bool:
+        channel = self._ari.channels.get(channelId=channel_id)
+        protocol, endpoint = protocol_interface_from_channel(channel.json['name'])
+        if protocol.lower() != 'sip':
+            return False
+
+        channel_user_uuid = channel.json.get('channelvars', {}).get('WAZO_USERUUID')
+        if channel_user_uuid != user_uuid:
+            return False
+
+        raw_contacts = self._ari.channels.getChannelVar(
+            channelId=channel_id,
+            variable=f'PJSIP_AOR({endpoint},contact)',
+        )['value']
+        for contact in raw_contacts.split(','):
+            if not contact:
+                continue
+            mobility = self._ari.channels.getChannelVar(
+                channelId=channel_id, variable=f'PJSIP_CONTACT({contact},mobility)'
+            )['value']
+            if mobility == 'mobile':
+                return True
+        return False
+
     def _incoming_call_lock(self, call_id: str) -> contextlib.AbstractContextManager:
         lock = self._call_locks.get(call_id)
         # handle missing lock as a no-op context manager
@@ -1060,28 +1122,3 @@ class DialMobileService:
                             'PSTN fallback aborted but state already %s', state
                         )
                         return
-
-    def has_a_registered_mobile_and_pending_push(
-        self, push_call_id, call_id, endpoint, user_uuid
-    ):
-        pending_push = self._incoming_calls.get(push_call_id)
-        match pending_push:
-            case None | IncomingCallReceived() | IncomingCallPushCancelled():
-                return False
-
-        if user_uuid != pending_push.user_uuid:
-            return False
-
-        raw_contacts = self._ari.channels.getChannelVar(
-            channelId=call_id,
-            variable=f'PJSIP_AOR({endpoint},contact)',
-        )['value']
-        for contact in raw_contacts.split(','):
-            if not contact:
-                continue
-            mobility = self._ari.channels.getChannelVar(
-                channelId=call_id, variable=f'PJSIP_CONTACT({contact},mobility)'
-            )['value']
-            if mobility == 'mobile':
-                return True
-        return False

--- a/wazo_calld/plugins/dial_mobile/tests/test_bus_consume.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_bus_consume.py
@@ -3,9 +3,8 @@
 
 from unittest import TestCase
 from unittest.mock import Mock
-from unittest.mock import sentinel as s
 
-from ..bus_consume import ARINotFound, EventHandler
+from ..bus_consume import EventHandler
 from ..services import DialMobileService
 
 
@@ -191,105 +190,3 @@ class TestEventHandler(TestCase):
         self.event_handler._on_dial_end(event)
 
         self.service.cancel_push_mobile.assert_not_called()
-
-    def test_on_bridge_enter_not_a_dial_mobile_bridge(self):
-        event = {
-            'Event': 'BridgeEnter',
-            'BridgeType': 'unknown',
-            'BridgeUniqueid': '<UUID>',
-        }
-
-        self.event_handler._on_bridge_enter(event)
-
-        self.service.cancel_push_mobile.assert_not_called()
-        self.service.complete_pending_push_mobile.assert_not_called()
-
-    def test_on_bridge_enter_ignore_not_pjsip(self):
-        event = {
-            'Event': 'BridgeEnter',
-            'BridgeType': 'stasis',
-            'Channel': 'Local/endpoint@wazo-wait-for-mobile-9090832;1',
-            'BridgeUniqueid': 'wazo-dial-mobile-<UUID>',
-        }
-
-        self.event_handler._on_bridge_enter(event)
-
-        self.service.cancel_push_mobile.assert_not_called()
-        self.service.complete_pending_push_mobile.assert_not_called()
-
-    def test_on_bridge_enter_not_answered_by_mobile(self):
-        self.service.has_a_registered_mobile_and_pending_push.return_value = False
-
-        event = {
-            'Event': 'BridgeEnter',
-            'BridgeType': 'stasis',
-            'BridgeUniqueid': 'wazo-dial-mobile-<UUID>',
-            'Channel': 'PJSIP/myendpoint-000000213',
-            'ChanVariable': {'WAZO_USERUUID': s.user_uuid},
-            'Linkedid': s.linkedid,
-            'Uniqueid': s.uniqueid,
-        }
-
-        self.event_handler._on_bridge_enter(event)
-
-        self.service.has_a_registered_mobile_and_pending_push.assert_called_once_with(
-            s.linkedid,
-            s.uniqueid,
-            'myendpoint',
-            s.user_uuid,
-        )
-
-        self.service.cancel_push_mobile.assert_called_once_with(s.linkedid)
-        self.service.complete_pending_push_mobile.assert_not_called()
-
-    def test_on_bridge_enter_answered_by_mobile(self):
-        self.service.has_a_registered_mobile_and_pending_push.return_value = True
-
-        event = {
-            'Event': 'BridgeEnter',
-            'BridgeType': 'stasis',
-            'BridgeUniqueid': 'wazo-dial-mobile-<UUID>',
-            'Channel': 'PJSIP/myendpoint-000000213',
-            'ChanVariable': {'WAZO_USERUUID': s.user_uuid},
-            'Linkedid': s.linkedid,
-            'Uniqueid': s.uniqueid,
-        }
-
-        self.event_handler._on_bridge_enter(event)
-
-        self.service.has_a_registered_mobile_and_pending_push.assert_called_once_with(
-            s.linkedid,
-            s.uniqueid,
-            'myendpoint',
-            s.user_uuid,
-        )
-
-        self.service.cancel_push_mobile.assert_not_called()
-        self.service.complete_pending_push_mobile.assert_called_once_with(s.linkedid)
-
-    def test_on_bridge_enter_caller_hung_up(self):
-        self.service.has_a_registered_mobile_and_pending_push.side_effect = ARINotFound(
-            Mock, Mock
-        )
-
-        event = {
-            'Event': 'BridgeEnter',
-            'BridgeType': 'stasis',
-            'BridgeUniqueid': 'wazo-dial-mobile-<UUID>',
-            'Channel': 'PJSIP/myendpoint-000000213',
-            'ChanVariable': {'WAZO_USERUUID': s.user_uuid},
-            'Linkedid': s.linkedid,
-            'Uniqueid': s.uniqueid,
-        }
-
-        self.event_handler._on_bridge_enter(event)
-
-        self.service.has_a_registered_mobile_and_pending_push.assert_called_once_with(
-            s.linkedid,
-            s.uniqueid,
-            'myendpoint',
-            s.user_uuid,
-        )
-
-        self.service.cancel_push_mobile.assert_called_once_with(s.linkedid)
-        self.service.complete_pending_push_mobile.assert_not_called()

--- a/wazo_calld/plugins/dial_mobile/tests/test_services.py
+++ b/wazo_calld/plugins/dial_mobile/tests/test_services.py
@@ -476,6 +476,183 @@ class TestCancelPushNotification(TestCase):
         )
 
 
+class TestJoinBridgePushResolution(TestCase):
+    def setUp(self):
+        self.ari = Mock()
+        self.ari.client = self.ari_client = Mock()
+        self.notifier = Mock(Notifier)
+        self.amid_client = Mock()
+        self.auth_client = Mock()
+        self.confd_client = Mock()
+        self.service = DialMobileService(
+            self.ari,
+            self.notifier,
+            self.amid_client,
+            self.auth_client,
+            self.confd_client,
+        )
+
+    def _make_notified(self):
+        return IncomingCallNotified(
+            call_id='call-id',
+            tenant_uuid='tenant-uuid',
+            user_uuid='user-uuid',
+            origin_call_id='call-id',
+            payload={'peer_caller_id_name': 'Alice', 'peer_caller_id_number': '101'},
+        )
+
+    def _mock_answering_channel(
+        self, name='PJSIP/myendpoint-00000001', user_uuid='user-uuid', mobility='mobile'
+    ):
+        self.ari_client.channels.get.return_value = Mock(
+            json={'name': name, 'channelvars': {'WAZO_USERUUID': user_uuid}}
+        )
+        channel_vars = {
+            'PJSIP_AOR(myendpoint,contact)': 'contact1',
+            'PJSIP_CONTACT(contact1,mobility)': mobility,
+        }
+        self.ari_client.channels.getChannelVar.side_effect = (
+            lambda channelId, variable: {'value': channel_vars[variable]}
+        )
+
+    def test_mobile_contact_answering_completes_push_flow(self):
+        self.service._incoming_calls['call-id'] = self._make_notified()
+        self._mock_answering_channel()
+
+        self.service._resolve_pending_push('call-id', 'mobile-ch')
+
+        self.notifier.cancel_push_notification.assert_not_called()
+        assert isinstance(self.service._incoming_calls['call-id'], IncomingCallReceived)
+
+    def test_other_users_device_answering_cancels_push(self):
+        self.service._incoming_calls['call-id'] = self._make_notified()
+        self._mock_answering_channel(user_uuid='other-user-uuid')
+
+        self.service._resolve_pending_push('call-id', 'deskphone-ch')
+
+        self.notifier.cancel_push_notification.assert_called_once()
+        assert isinstance(
+            self.service._incoming_calls['call-id'], IncomingCallPushCancelled
+        )
+
+    def test_non_mobile_contact_answering_cancels_push(self):
+        self.service._incoming_calls['call-id'] = self._make_notified()
+        self._mock_answering_channel(mobility='none')
+
+        self.service._resolve_pending_push('call-id', 'webrtc-ch')
+
+        self.notifier.cancel_push_notification.assert_called_once()
+
+    def test_non_sip_channel_answering_cancels_push(self):
+        # The PSTN fallback leg answers through a Local channel
+        self.service._incoming_calls['call-id'] = self._make_notified()
+        self.ari_client.channels.get.return_value = Mock(
+            json={'name': 'Local/+33123456789@my-outbound-context-0000000a;2'}
+        )
+
+        self.service._resolve_pending_push('call-id', 'local-ch')
+
+        self.notifier.cancel_push_notification.assert_called_once()
+
+    def test_answering_channel_gone_cancels_push(self):
+        self.service._incoming_calls['call-id'] = self._make_notified()
+        self.ari_client.channels.get.side_effect = ARINotFound(
+            s.ari_client, s.original_error
+        )
+
+        self.service._resolve_pending_push('call-id', 'mobile-ch')
+
+        self.notifier.cancel_push_notification.assert_called_once()
+
+    def test_channel_inspection_error_cancels_push_without_raising(self):
+        self.service._incoming_calls['call-id'] = self._make_notified()
+        self.ari_client.channels.get.side_effect = requests.HTTPError()
+
+        self.service._resolve_pending_push('call-id', 'mobile-ch')
+
+        self.notifier.cancel_push_notification.assert_called_once()
+
+    def test_join_bridge_still_bridges_on_channel_inspection_error(self):
+        self.service._incoming_calls['call-id'] = self._make_notified()
+        self.service._call_locks['call-id'] = threading.RLock()
+        self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'call-id'
+        self.service._contact_dialers['bridge-uuid'] = Mock()
+        self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
+        self.ari_client.channels.get.side_effect = requests.HTTPError()
+
+        self.service.join_bridge('mobile-ch', 'bridge-uuid')
+
+        self.notifier.cancel_push_notification.assert_called_once()
+        self.ari_client.bridges.createWithId.assert_called_once()
+
+    def test_join_bridge_answering_channel_gone_cancels_push(self):
+        self.service._incoming_calls['call-id'] = self._make_notified()
+        self.service._call_locks['call-id'] = threading.RLock()
+        self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'call-id'
+        self.service._contact_dialers['bridge-uuid'] = Mock()
+        self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
+
+        def answer(channelId):
+            if channelId == 'mobile-ch':
+                raise ARINotFound(s.ari_client, s.original_error)
+
+        self.ari_client.channels.answer.side_effect = answer
+
+        self.service.join_bridge('mobile-ch', 'bridge-uuid')
+
+        self.notifier.cancel_push_notification.assert_called_once()
+        self.ari_client.bridges.createWithId.assert_not_called()
+
+    def test_terminal_state_is_not_resolved_again(self):
+        self.service._incoming_calls['call-id'] = self._make_notified().received()
+
+        self.service._resolve_pending_push('call-id', 'mobile-ch')
+
+        self.notifier.cancel_push_notification.assert_not_called()
+        self.ari_client.channels.get.assert_not_called()
+        assert isinstance(self.service._incoming_calls['call-id'], IncomingCallReceived)
+
+    def test_no_push_state_is_a_noop(self):
+        self.service._resolve_pending_push('call-id', 'mobile-ch')
+
+        self.notifier.cancel_push_notification.assert_not_called()
+        self.ari_client.channels.get.assert_not_called()
+
+    def test_join_bridge_resolves_push_before_pruning_state(self):
+        # Regression test: the resolution must run inside join_bridge, while
+        # the push state is still present — the AMI BridgeEnter event always
+        # arrived after join_bridge had pruned the state, so the completion
+        # path never ran and every answered call logged a cancel warning.
+        self.service._incoming_calls['call-id'] = self._make_notified()
+        self.service._call_locks['call-id'] = threading.RLock()
+        self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'call-id'
+        self.service._bridge_uuid_by_origin_call_id['call-id'] = 'bridge-uuid'
+        self.service._contact_dialers['bridge-uuid'] = Mock()
+        self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
+        self._mock_answering_channel()
+
+        with patch.object(self.service, 'complete_pending_push_mobile') as complete:
+            self.service.join_bridge('mobile-ch', 'bridge-uuid')
+
+        complete.assert_called_once_with('call-id')
+        self.notifier.cancel_push_notification.assert_not_called()
+        assert 'call-id' not in self.service._incoming_calls
+
+    def test_join_bridge_cancels_push_when_not_answered_by_mobile(self):
+        self.service._incoming_calls['call-id'] = self._make_notified()
+        self.service._call_locks['call-id'] = threading.RLock()
+        self.service._origin_call_id_by_bridge_uuid['bridge-uuid'] = 'call-id'
+        self.service._bridge_uuid_by_origin_call_id['call-id'] = 'bridge-uuid'
+        self.service._contact_dialers['bridge-uuid'] = Mock()
+        self.service._caller_channel_leg_by_bridge['bridge-uuid'] = 'caller-ch'
+        self._mock_answering_channel(user_uuid='other-user-uuid')
+
+        self.service.join_bridge('deskphone-ch', 'bridge-uuid')
+
+        self.notifier.cancel_push_notification.assert_called_once()
+        assert 'call-id' not in self.service._incoming_calls
+
+
 class TestPSTNFallback(TestCase):
     def setUp(self):
         self.ari = Mock()
@@ -1109,27 +1286,6 @@ class TestPSTNFallback(TestCase):
         assert 'call-id' not in self.service._call_ring_time
         assert 'bridge-uuid' not in self.service._caller_channel_leg_by_bridge
         assert 'call-id' not in self.service._incoming_calls
-
-    def test_has_a_registered_mobile_and_pending_push_false_on_terminal_state(
-        self,
-    ):
-        # Once a call reaches Received or Cancelled, it is no longer
-        # considered to have a pending push.
-        self.service._incoming_calls['call-id'] = self._make_notified().received()
-        assert (
-            self.service.has_a_registered_mobile_and_pending_push(
-                'call-id', 'asterisk-call-id', 'PJSIP/aor', 'user-uuid'
-            )
-            is False
-        )
-
-        self.service._incoming_calls['call-id'] = self._make_notified().push_cancelled()
-        assert (
-            self.service.has_a_registered_mobile_and_pending_push(
-                'call-id', 'asterisk-call-id', 'PJSIP/aor', 'user-uuid'
-            )
-            is False
-        )
 
     def test_notify_channel_gone_prunes_call_state(self):
         caller_channel_id = '1234567890.42'


### PR DESCRIPTION
Why: join_bridge pruned the push state in its finally block, while the
completed-vs-cancelled decision lived in the AMI BridgeEnter bus
handler. Since join_bridge is what creates the bridge, the handler
structurally always ran after the prune: the completion path never
executed and every answered mobile-push call logged a
"cancel_push_mobile: no mobile push state" warning.

The decision now happens synchronously in join_bridge, which knows the
answering channel; the dead BridgeEnter handler is removed.

Side effect: when a pickup or another non-mobile device answers, the
push cancellation is now actually dispatched, so the mobile app
dismisses the incoming call instead of ringing until timeout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timing and ownership of mobile push lifecycle on answered calls—a user-visible telephony path—but the change aligns behavior with intended design and adds regression tests.
> 
> **Overview**
> **Fixes mobile push never completing on answer** because `join_bridge` always pruned push state in `finally` before the AMI `BridgeEnter` handler could decide complete vs cancel—so every answered call hit spurious cancel warnings and the mobile completion path never ran.
> 
> Push resolution now runs **inside `join_bridge`** (after answer, before bridge creation) via `_resolve_pending_push`, which inspects the answering channel with `_is_users_mobile_channel` (PJSIP user UUID + `mobility=mobile`) and calls `complete_pending_push_mobile` or `cancel_push_mobile`. The **`BridgeEnter` bus subscription and `has_a_registered_mobile_and_pending_push`** are removed; `DialEnd` comments note answered calls are handled by join.
> 
> **Behavioral fix:** when a desk phone, pickup, or other non-mobile leg answers, **cancel push is actually sent** so the mobile app stops ringing instead of timing out.
> 
> Adds an integration test for join-time cancel and broad unit coverage for resolution edge cases; drops obsolete `BridgeEnter` consumer tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit add69ce7b0a7f6c837af3ca3820995fcbb3c7c24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->