### PR TITLE
[ITEM-616] transfers: use transferred caller id for blind transfer recipient

### DIFF
--- a/integration_tests/suite/test_transfers.py
+++ b/integration_tests/suite/test_transfers.py
@@ -1040,6 +1040,39 @@ class TestCreateTransfer(TestTransfers):
 
         until.assert_(caller_id_are_right, timeout=10)
 
+    def test_when_create_blind_transfer_then_recipient_sees_transferred_caller_id(self):
+        (
+            transferred_channel_id,
+            initiator_channel_id,
+        ) = self.real_asterisk.given_bridged_call_stasis()
+        transferred_caller_id_name = 'trânsfêrrêd'
+        initiator_caller_id_name = 'înîtîâtôr'
+        self.ari.channels.setChannelVar(
+            channelId=initiator_channel_id,
+            variable='CALLERID(name)',
+            value=initiator_caller_id_name.encode('utf-8'),
+        )
+        self.ari.channels.setChannelVar(
+            channelId=transferred_channel_id,
+            variable='CALLERID(name)',
+            value=transferred_caller_id_name.encode('utf-8'),
+        )
+
+        response = self.calld.create_blind_transfer(
+            transferred_channel_id, initiator_channel_id, **RECIPIENT_CALLER_ID
+        )
+
+        def caller_id_is_right():
+            recipient_channel = self.ari.channels.get(
+                channelId=response['recipient_call']
+            )
+            assert_that(
+                recipient_channel.json['connected']['name'],
+                equal_to(transferred_caller_id_name),
+            )
+
+        until.assert_(caller_id_is_right, timeout=10)
+
     def test_given_no_content_type_when_create_then_ok(self):
         (
             transferred_channel_id,

--- a/wazo_calld/plugins/transfers/services.py
+++ b/wazo_calld/plugins/transfers/services.py
@@ -157,12 +157,25 @@ class TransfersService:
         )
 
     def originate_recipient(
-        self, initiator_call, context, exten, transfer_id, variables, timeout
+        self,
+        initiator_call,
+        context,
+        exten,
+        transfer_id,
+        variables,
+        timeout,
+        transferred_call=None,
     ):
         initiator_channel = self.ari.channels.get(channelId=initiator_call)
+        caller_id_channel = initiator_channel
+        if transferred_call:
+            try:
+                caller_id_channel = self.ari.channels.get(channelId=transferred_call)
+            except ARINotFound:
+                pass
         caller_id = assemble_caller_id(
-            initiator_channel.json['caller']['name'],
-            initiator_channel.json['caller']['number'],
+            caller_id_channel.json['caller']['name'],
+            caller_id_channel.json['caller']['number'],
         ).encode('utf-8')
         recipient_endpoint = 'Local/{exten}@{context}'.format(
             exten=exten, context=context

--- a/wazo_calld/plugins/transfers/state.py
+++ b/wazo_calld/plugins/transfers/state.py
@@ -311,6 +311,11 @@ class TransferState:
                 self.transfer.id,
                 variables,
                 timeout,
+                transferred_call=(
+                    self.transfer.transferred_call
+                    if self.transfer.flow == 'blind'
+                    else None
+                ),
             )
         except TransferCreationError as e:
             logger.error('%s %s', e.message, e.details)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how caller ID is assembled when originating the transfer recipient, which affects live call presentation. Attended transfers keep the previous initiator-based behavior; missing transferred channels fall back safely.
> 
> **Overview**
> Blind-transfer recipients now see the **transferred party’s** caller ID instead of the initiator’s.
> 
> `originate_recipient` optionally takes `transferred_call` and uses that channel’s name/number when present (falls back to the initiator if the channel is gone). Blind flow passes the transferred channel; attended transfers are unchanged.
> 
> Adds an integration test that the recipient’s connected name matches the transferred caller ID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d8d978d061f53d548f02e1ee7b1e2dc7edb5bac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->